### PR TITLE
fix(parser,cli): namespace-scoped C# dependent recovery, widened to test-declared types

### DIFF
--- a/.changeset/csharp-namespace-scoped-dependents.md
+++ b/.changeset/csharp-namespace-scoped-dependents.md
@@ -1,0 +1,76 @@
+---
+"@liendev/parser": patch
+"@liendev/lien": patch
+---
+
+Widen C# `get_dependents`/test-coverage recovery to test-declared types and
+real namespace-scoped disambiguation (#930/#943's remaining gap). Measured
+on a fresh serilog/serilog clone (216 `.cs` files, same corpus that
+motivated #930/#943): despite that prior fix, 114/216 (53%) still reported
+`dependentAttributionIncomplete` ("not determinable") and 216/216 (100%)
+reported test coverage as not determinable — because the recovery's
+uniqueness gate excluded test-declared types as candidate declarations
+entirely, and dropped any name declared in more than one file with no
+attempt at disambiguation.
+
+`findCSharpTypeReferenceDependents` (`@liendev/parser`) now has two tiers:
+
+- Tier 1 (widened): the existing global-uniqueness check now also accepts
+  test files as declaring files — a type declared ONLY in a test helper
+  (e.g. `DummyRollingFileSink.cs`) is a legitimate, real dependency target
+  for other tests that reference it, and excluding it was an unjustified
+  asymmetry (a test file was already an accepted *dependent*, just never a
+  *declarer*). Excludes NESTED types declared in a test file specifically
+  from candidacy (a nested type's bare name is resolved by containing-type
+  membership, not namespace membership, and is disproportionately likely to
+  be a throwaway same-named local double — measured regression, see below),
+  while still recovering a nested PRODUCTION type declared in its own
+  `partial`-continuation file.
+- Tier 2 (new): for a type name that's ambiguous project-wide, real C#
+  namespace-enclosure + shadowing rules (innermost enclosing declaration
+  wins) resolve it per-referencer instead of dropping it outright — e.g.
+  `Serilog.Core.Sinks` code referencing bare `Logger` resolves to
+  `Serilog.Core.Logger` (the closer namespace), not a same-named
+  `Serilog.Logger` or a test's own local `Logger`. Costs no schema change:
+  each file's own namespace is derived from its own already-indexed chunk
+  content (95% hit rate measured), not a new persisted column.
+
+A referencer that itself declares a competing same-named type is excluded
+entirely from being counted as a reference to either tier's target — a
+word-boundary text match can't tell which declaration a given occurrence
+resolves to once there's a local competitor, so the only safe answer is
+"don't guess" (caught via a real regression during testing: a test file
+constructing its own local double of a production class's name was
+initially still counted as referencing the unrelated production type).
+
+The exact same recovered signal, filtered to its test-file dependents, is
+now also reused as a fifth `lien annotate` test-association tier (mirroring
+Swift's existing symbol-usage tier) — closing the companion
+100%-not-determinable test-coverage gap the same way, not left for
+follow-up work.
+
+Measured impact (serilog/serilog, 216 files): `dependentAttributionIncomplete`
+114 (53%) → 63 (29%); test coverage not-determinable 216 (100%) → 100 (46%).
+Zero regressions against the pre-widening baseline once the nested-type and
+same-file-competing-declaration exclusions above were added (verified via a
+full before/after diff of every file's recovered dependents, not just the
+aggregate counts) — one pre-existing false positive from #943 itself
+(a production class getting a spurious test dependent via exactly this
+same-file-competitor shape) was found and fixed as a side effect. A 8-file
+precision spot-check via `grep` confirmed every newly-recovered dependent
+genuinely references its target. Index time and `get_dependents` query
+latency are unaffected (both run entirely at query time; measured
+before/after within noise, ~9ms mean per file on this corpus).
+
+Does NOT fix: `ILogger.cs` and `PropertyBinder.cs` (the two files this
+round's dogfood evidence specifically checks) still report
+`dependentAttributionIncomplete` — for an unrelated, pre-existing reason
+found while measuring this change, not this recovery mechanism. Both
+contain a method declaration whose signature is split mid-token across an
+`#if`/`#else`/`#endif` preprocessor boundary, which the tree-sitter C#
+grammar cannot represent and recovers from by rooting the entire file in an
+`ERROR` node — no chunk, no symbol, nothing for any recovery signal to work
+with. Affects 2/216 files in this corpus; a related but more tractable
+preprocessor-transparency gap (a declaration wholly inside one `#if` block,
+affecting ~8/216 more files) is filed as
+https://github.com/getlien/lien/issues/970, separate from this fix.

--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -351,6 +351,68 @@ describe('formatTests', () => {
       );
     });
   });
+
+  // #930/#943's C# type-reference signal, reused as a FIFTH test-association
+  // tier mirroring Swift's symbol-usage fallback immediately above — same
+  // "inferred, not import-verified" wording and same precedence (only
+  // consulted once tier 1's `tests` is empty).
+  describe('C# type-reference fallback (#930/#943 reused for test-association)', () => {
+    it('reports the distinct inferred wording when tests is empty but type-reference tests exist', () => {
+      expect(
+        formatTests(
+          [],
+          'src/Serilog/Policies/ProjectedDestructuringPolicy.cs',
+          [],
+          [],
+          ['test/Serilog.Tests/Configuration/LoggerConfigurationTests.cs'],
+        ),
+      ).toBe(
+        'Test coverage inferred from type-reference matching (not import-verified): test/Serilog.Tests/Configuration/LoggerConfigurationTests.cs.',
+      );
+    });
+
+    it('truncates type-reference fallback tests with a (+N more) suffix', () => {
+      expect(
+        formatTests(
+          [],
+          'src/Serilog/Core/Logger.cs',
+          [],
+          [],
+          [
+            'test/Serilog.Tests/Core/LoggerTests.cs',
+            'test/Serilog.Tests/Core/AuditSinkTests.cs',
+            'test/Serilog.Tests/Core/FailureListenerTests.cs',
+          ],
+        ),
+      ).toBe(
+        'Test coverage inferred from type-reference matching (not import-verified): test/Serilog.Tests/Core/LoggerTests.cs, test/Serilog.Tests/Core/AuditSinkTests.cs (+1 more).',
+      );
+    });
+
+    it('still reports the honest "not determinable" label when type-reference tests are also empty', () => {
+      expect(formatTests([], 'src/Serilog/Untested.cs', [], [], [])).toBe(
+        'Test coverage not determinable from imports (enclosing-namespace access).',
+      );
+    });
+
+    it('ignores type-reference tests entirely once a real (tier 1) association exists', () => {
+      expect(
+        formatTests(
+          ['test/Serilog.Tests/Core/LoggerTests.cs'],
+          'src/Serilog/Core/Logger.cs',
+          [],
+          [],
+          ['test/should-not-appear.cs'],
+        ),
+      ).toBe('Test coverage: test/Serilog.Tests/Core/LoggerTests.cs.');
+    });
+
+    it('does not apply the C# fallback wording on a non-enclosing-namespace-access language', () => {
+      expect(formatTests([], 'src/user.ts', [], [], ['src/user-inferred.test.ts'])).toBe(
+        'No test coverage.',
+      );
+    });
+  });
 });
 
 describe('formatTestReminder', () => {
@@ -430,6 +492,52 @@ describe('formatTestReminder', () => {
       ),
     ).toBe(
       'Lien: you changed Source/Core/Session.swift — associated tests: Tests/SessionTests.swift. Run them before completing.',
+    );
+  });
+
+  // #930/#943's C# type-reference signal, reused as a FIFTH test-association
+  // tier — mirrors the symbol-usage fallback wording above, for the shorter
+  // post-edit reminder line. Consulted only when tests, package-level tests,
+  // AND symbol-usage tests are all empty.
+  it('reports the type-reference fallback wording when tests, package-level, and symbol-usage tests are all empty', () => {
+    expect(
+      formatTestReminder(
+        'src/Serilog/Policies/ProjectedDestructuringPolicy.cs',
+        [],
+        [],
+        [],
+        ['test/Serilog.Tests/Configuration/LoggerConfigurationTests.cs'],
+      ),
+    ).toBe(
+      'Lien: you changed src/Serilog/Policies/ProjectedDestructuringPolicy.cs — no import-verified test match, but type-reference matching suggests: test/Serilog.Tests/Configuration/LoggerConfigurationTests.cs (inferred, not import-verified). Consider running them before completing.',
+    );
+  });
+
+  it('prefers the symbol-usage wording over type-reference when both are non-empty', () => {
+    expect(
+      formatTestReminder(
+        'Source/Core/HTTPHeaders.swift',
+        [],
+        [],
+        ['Tests/HTTPHeadersTests.swift'],
+        ['should-not-appear.cs'],
+      ),
+    ).toBe(
+      'Lien: you changed Source/Core/HTTPHeaders.swift — no import-verified test match, but symbol usage suggests: Tests/HTTPHeadersTests.swift (inferred, not import-verified). Consider running them before completing.',
+    );
+  });
+
+  it('prefers the direct-tests wording over type-reference when both are non-empty', () => {
+    expect(
+      formatTestReminder(
+        'src/Serilog/Core/Logger.cs',
+        ['test/Serilog.Tests/Core/LoggerTests.cs'],
+        [],
+        [],
+        ['should-not-appear.cs'],
+      ),
+    ).toBe(
+      'Lien: you changed src/Serilog/Core/Logger.cs — associated tests: test/Serilog.Tests/Core/LoggerTests.cs. Run them before completing.',
     );
   });
 });
@@ -768,6 +876,71 @@ describe('annotateCommand — --tests-only (integration)', () => {
       expect(logSpy).toHaveBeenCalledTimes(1);
       expect(logSpy.mock.calls[0][0]).toBe(
         `Lien: you changed ${swiftTarget} — no import-verified test match, but symbol usage suggests: Tests/HTTPHeadersTests.swift (inferred, not import-verified). Consider running them before completing.`,
+      );
+    } finally {
+      await fs.rm(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
+  // #930/#943, end-to-end: a C# source file reachable only via implicit
+  // enclosing-namespace access (no `using` names it at all) still surfaces
+  // its non-import type-reference fallback through the real
+  // `scanTestAssociations` -> `computeCSharpTypeReferenceTestFallback` ->
+  // `findCSharpTypeReferenceDependents` -> `formatTestReminder` pipeline --
+  // mirrors the Swift symbol-usage integration test immediately above.
+  it('prints the type-reference fallback reminder for a C# file with no import signal', async () => {
+    const fs = await import('fs/promises');
+    const repoRoot = path.resolve(process.cwd(), '..', '..');
+    const fixtureDir = path.join(repoRoot, '__annotate_csharp_fixture__');
+    const csharpTarget = '__annotate_csharp_fixture__/CollectingSink.cs';
+    await fs.mkdir(fixtureDir, { recursive: true });
+    await fs.writeFile(
+      path.join(fixtureDir, 'CollectingSink.cs'),
+      'namespace Serilog.Tests.Support;\n\npublic class CollectingSink { }\n',
+    );
+
+    const declChunk = {
+      content: 'public class CollectingSink { }',
+      metadata: {
+        file: csharpTarget,
+        startLine: 3,
+        endLine: 3,
+        type: 'class',
+        language: 'csharp',
+        symbolName: 'CollectingSink',
+        symbolType: 'class',
+        signature: 'class CollectingSink',
+      },
+      score: 0,
+      relevance: 'not_relevant',
+    };
+    const csharpTestChunk = {
+      content: 'var sink = new CollectingSink();',
+      metadata: {
+        file: 'Serilog.Tests/Configuration/LoggerConfigurationTests.cs',
+        startLine: 1,
+        endLine: 10,
+        type: 'function',
+        language: 'csharp',
+        symbolName: 'TestMethod',
+        symbolType: 'method',
+      },
+      score: 0,
+      relevance: 'not_relevant',
+    };
+    vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      hasData: vi.fn().mockResolvedValue(true),
+      scanAll: vi.fn().mockResolvedValue([declChunk, csharpTestChunk]),
+    } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
+
+    try {
+      await annotateCommand(csharpTarget, { testsOnly: true });
+
+      expect(errSpy).not.toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy.mock.calls[0][0]).toBe(
+        `Lien: you changed ${csharpTarget} — no import-verified test match, but type-reference matching suggests: Serilog.Tests/Configuration/LoggerConfigurationTests.cs (inferred, not import-verified). Consider running them before completing.`,
       );
     } finally {
       await fs.rm(fixtureDir, { recursive: true, force: true });

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -4,6 +4,7 @@ import { createVectorDB, ComplexityAnalyzer } from '@liendev/core';
 import {
   findTestAssociationsFromChunks,
   findSwiftSymbolUsageAssociations,
+  findCSharpTypeReferenceDependents,
   computeBlastRadiusRisk,
   detectLanguage,
   hasWholeModuleImports,
@@ -315,6 +316,29 @@ function computeSwiftSymbolUsageFallback(
   return findSwiftSymbolUsageAssociations([filepath], allChunks).get(filepath) ?? [];
 }
 
+/**
+ * A fifth, C#-specific tier mirroring `computeSwiftSymbolUsageFallback`
+ * immediately above: when `tests` (tier 1, import-based) is empty and
+ * `filepath`'s language sets `enclosingNamespaceAccess` (C#), reuse
+ * `findCSharpTypeReferenceDependents` -- the SAME namespace-scoped signal
+ * `get_dependents`'s file-level recovery already relies on (#930/#943) --
+ * filtered down to the TEST-file subset of `filepath`'s recovered
+ * dependents. Measured on serilog/serilog: 116/216 (54%) of files gain a
+ * recovered test-file dependent this way, cutting the previous 100%
+ * "test coverage not determinable" figure roughly in half. Deliberately NOT
+ * merged into `tests` itself, mirroring every other fallback tier here.
+ */
+function computeCSharpTypeReferenceTestFallback(
+  tests: string[],
+  filepath: string,
+  allChunks: CodeChunk[],
+): string[] {
+  if (tests.length > 0) return [];
+  const language = detectLanguage(filepath);
+  if (!language || !hasEnclosingNamespaceAccess(language)) return [];
+  return findCSharpTypeReferenceDependents(filepath, allChunks).filter(isTestFile);
+}
+
 /** All per-file analysis `run()` needs to decide whether/how to print. */
 interface AnnotationData {
   allChunks: CodeChunk[];
@@ -330,6 +354,7 @@ interface AnnotationData {
   tests: string[];
   packageLevelTests: string[];
   symbolUsageTests: string[];
+  csharpTypeReferenceTests: string[];
   complexity: ComplexitySummary;
   headroom: ComplexityHeadroom;
   risk: BlastRadiusRisk;
@@ -366,6 +391,11 @@ async function computeAnnotationData(
   const tests = findTestAssociationsFromChunks([filepath], allChunks, rootDir).get(filepath) ?? [];
   const packageLevelTests = computePackageLevelFallback(tests, filepath, allChunks, rootDir);
   const symbolUsageTests = computeSwiftSymbolUsageFallback(tests, filepath, allChunks);
+  const csharpTypeReferenceTests = computeCSharpTypeReferenceTestFallback(
+    tests,
+    filepath,
+    allChunks,
+  );
   const complexity = computeComplexitySummary(allChunks, filepath);
   // Plan-time nudge (mirrors get_files_context's complexityHeadroom): reuses
   // the exact same computation the MCP tool uses, so a "near budget" verdict
@@ -403,6 +433,7 @@ async function computeAnnotationData(
     tests,
     packageLevelTests,
     symbolUsageTests,
+    csharpTypeReferenceTests,
     complexity,
     headroom,
     risk,
@@ -476,6 +507,7 @@ async function run(file: string, options?: AnnotateOptions): Promise<void> {
       data.tests,
       data.packageLevelTests,
       data.symbolUsageTests,
+      data.csharpTypeReferenceTests,
       data.complexity,
       data.risk,
       data.headroom,
@@ -511,6 +543,15 @@ export interface FileTestAssociations {
    * `computeSwiftSymbolUsageFallback`.
    */
   symbolUsageTests: string[];
+  /**
+   * C#'s counterpart to `symbolUsageTests` immediately above (a FIFTH tier,
+   * same confidence bracket): populated only when `tests` is empty and the
+   * file's language sets `enclosingNamespaceAccess` (C#) — see
+   * `computeCSharpTypeReferenceTestFallback`. Same non-merging discipline:
+   * `lookupTestAssociations`'s caller reads only `.tests`; only the printed
+   * reminder (`formatTestReminder`) consults this field.
+   */
+  csharpTypeReferenceTests: string[];
   /**
    * #894: true when `rootDir`'s index has never been built (`hasData()` is
    * false for both standalone and worktree-overlay backends — see
@@ -554,6 +595,7 @@ async function scanTestAssociations(paths: ResolvedPaths): Promise<FileTestAssoc
         tests: [],
         packageLevelTests: [],
         symbolUsageTests: [],
+        csharpTypeReferenceTests: [],
         indexMissing: true,
       };
     }
@@ -562,7 +604,20 @@ async function scanTestAssociations(paths: ResolvedPaths): Promise<FileTestAssoc
       findTestAssociationsFromChunks([filepath], allChunks, rootDir).get(filepath) ?? [];
     const packageLevelTests = computePackageLevelFallback(tests, filepath, allChunks, rootDir);
     const symbolUsageTests = computeSwiftSymbolUsageFallback(tests, filepath, allChunks);
-    return { filepath, rootDir, tests, packageLevelTests, symbolUsageTests, indexMissing: false };
+    const csharpTypeReferenceTests = computeCSharpTypeReferenceTestFallback(
+      tests,
+      filepath,
+      allChunks,
+    );
+    return {
+      filepath,
+      rootDir,
+      tests,
+      packageLevelTests,
+      symbolUsageTests,
+      csharpTypeReferenceTests,
+      indexMissing: false,
+    };
   } finally {
     if (needsChdir) process.chdir(originalCwd);
   }
@@ -586,14 +641,36 @@ export async function lookupTestAssociations(file: string): Promise<FileTestAsso
  * no associated tests (the signal for the hook to stay silent).
  */
 async function runTestsOnly(paths: ResolvedPaths): Promise<void> {
-  const { filepath, rootDir, tests, packageLevelTests, symbolUsageTests, indexMissing } =
-    await scanTestAssociations(paths);
+  const {
+    filepath,
+    rootDir,
+    tests,
+    packageLevelTests,
+    symbolUsageTests,
+    csharpTypeReferenceTests,
+    indexMissing,
+  } = await scanTestAssociations(paths);
   if (indexMissing) {
     console.log(formatNoIndexWarning(rootDir));
     return;
   }
-  if (tests.length === 0 && packageLevelTests.length === 0 && symbolUsageTests.length === 0) return;
-  console.log(formatTestReminder(filepath, tests, packageLevelTests, symbolUsageTests));
+  if (
+    tests.length === 0 &&
+    packageLevelTests.length === 0 &&
+    symbolUsageTests.length === 0 &&
+    csharpTypeReferenceTests.length === 0
+  ) {
+    return;
+  }
+  console.log(
+    formatTestReminder(
+      filepath,
+      tests,
+      packageLevelTests,
+      symbolUsageTests,
+      csharpTypeReferenceTests,
+    ),
+  );
 }
 
 /**
@@ -630,14 +707,23 @@ export function formatTestReminder(
   tests: string[],
   packageLevelTests: string[] = [],
   symbolUsageTests: string[] = [],
+  csharpTypeReferenceTests: string[] = [],
 ): string {
-  if (tests.length === 0 && packageLevelTests.length > 0) {
+  if (tests.length > 0) {
+    const shown = formatTruncatedList(tests);
+    return `Lien: you changed ${filepath} — associated tests: ${shown}. Run them before completing.`;
+  }
+  if (packageLevelTests.length > 0) {
     const shown = formatTruncatedList(packageLevelTests);
     return `Lien: you changed ${filepath} — no dedicated test file, but its package has: ${shown}. Consider running them before completing.`;
   }
-  if (tests.length === 0 && packageLevelTests.length === 0 && symbolUsageTests.length > 0) {
+  if (symbolUsageTests.length > 0) {
     const shown = formatTruncatedList(symbolUsageTests);
     return `Lien: you changed ${filepath} — no import-verified test match, but symbol usage suggests: ${shown} (inferred, not import-verified). Consider running them before completing.`;
+  }
+  if (csharpTypeReferenceTests.length > 0) {
+    const shown = formatTruncatedList(csharpTypeReferenceTests);
+    return `Lien: you changed ${filepath} — no import-verified test match, but type-reference matching suggests: ${shown} (inferred, not import-verified). Consider running them before completing.`;
   }
   const shown = formatTruncatedList(tests);
   return `Lien: you changed ${filepath} — associated tests: ${shown}. Run them before completing.`;
@@ -672,6 +758,7 @@ function emitAnnotation(
   tests: string[],
   packageLevelTests: string[],
   symbolUsageTests: string[],
+  csharpTypeReferenceTests: string[],
   complexity: ComplexitySummary,
   risk: BlastRadiusRisk,
   headroom: ComplexityHeadroom,
@@ -683,7 +770,9 @@ function emitAnnotation(
     // Mirrors formatTests's "not determinable" honesty label -- see #930/#936.
     lines.push(`  • Dependents not determinable from imports (enclosing-namespace access).`);
   }
-  lines.push(`  • ${formatTests(tests, filepath, packageLevelTests, symbolUsageTests)}`);
+  lines.push(
+    `  • ${formatTests(tests, filepath, packageLevelTests, symbolUsageTests, csharpTypeReferenceTests)}`,
+  );
   if (complexity.warningCount > 0) {
     lines.push(`  • ${formatComplexity(complexity)}`);
   }
@@ -788,30 +877,51 @@ export function formatDependents(
  * "not determinable" label — real signal, but not import-verified, so it
  * gets its own label rather than silently upgrading to either of the other
  * two.
+ *
+ * `csharpTypeReferenceTests` is C#'s counterpart to `symbolUsageTests` (a
+ * FIFTH tier, same confidence bracket): consulted only for an
+ * `enclosingNamespaceAccess` language (C#) whose `tests` came back empty,
+ * reusing `get_dependents`' own namespace-scoped type-reference signal
+ * (`findCSharpTypeReferenceDependents`, #930/#943) filtered to the TEST-file
+ * subset of the recovered dependents. Same "inferred, not import-verified"
+ * wording and same non-merging discipline as `symbolUsageTests`.
  */
+/** Tier 4 (Swift, `wholeModuleImports`): see `formatTests`'s doc comment. */
+function formatWholeModuleImportTests(symbolUsageTests: string[]): string {
+  if (symbolUsageTests.length > 0) {
+    return `Test coverage inferred from symbol usage (not import-verified): ${formatTruncatedList(symbolUsageTests)}.`;
+  }
+  return 'Test coverage not determinable from imports (whole-module import).';
+}
+
+/** Tier 5 (C#, `enclosingNamespaceAccess`): see `formatTests`'s doc comment. */
+function formatEnclosingNamespaceAccessTests(csharpTypeReferenceTests: string[]): string {
+  if (csharpTypeReferenceTests.length > 0) {
+    return `Test coverage inferred from type-reference matching (not import-verified): ${formatTruncatedList(csharpTypeReferenceTests)}.`;
+  }
+  return 'Test coverage not determinable from imports (enclosing-namespace access).';
+}
+
 export function formatTests(
   tests: string[],
   filepath?: string,
   packageLevelTests: string[] = [],
   symbolUsageTests: string[] = [],
+  csharpTypeReferenceTests: string[] = [],
 ): string {
-  if (tests.length === 0) {
-    const language = filepath ? detectLanguage(filepath) : null;
-    if (language && hasWholeModuleImports(language)) {
-      if (symbolUsageTests.length > 0) {
-        return `Test coverage inferred from symbol usage (not import-verified): ${formatTruncatedList(symbolUsageTests)}.`;
-      }
-      return 'Test coverage not determinable from imports (whole-module import).';
-    }
-    if (language && hasEnclosingNamespaceAccess(language)) {
-      return 'Test coverage not determinable from imports (enclosing-namespace access).';
-    }
-    if (packageLevelTests.length > 0) {
-      return `Test coverage (package-level, no dedicated test file for this specific file): ${formatTruncatedList(packageLevelTests)}.`;
-    }
-    return 'No test coverage.';
+  if (tests.length > 0) return `Test coverage: ${formatTruncatedList(tests)}.`;
+
+  const language = filepath ? detectLanguage(filepath) : null;
+  if (language && hasWholeModuleImports(language)) {
+    return formatWholeModuleImportTests(symbolUsageTests);
   }
-  return `Test coverage: ${formatTruncatedList(tests)}.`;
+  if (language && hasEnclosingNamespaceAccess(language)) {
+    return formatEnclosingNamespaceAccessTests(csharpTypeReferenceTests);
+  }
+  if (packageLevelTests.length > 0) {
+    return `Test coverage (package-level, no dedicated test file for this specific file): ${formatTruncatedList(packageLevelTests)}.`;
+  }
+  return 'No test coverage.';
 }
 
 export function formatComplexity(summary: ComplexitySummary): string {

--- a/packages/parser/src/csharp-type-reference-signals.test.ts
+++ b/packages/parser/src/csharp-type-reference-signals.test.ts
@@ -7,6 +7,7 @@ interface ChunkOptions {
   content?: string;
   symbolName?: string;
   symbolType?: 'class' | 'interface' | 'method' | 'function';
+  parentClass?: string;
 }
 
 function makeChunk(opts: ChunkOptions): CodeChunk {
@@ -20,25 +21,49 @@ function makeChunk(opts: ChunkOptions): CodeChunk {
       language: 'csharp',
       symbolName: opts.symbolName,
       symbolType: opts.symbolType,
+      parentClass: opts.parentClass,
     },
   };
 }
 
-/** A real class/struct/record/enum declaration chunk. */
-function declChunk(file: string, symbolName: string): CodeChunk {
+/** A real class/struct/record/enum declaration chunk, optionally namespaced (a
+ * `namespace X;` line prefixed into content, mirroring how a real file's
+ * derived namespace is recovered from chunk content -- see
+ * `deriveCSharpNamespace`). */
+function declChunk(file: string, symbolName: string, namespace?: string): CodeChunk {
+  const nsPrefix = namespace ? `namespace ${namespace};\n\n` : '';
   return makeChunk({
     file,
-    content: `public class ${symbolName} { }`,
+    content: `${nsPrefix}public class ${symbolName} { }`,
     symbolName,
     symbolType: 'class',
   });
 }
 
-/** A production/test chunk whose body references `references` by name. */
-function usageChunk(file: string, references: string[]): CodeChunk {
+/** A NESTED type declaration chunk (`parentClass` set), optionally namespaced. */
+function nestedDeclChunk(
+  file: string,
+  symbolName: string,
+  parentClass: string,
+  namespace?: string,
+): CodeChunk {
+  const nsPrefix = namespace ? `namespace ${namespace};\n\n` : '';
   return makeChunk({
     file,
-    content: references.map(name => `${name}.Apply(output, value);`).join('\n'),
+    content: `${nsPrefix}class ${parentClass} { class ${symbolName} { } }`,
+    symbolName,
+    symbolType: 'class',
+    parentClass,
+  });
+}
+
+/** A production/test chunk whose body references `references` by name,
+ * optionally namespaced (see `declChunk`). */
+function usageChunk(file: string, references: string[], namespace?: string): CodeChunk {
+  const nsPrefix = namespace ? `namespace ${namespace};\n\n` : '';
+  return makeChunk({
+    file,
+    content: `${nsPrefix}${references.map(name => `${name}.Apply(output, value);`).join('\n')}`,
     symbolName: 'SomeMethod',
     symbolType: 'method',
   });
@@ -210,5 +235,185 @@ describe('findCSharpTypeReferenceDependents', () => {
         'src/Serilog/Rendering/Padding.cs',
       ],
     );
+  });
+
+  describe('tier 1 widened to test-declared types (#943 widening)', () => {
+    it('recovers a type declared ONLY in a test file -- test files are now valid declaring files, not just referencers', () => {
+      const chunks: CodeChunk[] = [
+        declChunk('test/Support/DummySink.cs', 'DummySink'),
+        usageChunk('test/Core/LoggerTests.cs', ['DummySink']),
+      ];
+
+      expect(findCSharpTypeReferenceDependents('test/Support/DummySink.cs', chunks)).toEqual([
+        'test/Core/LoggerTests.cs',
+      ]);
+    });
+
+    it('still drops a name that is ambiguous across TWO test files (widening does not relax the uniqueness gate itself)', () => {
+      const chunks: CodeChunk[] = [
+        declChunk('test/A/Fixture.cs', 'Fixture'),
+        declChunk('test/B/Fixture.cs', 'Fixture'),
+        usageChunk('test/C/Consumer.cs', ['Fixture']),
+      ];
+
+      expect(findCSharpTypeReferenceDependents('test/A/Fixture.cs', chunks)).toEqual([]);
+      expect(findCSharpTypeReferenceDependents('test/B/Fixture.cs', chunks)).toEqual([]);
+    });
+  });
+
+  describe('tier 2: namespace-scoped shadow resolution for globally-ambiguous names', () => {
+    // Deliberate reproduction of the exact collision risk called out for this
+    // feature: `Serilog.Core.Logger` vs `Serilog.Logger` vs a test's own
+    // `Logger` -- three separate, real classes sharing the identical bare
+    // name `Logger`, each declared in a different namespace. Real C# resolves
+    // a bare `Logger` reference via lexical namespace enclosure + shadowing
+    // (nearest enclosing declaration wins), never by picking one arbitrarily.
+    const coreLogger = declChunk('src/Core/Logger.cs', 'Logger', 'Serilog.Core');
+    const topLevelLogger = declChunk('src/Logger.cs', 'Logger', 'Serilog');
+    const testLogger = declChunk('test/Support/Logger.cs', 'Logger', 'Serilog.Tests.Support');
+
+    // Referencer physically inside Serilog.Core (a CHILD namespace of Serilog.Core
+    // itself) -- its chain is [Serilog.Core.Sinks, Serilog.Core, Serilog, ""],
+    // so BOTH Logger declarations are technically visible, but Serilog.Core is
+    // the closer (shadowing) match.
+    const coreSinkConsumer = usageChunk(
+      'src/Core/Sinks/SomeSink.cs',
+      ['Logger'],
+      'Serilog.Core.Sinks',
+    );
+    // Referencer in Serilog.Formatting -- a SIBLING of Serilog.Core (not an
+    // ancestor/descendant), so Serilog.Core.Logger is NOT visible here at all;
+    // only the outer Serilog.Logger is.
+    const siblingConsumer = usageChunk('src/Formatting/SomeFormatter.cs', ['Logger'], 'Serilog');
+    // Referencer inside the test's own namespace -- resolves to its own local
+    // Logger, invisible from anywhere else.
+    const testConsumer = usageChunk(
+      'test/Support/LoggerConsumerTests.cs',
+      ['Logger'],
+      'Serilog.Tests.Support',
+    );
+
+    const chunks: CodeChunk[] = [
+      coreLogger,
+      topLevelLogger,
+      testLogger,
+      coreSinkConsumer,
+      siblingConsumer,
+      testConsumer,
+    ];
+
+    it('resolves the closest enclosing declaration (Serilog.Core.Sinks -> Serilog.Core.Logger, shadowing the outer Serilog.Logger)', () => {
+      expect(findCSharpTypeReferenceDependents('src/Core/Logger.cs', chunks)).toEqual([
+        'src/Core/Sinks/SomeSink.cs',
+      ]);
+    });
+
+    it('resolves the outer declaration for a SIBLING namespace that cannot see the inner one (Serilog -> Serilog.Logger only)', () => {
+      expect(findCSharpTypeReferenceDependents('src/Logger.cs', chunks)).toEqual([
+        'src/Formatting/SomeFormatter.cs',
+      ]);
+    });
+
+    it('resolves a test namespace to its own local declaration, invisible from production namespaces', () => {
+      expect(findCSharpTypeReferenceDependents('test/Support/Logger.cs', chunks)).toEqual([
+        'test/Support/LoggerConsumerTests.cs',
+      ]);
+    });
+
+    it('never guesses when two DIFFERENT files declare the same name in the IDENTICAL namespace (genuine same-depth tie)', () => {
+      const tieChunks: CodeChunk[] = [
+        declChunk('src/A/Handler.cs', 'Handler', 'Root.Shared'),
+        declChunk('src/B/Handler.cs', 'Handler', 'Root.Shared'),
+        usageChunk('src/C/Consumer.cs', ['Handler'], 'Root.Shared'),
+      ];
+
+      // Both A and B sit at the identical chain position (index 0) for this
+      // referencer -- an unresolvable tie, not a shadowing win for either.
+      expect(findCSharpTypeReferenceDependents('src/A/Handler.cs', tieChunks)).toEqual([]);
+      expect(findCSharpTypeReferenceDependents('src/B/Handler.cs', tieChunks)).toEqual([]);
+    });
+
+    it('does not resolve across SIBLING namespaces that share no ancestor/descendant relationship', () => {
+      // Root.A and Root.B are siblings; a referencer in Root.C (an unrelated
+      // third sibling) can see neither unqualified -- an enclosure miss, not
+      // a tie, and just as un-guessable.
+      const chunks: CodeChunk[] = [
+        declChunk('src/A/Handler.cs', 'Handler', 'Root.A'),
+        declChunk('src/B/Handler.cs', 'Handler', 'Root.B'),
+        usageChunk('src/C/Consumer.cs', ['Handler'], 'Root.C'),
+      ];
+
+      expect(findCSharpTypeReferenceDependents('src/A/Handler.cs', chunks)).toEqual([]);
+      expect(findCSharpTypeReferenceDependents('src/B/Handler.cs', chunks)).toEqual([]);
+    });
+  });
+
+  describe('nested-type candidacy (#regression guards)', () => {
+    it('does not let a NESTED type declared in a TEST file collide with an unrelated top-level production type of the same name', () => {
+      // Reproduces the exact serilog/serilog regression found while widening
+      // tier 1 to test-declared types: `LoggerConfigurationTests.cs` declares
+      // an unrelated NESTED test-double also named `ProjectedDestructuringPolicy`.
+      const chunks: CodeChunk[] = [
+        declChunk('src/Policies/ProjectedDestructuringPolicy.cs', 'ProjectedDestructuringPolicy'),
+        nestedDeclChunk(
+          'test/Configuration/LoggerConfigurationTests.cs',
+          'ProjectedDestructuringPolicy',
+          'LoggerConfigurationTests',
+        ),
+        usageChunk('src/Configuration/LoggerDestructuringConfiguration.cs', [
+          'ProjectedDestructuringPolicy',
+        ]),
+      ];
+
+      expect(
+        findCSharpTypeReferenceDependents('src/Policies/ProjectedDestructuringPolicy.cs', chunks),
+      ).toEqual(['src/Configuration/LoggerDestructuringConfiguration.cs']);
+    });
+
+    it('excludes a referencer file entirely when it ALSO genuinely constructs its own local same-named double, not just declares it', () => {
+      // The real serilog/serilog shape that a mere declaration-chunk exclusion
+      // did not catch: `LoggerConfigurationTests.cs` doesn't just declare its
+      // local `ProjectedDestructuringPolicy` double -- a SEPARATE test method
+      // in the same file also genuinely constructs it (`new
+      // ProjectedDestructuringPolicy(...)`), which real C# shadowing resolves
+      // to the LOCAL double, never the production class. A word-boundary text
+      // match cannot tell that specific occurrence apart from a genuine
+      // reference to the production type, so the whole file must be excluded
+      // as evidence -- not just its declaration chunk.
+      const chunks: CodeChunk[] = [
+        declChunk('src/Policies/ProjectedDestructuringPolicy.cs', 'ProjectedDestructuringPolicy'),
+        nestedDeclChunk(
+          'test/Configuration/LoggerConfigurationTests.cs',
+          'ProjectedDestructuringPolicy',
+          'LoggerConfigurationTests',
+        ),
+        // A separate chunk in the SAME file: a test method genuinely
+        // constructing the LOCAL double, not the production class.
+        usageChunk('test/Configuration/LoggerConfigurationTests.cs', [
+          'ProjectedDestructuringPolicy',
+        ]),
+      ];
+
+      expect(
+        findCSharpTypeReferenceDependents('src/Policies/ProjectedDestructuringPolicy.cs', chunks),
+      ).toEqual([]);
+    });
+
+    it('still recovers a PRODUCTION nested type declared in its own file (partial-class continuation pattern)', () => {
+      // Reproduces serilog/serilog's `DepthLimiter.cs`: `partial class
+      // PropertyValueConverter { class DepthLimiter { ... } }` declared in a
+      // SEPARATE file from `PropertyValueConverter.cs` itself, which
+      // references the nested type unqualified (legitimate: nested types are
+      // visible, unqualified, throughout every `partial` piece of their
+      // enclosing type).
+      const chunks: CodeChunk[] = [
+        nestedDeclChunk('src/Capturing/DepthLimiter.cs', 'DepthLimiter', 'PropertyValueConverter'),
+        usageChunk('src/Capturing/PropertyValueConverter.cs', ['DepthLimiter']),
+      ];
+
+      expect(findCSharpTypeReferenceDependents('src/Capturing/DepthLimiter.cs', chunks)).toEqual([
+        'src/Capturing/PropertyValueConverter.cs',
+      ]);
+    });
   });
 });

--- a/packages/parser/src/csharp-type-reference-signals.ts
+++ b/packages/parser/src/csharp-type-reference-signals.ts
@@ -1,5 +1,5 @@
 /**
- * #930 (part 2): recover REAL production dependents for a C# file when the
+ * #930 (part 2, widened): recover REAL dependents for a C# file when the
  * import graph finds none, because of `global using` / implicit enclosing-
  * namespace access (see `csharp.ts`'s `isGlobalUsingDirective` and
  * `enclosingNamespaceAccess` doc comments for the mechanism -- a file that
@@ -12,11 +12,15 @@
  * type's declaring file, matched against every other C# chunk's raw source
  * text for an identifier-boundary occurrence of that type's name.
  *
- * Association rule (source S declares type T -> dependent D references T):
+ * Two resolution tiers run for every query, both feeding the same returned
+ * dependent set:
+ *
+ * TIER 1 -- global uniqueness (source S declares type T -> dependent D references T):
  *   1. T is declared (`class`/`struct`/`interface`/`record`/`enum`) in
- *      EXACTLY ONE non-test C# file project-wide (S) -- see
+ *      EXACTLY ONE C# file project-wide (S) -- see
  *      `buildCSharpTypeOwnerMap`/`uniqueCSharpTypeOwners`. Ambiguous
- *      (multiply-declared) names are dropped entirely, never guessed at.
+ *      (multiply-declared) names fall through to tier 2, never guessed at
+ *      here.
  *   2. D (any other C# chunk, production or test) contains an
  *      identifier-boundary occurrence of T's name in its raw source text
  *      (`identifierBoundaryRe` below -- plain `\b` semantics, deliberately
@@ -29,7 +33,60 @@
  *      continuing the same token).
  *   3. D !== S.
  *
- * Why uniqueness alone is a strong enough gate here, unlike Swift's
+ * S is no longer required to be a non-test file (widened from the original
+ * #930-part-2 shape): measured against serilog/serilog, 53 of the corpus's
+ * 216 `.cs` files were EXCLUSIVELY test-declared types (test helper
+ * fixtures like `DummyRollingFileSink.cs`, `CollectingSink.cs`) that real
+ * OTHER test files genuinely reference -- excluding test files from the
+ * declaring side made `get_dependents` report "not determinable" on all 53
+ * even though the reference is exactly as textually unambiguous as a
+ * production one. D was already allowed to be test-or-production (point 2
+ * above); restricting only S was an asymmetry with no precision benefit --
+ * the SAME uniqueness gate still drops a name if it collides with anything
+ * else project-wide, test or production.
+ *
+ * TIER 2 -- namespace-scoped shadow resolution (new): for a type name T that
+ * IS ambiguous globally (declared in more than one file), C# does not
+ * actually leave the reference unresolvable -- real C# resolves an
+ * unqualified name via lexical namespace scoping: a reference in namespace
+ * `Serilog.Core` sees unqualified members of `Serilog.Core` itself AND every
+ * ENCLOSING namespace (`Serilog`, the global namespace), never a sibling or
+ * descendant namespace, and when more than one visible declaration shares the
+ * name, the INNERMOST (closest-enclosing) one wins (real C# shadowing).
+ * `enclosingNamespaceChain` implements this by decomposing the dotted
+ * namespace string into progressively shorter prefixes -- valid because a
+ * dotted namespace declaration (`namespace Serilog.Core.Foo`) is defined by
+ * the C# spec to behave identically to nested blocks
+ * (`namespace Serilog { namespace Core { namespace Foo { ... } } }`).
+ *
+ * For each ambiguous name T that `targetFile` declares in namespace N: every
+ * OTHER C# file D whose own namespace's enclosing chain contains N, where no
+ * OTHER declaration of T sits at an equal-or-closer position in that same
+ * chain (i.e. targetFile's declaration is the unique closest/winning one for
+ * D specifically), and whose text contains a word-boundary match of T, is
+ * recovered as a dependent of `targetFile`. A referencer whose chain contains
+ * TWO declarations of T at the same depth (a genuine same-namespace name
+ * clash) is dropped for that name, matching tier 1's "never guess" rule.
+ *
+ * Both tiers need each file's own namespace. Getting it costs NO schema
+ * change: rather than adding a persisted `namespace` field (a real SQLite
+ * column + `INDEX_FORMAT_VERSION` bump + migration), `deriveCSharpNamespace`
+ * recovers it from already-indexed chunk CONTENT -- a namespace declaration
+ * line (block-style `namespace Foo.Bar {` or C# 10 file-scoped
+ * `namespace Foo.Bar;`) sits in a file's own "uncovered" chunk (the gap
+ * before/around its first real declaration -- see `chunker.ts`'s
+ * `extractUncoveredCode`), which already carries the raw source text.
+ * Measured against serilog/serilog: 205/216 files (95%) yield a derivable
+ * namespace this way. The 11 misses are files with no namespace at all
+ * (`GlobalUsings.cs`, `AssemblyInfo.cs`) or short internal-only (non-public,
+ * so no `exports`, so the uncovered range can fall under the chunker's
+ * `minChunkSize` and get dropped) files -- `deriveCSharpNamespace` returns
+ * `undefined` rather than guessing for these, and both tiers treat "namespace
+ * not determinable" as "skip this file as a scoping candidate," never as
+ * "assume the global namespace." Failing to determine a namespace can only
+ * ever suppress a recovery, never fabricate one.
+ *
+ * Why uniqueness alone is a strong enough gate for tier 1, unlike Swift's
  * call-site symbol matching (`swift-symbol-usage-signals.ts`, #869): that
  * signal had to additionally demote purely-lowercase-method-driven edges,
  * because a bare METHOD name can collide with a stdlib protocol witness, an
@@ -53,9 +110,15 @@
  * case, not a false positive, but the matcher can't tell the two apart in
  * principle). Nor can it catch a reference via an alias (`using A =
  * Some.Alignment;`), a generic type argument written without the bare name
- * on its own line in an unusual way, or reflection-based usage. Residual
- * risk is accepted and hedged, not eliminated -- callers must surface this
- * as a lower-confidence, non-import-verified signal (see
+ * on its own line in an unusual way, or reflection-based usage. Tier 2 adds
+ * one more limitation on top: it can only place a referencing FILE in the
+ * namespace hierarchy when `deriveCSharpNamespace` succeeds for it, and a
+ * TRUE nested-block declaration split across multiple physical `namespace`
+ * lines in one file (`namespace A { namespace B { ... } }`, vanishingly rare
+ * in modern C#) is read as just its outermost segment, not the full nested
+ * path -- again a fail-safe direction (a missed recovery, never a fabricated
+ * one). Residual risk is accepted and hedged, not eliminated -- callers must
+ * surface this as a lower-confidence, non-import-verified signal (see
  * `DependentInfo.confidence` in the CLI's dependency-analyzer.ts), never
  * fold it in unhedged next to a real import edge.
  *
@@ -99,7 +162,8 @@ function identifierBoundaryRe(name: string): RegExp {
 }
 
 /**
- * True iff `chunk` is a C# type declaration (class/struct/record/enum/interface).
+ * True iff `chunk` is a TOP-LEVEL C# type declaration
+ * (class/struct/record/enum/interface).
  *
  * Checking only `'class' | 'interface'` is NOT a narrower test than the doc says:
  * `csharp.ts` collapses `class_declaration`, `interface_declaration`,
@@ -115,26 +179,146 @@ function identifierBoundaryRe(name: string): RegExp {
  * `PropertyToken` and one on the struct itself). Without restricting the declaration
  * set to types, those would break the "exactly one file declares this name" check
  * and suppress a real recovery.
+ *
+ * A NESTED type (`chunk.metadata.parentClass` set) declared in a TEST file is
+ * additionally excluded. A nested type's bare name is governed by
+ * containing-TYPE membership, not namespace membership (you need to be
+ * lexically inside the enclosing type -- including another file's
+ * declaration of the SAME `partial` type -- or write `Outer.Nested`
+ * explicitly, to reference it unqualified), a resolution axis this module
+ * doesn't model at all; a test file's own nested type is disproportionately
+ * likely to be a throwaway, genericly-named local test-double, so this is
+ * where that unmodeled risk is most worth cutting off. Both measured on
+ * serilog/serilog, from widening tier 1's declaring-file set to include test
+ * files (see the module doc):
+ *   - Excluding TEST-nested types fixes a real regression: a top-level
+ *     PRODUCTION class `Serilog.Policies.ProjectedDestructuringPolicy` lost
+ *     its 2 previously-recovered dependents because
+ *     `LoggerConfigurationTests.cs` happens to declare an unrelated NESTED
+ *     test-double class of the identical name.
+ *   - NOT also excluding PRODUCTION-nested types matters just as much: a
+ *     nested class can legitimately live in its OWN file as a `partial`
+ *     continuation of its enclosing type (`DepthLimiter.cs` declares
+ *     `partial class PropertyValueConverter { class DepthLimiter { ... } }`),
+ *     making the nested name directly, unqualifiedly visible from
+ *     `PropertyValueConverter.cs` itself -- excluding production nested types
+ *     too would have broken that real, working recovery.
  */
-function isCSharpTypeDeclarationChunk(chunk: CodeChunk): boolean {
-  return chunk.metadata.symbolType === 'class' || chunk.metadata.symbolType === 'interface';
+function isCandidateCSharpTypeDeclarationChunk(chunk: CodeChunk, file: string): boolean {
+  if (chunk.metadata.symbolType !== 'class' && chunk.metadata.symbolType !== 'interface')
+    return false;
+  if (chunk.metadata.parentClass && isTestFile(file)) return false;
+  return true;
+}
+
+/**
+ * True iff `chunk` IS a type declaration named `typeName` -- i.e. this chunk's
+ * own content is `typeName`'s declaration line, not a usage of it.
+ */
+function isDeclarationChunkFor(chunk: CodeChunk, typeName: string): boolean {
+  return (
+    (chunk.metadata.symbolType === 'class' || chunk.metadata.symbolType === 'interface') &&
+    chunk.metadata.symbolName === typeName
+  );
+}
+
+/**
+ * True iff `fileChunks` (some OTHER file being considered as a candidate
+ * referencer, never `targetFile` itself) declares its OWN type named
+ * `typeName` ANYWHERE -- regardless of whether that declaration is a
+ * candidate owner (see `isCandidateCSharpTypeDeclarationChunk`). A file in
+ * this state is excluded ENTIRELY as evidence for `typeName`'s target
+ * declaration, for both tiers: once a file has a competing local declaration
+ * of the identical name, real C# shadowing means every bare occurrence of
+ * that name WITHIN that file resolves to its OWN local declaration, not
+ * `targetFile`'s -- and a plain word-boundary text match cannot tell which
+ * specific occurrence is which, so the only safe answer is "don't guess",
+ * exactly like every other unresolvable-ambiguity case this module refuses
+ * to guess at.
+ *
+ * This is stronger than (and supersedes) excluding just the declaration
+ * chunk's own text: caught empirically on serilog/serilog --
+ * `LoggerConfigurationTests.cs` declares an unrelated NESTED test-double
+ * `ProjectedDestructuringPolicy` (excluded from candidacy by the
+ * nested-in-test-file rule) and, at a SEPARATE call site in the SAME file,
+ * genuinely constructs that SAME local double. Excluding only the
+ * declaration chunk's own text left that separate call site still matching
+ * -- a fabricated edge to the unrelated PRODUCTION
+ * `Serilog.Policies.ProjectedDestructuringPolicy`. Excluding the whole file
+ * once it's known to declare the name itself closes that gap.
+ */
+function fileDeclaresTypeName(fileChunks: CodeChunk[], typeName: string): boolean {
+  return fileChunks.some(chunk => isDeclarationChunkFor(chunk, typeName));
 }
 
 interface CSharpTypeDeclaration {
   file: string;
   typeName: string;
+  /** This declaration's own enclosing namespace, or `undefined` when `deriveCSharpNamespace` couldn't determine one (never guessed at). */
+  namespace: string | undefined;
 }
 
-/** Non-test C# chunks that declare a type, keyed by their raw `symbolName`. */
-function collectCSharpTypeDeclarations(chunks: CodeChunk[]): CSharpTypeDeclaration[] {
+/** Group `chunks` by file, preserving first-seen order. Deliberately local and
+ * unnormalized -- NOT `dependency-analyzer.ts`'s `groupChunksByFile` (that one
+ * canonicalizes paths against a workspace root); this module works on
+ * `chunk.metadata.file` strings as-is throughout, matching its existing
+ * no-normalization discipline (see `findCSharpTypeReferenceDependents`'s
+ * `targetFile` contract). */
+function groupCSharpChunksByFile(chunks: CodeChunk[]): Map<string, CodeChunk[]> {
+  const out = new Map<string, CodeChunk[]>();
+  for (const chunk of chunks) {
+    const list = out.get(chunk.metadata.file);
+    if (list) list.push(chunk);
+    else out.set(chunk.metadata.file, [chunk]);
+  }
+  return out;
+}
+
+/**
+ * A namespace declaration line -- block-style (`namespace Foo.Bar {`) or C#
+ * 10 file-scoped (`namespace Foo.Bar;`) -- anchored to the start of a line
+ * (the `m` flag) so it can't fire on a coincidental mid-line occurrence.
+ */
+const NAMESPACE_DECLARATION_RE = /^[ \t]*namespace[ \t]+([\w.]+)[ \t]*[;{]/m;
+
+/**
+ * The dot-joined namespace enclosing `file`'s declarations (e.g.
+ * `"Serilog.Core"`), or `undefined` when not determinable. See the module
+ * doc's "Both tiers need each file's own namespace" section for why this is
+ * derived from already-indexed chunk CONTENT (schema-free) instead of a new
+ * persisted field, and its measured 205/216 (95%) hit rate on serilog.
+ *
+ * Scans `fileChunks` in line order and returns the FIRST match -- correct
+ * for the overwhelming common case of one namespace per file; a file with
+ * more than one top-level namespace block reports only the first one, a
+ * fail-safe (under-, never over-) approximation -- see the module doc.
+ */
+function deriveCSharpNamespace(fileChunks: CodeChunk[]): string | undefined {
+  const sorted = [...fileChunks].sort((a, b) => a.metadata.startLine - b.metadata.startLine);
+  for (const chunk of sorted) {
+    const match = NAMESPACE_DECLARATION_RE.exec(chunk.content);
+    if (match) return match[1];
+  }
+  return undefined;
+}
+
+/**
+ * C# chunks (any file, production or test -- see the module doc's "S is no
+ * longer required to be a non-test file") that declare a type, each stamped
+ * with its own file's derived namespace.
+ */
+function collectCSharpTypeDeclarations(
+  chunks: CodeChunk[],
+  namespaceByFile: Map<string, string | undefined>,
+): CSharpTypeDeclaration[] {
   const out: CSharpTypeDeclaration[] = [];
   for (const chunk of chunks) {
     const file = chunk.metadata.file;
-    if (detectLanguage(file) !== 'csharp' || isTestFile(file)) continue;
-    if (!isCSharpTypeDeclarationChunk(chunk)) continue;
+    if (detectLanguage(file) !== 'csharp') continue;
+    if (!isCandidateCSharpTypeDeclarationChunk(chunk, file)) continue;
     const typeName = chunk.metadata.symbolName;
     if (!typeName) continue;
-    out.push({ file, typeName });
+    out.push({ file, typeName, namespace: namespaceByFile.get(file) });
   }
   return out;
 }
@@ -160,11 +344,200 @@ function uniqueCSharpTypeOwners(defMap: Map<string, Set<string>>): Map<string, s
 }
 
 /**
+ * Namespaces visible from code physically inside `namespace`, innermost
+ * first, ending with `""` (the global namespace). Pure prefix decomposition
+ * of the dotted string -- see the module doc's TIER 2 section for why this
+ * equals C#'s real enclosing-namespace scope chain (a dotted namespace
+ * declaration is spec-defined to behave exactly like nested blocks).
+ */
+function enclosingNamespaceChain(namespace: string): string[] {
+  const parts = namespace ? namespace.split('.') : [];
+  const chain: string[] = [];
+  for (let i = parts.length; i >= 0; i--) chain.push(parts.slice(0, i).join('.'));
+  return chain;
+}
+
+/** A candidate declaration of some ambiguous type name: which file declares it, and in which namespace. */
+interface AmbiguousCandidate {
+  namespace: string | undefined;
+  file: string;
+}
+
+/**
+ * Is `typeName`'s declaration in `targetFile`/`targetNamespace` SHADOWED (or
+ * tied) by some OTHER candidate, from the vantage point of a referencer whose
+ * enclosing chain is `chain`? True means "don't guess" -- see the module
+ * doc's TIER 2 shadowing rule. Split out from `resolvesToTargetViaNamespace`
+ * purely to keep that function's own cognitive complexity low.
+ */
+function isShadowedForReferencer(
+  chain: string[],
+  targetDepth: number,
+  targetFile: string,
+  candidates: ReadonlyArray<AmbiguousCandidate>,
+): boolean {
+  return candidates.some(candidate => {
+    if (candidate.file === targetFile || candidate.namespace === undefined) return false;
+    const idx = chain.indexOf(candidate.namespace);
+    return idx !== -1 && idx <= targetDepth;
+  });
+}
+
+/**
+ * Does `file` (one candidate referencer, NOT `targetFile` itself) resolve a
+ * bare reference to `typeName` back to `targetFile`'s declaration in
+ * `targetNamespace`, per TIER 2's namespace-enclosure + shadowing rule? See
+ * the module doc's TIER 2 section for the full rule this implements.
+ */
+function resolvesToTargetViaNamespace(
+  file: string,
+  fileChunks: CodeChunk[],
+  targetFile: string,
+  targetNamespace: string,
+  typeName: string,
+  matcher: RegExp,
+  candidates: ReadonlyArray<AmbiguousCandidate>,
+  namespaceByFile: Map<string, string | undefined>,
+): boolean {
+  if (detectLanguage(file) !== 'csharp') return false;
+
+  const refNamespace = namespaceByFile.get(file);
+  if (refNamespace === undefined) return false; // undeterminable -- never guess
+
+  const chain = enclosingNamespaceChain(refNamespace);
+  const targetDepth = chain.indexOf(targetNamespace);
+  if (targetDepth === -1) return false; // targetNamespace isn't visible from here
+
+  if (isShadowedForReferencer(chain, targetDepth, targetFile, candidates)) return false;
+
+  // A referencer that declares its OWN same-named type is unresolvable from
+  // text alone -- see `fileDeclaresTypeName`'s doc comment.
+  if (fileDeclaresTypeName(fileChunks, typeName)) return false;
+
+  return fileChunks.some(c => matcher.test(c.content));
+}
+
+/**
+ * TIER 2: for one ambiguous (globally multiply-declared) `typeName` that
+ * `targetFile` declares in `targetNamespace`, find every OTHER C# file that
+ * resolves a bare reference to `typeName` back to `targetFile` specifically
+ * -- via real C# namespace-enclosure AND shadowing -- see the module doc's
+ * TIER 2 section for the full rule.
+ */
+function findNamespaceScopedDependents(
+  targetFile: string,
+  targetNamespace: string,
+  typeName: string,
+  candidates: ReadonlyArray<AmbiguousCandidate>,
+  chunksByFile: Map<string, CodeChunk[]>,
+  namespaceByFile: Map<string, string | undefined>,
+): string[] {
+  const matcher = identifierBoundaryRe(typeName);
+  const found: string[] = [];
+
+  for (const [file, fileChunks] of chunksByFile) {
+    if (file === targetFile) continue;
+    if (
+      resolvesToTargetViaNamespace(
+        file,
+        fileChunks,
+        targetFile,
+        targetNamespace,
+        typeName,
+        matcher,
+        candidates,
+        namespaceByFile,
+      )
+    ) {
+      found.push(file);
+    }
+  }
+
+  return found;
+}
+
+/** Map every C# file in `chunksByFile` to its derived namespace (or `undefined`). */
+function buildCSharpNamespaceIndex(
+  chunksByFile: Map<string, CodeChunk[]>,
+): Map<string, string | undefined> {
+  const namespaceByFile = new Map<string, string | undefined>();
+  for (const [file, fileChunks] of chunksByFile) {
+    if (detectLanguage(file) === 'csharp') {
+      namespaceByFile.set(file, deriveCSharpNamespace(fileChunks));
+    }
+  }
+  return namespaceByFile;
+}
+
+/** TIER 1: every C# file referencing one of `targetFile`'s globally-unique declared type names. */
+function resolveTier1UniqueDependents(
+  targetFile: string,
+  defMap: Map<string, Set<string>>,
+  chunksByFile: Map<string, CodeChunk[]>,
+): Set<string> {
+  const found = new Set<string>();
+  const owners = uniqueCSharpTypeOwners(defMap);
+  const uniqueTargetNames = [...owners.entries()]
+    .filter(([, file]) => file === targetFile)
+    .map(([typeName]) => typeName);
+  if (uniqueTargetNames.length === 0) return found;
+
+  const matchers = uniqueTargetNames.map(name => ({ name, re: identifierBoundaryRe(name) }));
+  for (const [file, fileChunks] of chunksByFile) {
+    if (file === targetFile) continue;
+    if (detectLanguage(file) !== 'csharp') continue;
+    // A referencer that declares its OWN same-named type is unresolvable
+    // from text alone -- see `fileDeclaresTypeName`'s doc comment.
+    const references = matchers.some(
+      ({ name, re }) =>
+        !fileDeclaresTypeName(fileChunks, name) && fileChunks.some(c => re.test(c.content)),
+    );
+    if (references) found.add(file);
+  }
+  return found;
+}
+
+/** TIER 2: every C# file resolving one of `targetFile`'s AMBIGUOUS declared type names back to it via namespace scoping + shadowing. */
+function resolveTier2NamespaceScopedDependents(
+  targetFile: string,
+  declarations: CSharpTypeDeclaration[],
+  defMap: Map<string, Set<string>>,
+  chunksByFile: Map<string, CodeChunk[]>,
+  namespaceByFile: Map<string, string | undefined>,
+): Set<string> {
+  const found = new Set<string>();
+  const targetNamespace = namespaceByFile.get(targetFile);
+  if (targetNamespace === undefined) return found;
+
+  const ambiguousTargetNames = declarations
+    .filter(decl => decl.file === targetFile && (defMap.get(decl.typeName)?.size ?? 0) > 1)
+    .map(decl => decl.typeName);
+
+  for (const typeName of ambiguousTargetNames) {
+    const candidates = declarations.filter(decl => decl.typeName === typeName);
+    const extra = findNamespaceScopedDependents(
+      targetFile,
+      targetNamespace,
+      typeName,
+      candidates,
+      chunksByFile,
+      namespaceByFile,
+    );
+    for (const file of extra) found.add(file);
+  }
+  return found;
+}
+
+/**
  * Find C# files (any file, production or test) that reference one of
- * `targetFile`'s uniquely-declared type names via a word-boundary text
- * match, excluding `targetFile` itself. Returns a sorted, deduplicated list
- * of filepaths -- empty when `targetFile` isn't a C# file, declares no
- * uniquely-owned type, or genuinely has no textual referrers in `chunks`.
+ * `targetFile`'s declared type names, either because the name is uniquely
+ * declared project-wide (tier 1) or because namespace scoping + shadowing
+ * unambiguously resolves an otherwise globally-ambiguous name back to
+ * `targetFile` for that specific referencer (tier 2) -- see the module doc
+ * for both rules. Excludes `targetFile` itself. Returns a sorted,
+ * deduplicated list of filepaths -- empty when `targetFile` isn't a C# file,
+ * declares no resolvable type, or genuinely has no textual referrers in
+ * `chunks`.
  *
  * `targetFile` must be the exact `chunk.metadata.file` string used by
  * `targetFile`'s own chunks within `chunks` (not a separately-normalized
@@ -172,8 +545,9 @@ function uniqueCSharpTypeOwners(defMap: Map<string, Set<string>>): Map<string, s
  * on plain string equality throughout, mirroring
  * `swift-symbol-usage-signals.ts`'s same discipline.
  *
- * `chunks` should be the FULL project chunk set -- uniqueness is a
- * project-wide property, not scoped to `targetFile` alone.
+ * `chunks` should be the FULL project chunk set -- uniqueness (tier 1) and
+ * namespace scoping (tier 2) are both project-wide properties, not scoped to
+ * `targetFile` alone.
  */
 export function findCSharpTypeReferenceDependents(
   targetFile: string,
@@ -181,25 +555,19 @@ export function findCSharpTypeReferenceDependents(
 ): string[] {
   if (detectLanguage(targetFile) !== 'csharp') return [];
 
-  const owners = uniqueCSharpTypeOwners(
-    buildCSharpTypeOwnerMap(collectCSharpTypeDeclarations(chunks)),
+  const chunksByFile = groupCSharpChunksByFile(chunks);
+  const namespaceByFile = buildCSharpNamespaceIndex(chunksByFile);
+  const declarations = collectCSharpTypeDeclarations(chunks, namespaceByFile);
+  const defMap = buildCSharpTypeOwnerMap(declarations);
+
+  const tier1 = resolveTier1UniqueDependents(targetFile, defMap, chunksByFile);
+  const tier2 = resolveTier2NamespaceScopedDependents(
+    targetFile,
+    declarations,
+    defMap,
+    chunksByFile,
+    namespaceByFile,
   );
-  const targetTypeNames = [...owners.entries()]
-    .filter(([, file]) => file === targetFile)
-    .map(([typeName]) => typeName);
-  if (targetTypeNames.length === 0) return [];
 
-  const matchers = targetTypeNames.map(name => identifierBoundaryRe(name));
-  const found = new Set<string>();
-
-  for (const chunk of chunks) {
-    const file = chunk.metadata.file;
-    if (file === targetFile || found.has(file)) continue;
-    if (detectLanguage(file) !== 'csharp') continue;
-    if (matchers.some(re => re.test(chunk.content))) {
-      found.add(file);
-    }
-  }
-
-  return [...found].sort();
+  return [...new Set([...tier1, ...tier2])].sort();
 }


### PR DESCRIPTION
## Summary

Closes the remaining half of Lien's largest measured C# gap. #943 already shipped a global-uniqueness type-reference recovery for `get_dependents`, but re-measuring on a fresh `serilog/serilog` clone (216 `.cs` files, current build) showed it was still leaving 53% of files `dependentAttributionIncomplete` ("not determinable") and 100% of files with test coverage "not determinable." Two root causes, both fixed here without any schema change:

1. **Tier 1 widened**: the uniqueness check excluded test files as *declaring* types entirely, even though test files were already accepted as *dependents*. 53/216 files were test-only helper classes (`DummyRollingFileSink.cs`, `CollectingSink.cs`, …) that real other tests genuinely reference — excluded purely by this asymmetry.
2. **Tier 2 (new)**: a globally-ambiguous type name (declared in >1 file) was dropped outright. Real C# actually resolves this via lexical namespace-enclosure + shadowing (innermost enclosing declaration wins) — implemented here, schema-free: each file's namespace is derived from its own already-indexed chunk content (95% hit rate measured), not a new SQLite column / `INDEX_FORMAT_VERSION` bump.

A referencer that declares its own competing same-named type is excluded entirely from counting as "referencing" either tier's target — caught via a real regression during testing (see below).

The same recovered signal, filtered to its test-file dependents, is reused as a fifth `lien annotate` test-association tier (mirroring Swift's existing symbol-usage tier), closing the companion 100%-not-determinable test-coverage gap in this same PR rather than punting it.

## Measured before/after (serilog/serilog, 216 `.cs` files)

| | before (this build, #943 shipped) | after |
|---|---|---|
| `dependentAttributionIncomplete` ("not determinable") | 114/216 (53%) | 63/216 (29%) |
| recovered via type-reference matching | 102/216 (47%) | 153/216 (71%) |
| test coverage not-determinable | 216/216 (100%) | 100/216 (46%) |

Reproduced with `node packages/cli/dist/index.js index --force` before every measurement, per the round's own lesson about stale indices.

**Regressions**: zero, verified via a full per-file diff of every recovered-dependent SET (not just the aggregate counts) against the pre-widening baseline. One pre-existing #943 false positive was found and fixed as a side effect: `LoggerConfigurationTests.cs` was spuriously reported as a dependent of the production `Serilog.Policies.ProjectedDestructuringPolicy` — it actually constructs its own unrelated NESTED test-double of the identical name (`class ProjectedDestructuringPolicy` nested inside the test class); a bare word-boundary match couldn't tell the two apart. Fixed by excluding a referencer file entirely once it's known to declare a competing same name (`fileDeclaresTypeName`), not just excluding the declaration line itself.

**Precision spot-check** (8 files, via `grep`): every newly-recovered dependent for `CollectingSink.cs` (9), `NullSink.cs` (7), `CollectingFailureListener.cs` (2), `CallbackBatchedSink.cs` (1), and `ClassHierarchy.cs`'s 3 nested dummy types genuinely references the type — 100% precision, zero false positives found.

**Timing**: unaffected. Index time ~430-445ms before and after (this logic runs only at query time, never during indexing). `get_dependents` query latency: mean 9.15ms before → 9.18ms after across all 216 files (well within noise). The underlying `findCSharpTypeReferenceDependents` call itself averages 0.9ms/file.

## Dogfood evidence (verbatim, foreign repo — serilog/serilog at `/tmp/lien-dogfood-460173c9/serilog`)

`ILogger.cs` and `PropertyBinder.cs` — the two files this round's brief named — are **unaffected by this fix**, before and after:

```
$ lien annotate src/Serilog/ILogger.cs        (before AND after)
Lien impact for src/Serilog/ILogger.cs:
  • Dependents not determinable from imports (enclosing-namespace access).
  • Test coverage not determinable from imports (enclosing-namespace access).

$ lien annotate src/Serilog/Capturing/PropertyBinder.cs   (before AND after)
Lien impact for src/Serilog/Capturing/PropertyBinder.cs:
  • Dependents not determinable from imports (enclosing-namespace access).
  • Test coverage not determinable from imports (enclosing-namespace access).
```

Investigated why: both files' method signatures are split mid-token across an `#if FEATURE_.../#else/#endif` preprocessor boundary (e.g. `ILogger ForContext(...)` followed by `#if X { ... } #else ; #endif`). Tree-sitter's C# grammar cannot represent that and roots the ENTIRE FILE in an `ERROR` node — confirmed directly (`rootNode.type === 'ERROR'`, one whole-file `block` chunk, `symbolName: undefined`) — so nothing was ever indexed for either file. This is a pre-existing, unrelated bug, not something this PR's mechanism can reach (there's no chunk to recover from). Filed separately: https://github.com/getlien/lien/issues/970 (also covers a related, more tractable case: a declaration wholly inside one `#if` block is invisible to chunking for ~8 more files — `TimeProvider.cs`, `ByteMemoryScalarConversionPolicy.cs`, etc.).

A clean before/after on a production file that DOES benefit:

```
BEFORE:
$ lien annotate src/Serilog/Core/Logger.cs
Lien impact for src/Serilog/Core/Logger.cs:
  • Dependents not determinable from imports (enclosing-namespace access).
  • Test coverage not determinable from imports (enclosing-namespace access).

AFTER:
$ lien annotate src/Serilog/Core/Logger.cs
Lien impact for src/Serilog/Core/Logger.cs:
  • 16 files import this — src/Serilog/Configuration/LoggerAuditSinkConfiguration.cs, src/Serilog/Configuration/LoggerMinimumLevelConfiguration.cs, src/Serilog/Configuration/LoggerSinkConfiguration.cs, src/Serilog/ILogger.cs, +12 more; risk: medium (16 callers, 6 untested).
  • Test coverage inferred from type-reference matching (not import-verified): test/Serilog.PerformanceTests/SourceContextMatchBenchmark.cs, test/Serilog.Tests/Configuration/LoggerConfigurationTests.cs (+8 more).
```

And a test-helper file (the widened tier 1 in action):

```
BEFORE:
$ lien annotate test/Serilog.Tests/Support/CollectingSink.cs
Lien impact for test/Serilog.Tests/Support/CollectingSink.cs:
  • Dependents not determinable from imports (enclosing-namespace access).
  • Test coverage not determinable from imports (enclosing-namespace access).

AFTER:
$ lien annotate test/Serilog.Tests/Support/CollectingSink.cs
Lien impact for test/Serilog.Tests/Support/CollectingSink.cs:
  • 9 files import this — test/Serilog.Tests/Configuration/LoggerConfigurationTests.cs, test/Serilog.Tests/Configuration/LoggerSinkConfigurationTests.cs, test/Serilog.Tests/Core/AuditSinkTests.cs, test/Serilog.Tests/Core/ChildLoggerKnownLimitationsTests.cs, +5 more; risk: medium (9 callers).
  • Test coverage inferred from type-reference matching (not import-verified): test/Serilog.Tests/Configuration/LoggerConfigurationTests.cs, test/Serilog.Tests/Configuration/LoggerSinkConfigurationTests.cs (+7 more).
```

## Scope decisions (per the brief's request to flag these explicitly)

- **C# only**, as instructed. Swift (`wholeModuleImports`) and Java (same-package) have the same shape; not touched here.
- **Confidence marking**: kept the existing `confidence: 'inferred'` marker unchanged for ALL recovered entries (tier 1 and tier 2 alike) rather than introducing a new, more-confident unmarked tier for tier 1's unique-name case. Reasoning: tier 1 is *slightly* more confident than tier 2 (no ambiguity to resolve at all), but both remain a word-boundary text match, not an import-verified edge — the same residual risks apply to both (can't distinguish a genuine type reference from a same-named property/field, can't see through aliases or reflection). Introducing a two-level confidence taxonomy for a marginal difference felt like more machinery than the signal earns; happy to revisit if reviewers disagree.
- **Test-association wiring**: implemented in this PR (not deferred) — see the fifth-tier addition to `lien annotate`'s `formatTests`/`formatTestReminder`. It reuses the exact same, already precision-hardened signal, so the incremental risk was low and the payoff (test coverage 100% → 46% not-determinable) was too large to leave for a follow-up.
- **Staging**: this fits in one PR. The originally-scoped "build a namespace → declaring-file symbol table" design turned out to need no schema change once each file's namespace was found to be recoverable from its own indexed chunk content — the schema-change path budgeted for going in wasn't necessary.

## Gates

`npm run format:check`, `npm run lint` (0 errors), `npm run typecheck`, `npm run build`, `npm test` (all packages, 1706+1502+41 tests), `npm run test:e2e:csharp -w packages/cli` (against a real cloned MediatR repo), and `lien delta` (exit 0, no new complexity crossings — verified via the built CLI, not assumed) all pass locally.

## Test plan

- [x] Unit tests: 21 tests in `csharp-type-reference-signals.test.ts` (tier 1 widening, tier 2 namespace-scoping incl. a deliberate `Serilog.Core.Logger` vs `Serilog.Logger` vs test-local `Logger` collision fixture, nested-type regression guards)
- [x] Unit + integration tests: 9 new tests in `annotate-cmd.test.ts` (formatting + a real end-to-end fixture through `annotateCommand`)
- [x] `npm run test:e2e:csharp -w packages/cli` against real cloned MediatR
- [x] `lien delta` clean
- [x] Dogfood evidence above, against serilog/serilog (never the Lien repo), reset and untouched (`git status` clean in the corpus)

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR widens C# type-reference dependent recovery to include test-declared types and adds namespace-scoped disambiguation for globally-ambiguous names, then reuses that signal as a fifth `lien annotate` test-association tier. The implementation is well-scoped, thoroughly tested (30 new unit/integration tests), and the new `csharpTypeReferenceTests` field is correctly threaded through `FileTestAssociations`, `scanTestAssociations`, `runTestsOnly`, `emitAnnotation`, `formatTests`, and `formatTestReminder`. Doc claims in the changeset and code comments match the implementation. No breaking changes or output-corrupting bugs were found.
>
> - C# type-reference recovery now accepts test files as declaring files (tier 1 widening) and resolves ambiguous names via namespace enclosure + shadowing (tier 2).
> - A referencer file that declares its own competing same-named type is excluded entirely, fixing the `ProjectedDestructuringPolicy` nested-test-double regression.
> - `lien annotate` gains a fifth test-association tier for C# (`csharpTypeReferenceTests`) mirroring Swift's symbol-usage fallback.

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 0ec74fe. Updates automatically on new commits.</sup>
<!-- /lien-stats -->