### PR TITLE
refactor(parser,cli): share the dependent-chunk helpers instead of copying them

### DIFF
--- a/.changeset/share-dependent-chunk-helpers.md
+++ b/.changeset/share-dependent-chunk-helpers.md
@@ -1,0 +1,19 @@
+---
+"@liendev/parser": minor
+"@liendev/lien": patch
+---
+
+Share the dependent-chunk matching helpers instead of keeping two copies
+
+`addFuzzyMatchChunks` and `findDependentChunks` existed twice — once in
+`@liendev/parser`'s `dependency-analyzer.ts` and once, copied, in the CLI's MCP
+handler. The bodies were logically identical; the only real difference was the
+chunk type (`CodeChunk` vs `core`'s `SearchResult`).
+
+That copy is why the `'../..'` fuzzy-match fix had to be applied twice, and why
+one copy could be fixed while the other kept the bug.
+
+Both helpers are now generic over `<T extends CodeChunk>` and exported from
+`@liendev/parser`, and the CLI imports them. `SearchResult` already satisfies
+`CodeChunk` structurally, so this is a type-level change only — no behavioural
+change to `get_dependents`.

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -1,6 +1,7 @@
 import type { SearchResult, VectorDBInterface } from '@liendev/core';
 import {
   findTransitiveDependents,
+  findDependentChunks,
   findReExportedSymbolsForFile,
   normalizePath,
   matchesFile,
@@ -8,8 +9,6 @@ import {
   isTestFile,
   isUnresolvableWholeModuleImport,
   importMatchesTarget,
-  hasSingleFileImportSemantics,
-  hasPythonModuleSemantics,
   detectLanguage,
   hasEnclosingNamespaceAccess,
   findCSharpTypeReferenceDependents,
@@ -1005,7 +1004,7 @@ function seedDepth1Dependents(
   normalizedTarget: string,
 ): { chunksByFile: Map<string, SearchResult[]>; reExporterPaths: string[] } {
   const { importIndex, allChunksByFile, normalizePathCached, log } = ctx;
-  const dependentChunks = findDependentChunks(importIndex, normalizedTarget);
+  const dependentChunks = findDependentChunks(normalizedTarget, importIndex);
   const chunksByFile = groupChunksByFile(dependentChunks);
   const reExporters = resolveTransitiveDependents(
     allChunksByFile,
@@ -1152,7 +1151,7 @@ function discoverFrontierDependents(
   ctx: ScanContext,
   normalizedFrontier: string,
 ): Map<string, SearchResult[]> {
-  const dependentChunks = findDependentChunks(ctx.importIndex, normalizedFrontier);
+  const dependentChunks = findDependentChunks(normalizedFrontier, ctx.importIndex);
   if (dependentChunks.length === 0) return new Map();
   const grouped = groupChunksByFile(dependentChunks);
   resolveTransitiveDependents(
@@ -1222,7 +1221,7 @@ function countUncoveredProductionDependents(dependents: DependentInfo[], ctx: Sc
 }
 
 function hasTestImporter(filepath: string, ctx: ScanContext): boolean {
-  const importers = findDependentChunks(ctx.importIndex, ctx.normalizePathCached(filepath));
+  const importers = findDependentChunks(ctx.normalizePathCached(filepath), ctx.importIndex);
   for (const chunk of importers) {
     if (isTestFile(chunk.metadata.file)) return true;
   }
@@ -1261,60 +1260,6 @@ function hasTestImporter(filepath: string, ctx: ScanContext): boolean {
  * passes (its own bare-package match IS the real semantic), same as
  * `hasSingleFileImportSemantics` above.
  */
-function addFuzzyMatchChunks(
-  normalizedImport: string,
-  normalizedTarget: string,
-  chunks: SearchResult[],
-  addChunk: (chunk: SearchResult) => void,
-): void {
-  if (!matchesFile(normalizedImport, normalizedTarget)) return;
-
-  const ambiguous =
-    normalizedImport.includes('/') && !matchesFile(normalizedImport, normalizedTarget, true);
-  const pythonOnlyMatch = !matchesFile(normalizedImport, normalizedTarget, false, false);
-
-  for (const chunk of chunks) {
-    if (ambiguous && hasSingleFileImportSemantics(chunk.metadata.file)) continue;
-    if (pythonOnlyMatch && !hasPythonModuleSemantics(chunk.metadata.file)) continue;
-    addChunk(chunk);
-  }
-}
-
-/**
- * Find dependent chunks using direct lookup and fuzzy matching.
- */
-function findDependentChunks(
-  importIndex: Map<string, SearchResult[]>,
-  normalizedTarget: string,
-): SearchResult[] {
-  const dependentChunks: SearchResult[] = [];
-  const seenChunkIds = new Set<string>();
-
-  const addChunk = (chunk: SearchResult) => {
-    const chunkId = `${chunk.metadata.file}:${chunk.metadata.startLine}-${chunk.metadata.endLine}`;
-    if (!seenChunkIds.has(chunkId)) {
-      dependentChunks.push(chunk);
-      seenChunkIds.add(chunkId);
-    }
-  };
-
-  // Direct index lookup (fastest path)
-  if (importIndex.has(normalizedTarget)) {
-    for (const chunk of importIndex.get(normalizedTarget)!) {
-      addChunk(chunk);
-    }
-  }
-
-  // Fuzzy match for relative imports and path variations
-  for (const [normalizedImport, chunks] of importIndex.entries()) {
-    if (normalizedImport !== normalizedTarget) {
-      addFuzzyMatchChunks(normalizedImport, normalizedTarget, chunks, addChunk);
-    }
-  }
-
-  return dependentChunks;
-}
-
 /**
  * Restrict a file-level chunk map down to exactly the resolved dependent
  * filepaths. Used to join complexity metrics against `dependents` rather

--- a/packages/parser/src/dependency-analyzer.ts
+++ b/packages/parser/src/dependency-analyzer.ts
@@ -152,11 +152,11 @@ function buildImportIndex(
  * Python chunk still passes (its own bare-package match IS the real
  * semantic), same as `hasSingleFileImportSemantics` above.
  */
-function addFuzzyMatchChunks(
+export function addFuzzyMatchChunks<T extends CodeChunk>(
   normalizedImport: string,
   normalizedTarget: string,
-  chunks: CodeChunk[],
-  addChunk: (chunk: CodeChunk) => void,
+  chunks: T[],
+  addChunk: (chunk: T) => void,
 ): void {
   if (!matchesFile(normalizedImport, normalizedTarget)) return;
 
@@ -178,14 +178,14 @@ function addFuzzyMatchChunks(
  * @param importIndex - Index mapping import paths to chunks
  * @returns Array of chunks that import the target file (deduplicated)
  */
-function findDependentChunks(
+export function findDependentChunks<T extends CodeChunk>(
   normalizedTarget: string,
-  importIndex: Map<string, CodeChunk[]>,
-): CodeChunk[] {
-  const dependentChunks: CodeChunk[] = [];
+  importIndex: Map<string, T[]>,
+): T[] {
+  const dependentChunks: T[] = [];
   const seenChunkIds = new Set<string>();
 
-  const addChunk = (chunk: CodeChunk): void => {
+  const addChunk = (chunk: T): void => {
     const chunkId = `${chunk.metadata.file}:${chunk.metadata.startLine}-${chunk.metadata.endLine}`;
     if (!seenChunkIds.has(chunkId)) {
       dependentChunks.push(chunk);

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -187,6 +187,8 @@ export {
   analyzeDependencies,
   findTransitiveDependents,
   groupChunksByNormalizedPath,
+  addFuzzyMatchChunks,
+  findDependentChunks,
   chunkImportsFrom,
   fileIsReExporter,
   findReExportedSymbolsForFile,


### PR DESCRIPTION
## Why

`addFuzzyMatchChunks` and `findDependentChunks` were defined **twice** — in
`packages/parser/src/dependency-analyzer.ts` and, copied, in
`packages/cli/src/mcp/handlers/dependency-analyzer.ts` (the copy the MCP
`get_dependents` tool actually executes).

The bodies were logically identical. `addFuzzyMatchChunks` differed **only** in its
two type annotations:

```
  chunks: CodeChunk[],                  |    chunks: SearchResult[],
  addChunk: (chunk: CodeChunk) => void, |    addChunk: (chunk: SearchResult) => void,
```

`findDependentChunks` differed only in parameter order, `.has()`+`.get()!` vs
`.get()`+null-check, and one dropped comment.

That copy is the mechanism behind the fuzzy-match fix having to be applied twice
(#934 → #955): fixing one copy left the other returning the old answer.

## Why it was copied — and why that reason no longer applies

Two things made sharing impossible. Neither needed a design change:

1. **The parser's helpers were module-private** — not exported from `index.ts` — so
   the CLI could not import them at all.
2. **Callback contravariance.** `SearchResult` is a structural *superset* of
   `CodeChunk` and assignable to it, but `(c: SearchResult) => void` is **not**
   assignable where `(c: CodeChunk) => void` is required. Both helpers take a
   callback, so the obvious "just call the parser's version" does not typecheck.
   Copying was the path that compiled.

Verified with `tsc --strict --strictFunctionTypes` (exit 0, both `@ts-expect-error`
directives firing):

| Claim | Result |
|---|---|
| `const c: CodeChunk = searchResult` | **OK** |
| `const cs: CodeChunk[] = searchResults` | **OK** |
| `const s: SearchResult = codeChunk` | rejected (no `score`/`relevance`) |
| `const f: (c: CodeChunk)=>void = searchResultCb` | **rejected — contravariance** |
| `<T extends CodeChunk>(chunks: T[], add: (c: T)=>void)` accepts both | **OK** |

Making both helpers generic over `<T extends CodeChunk>` resolves it. Widening a
parameter type is backward compatible for existing callers.

## What changed

- `addFuzzyMatchChunks` / `findDependentChunks` → generic over `<T extends CodeChunk>`,
  exported from `@liendev/parser`
- CLI imports them; both local copies deleted
- 3 CLI call sites updated for the parser's parameter order

**Net: 14 insertions, 67 deletions. Types only — no behavioural change.**

Removing the CLI copy also left `hasSingleFileImportSemantics` and
`hasPythonModuleSemantics` unused there — confirming the copy was their only consumer.

## Gates

| Gate | Result |
|---|---|
| `format:check` | pass |
| `lint` | **0 errors** (38 pre-existing warnings in `review/test`, untouched) |
| `typecheck` | pass |
| `build` | pass |
| `npm test` | **5204 tests, 0 failures** |
| `lien delta` | **exit 0** |

`lien delta` output, which reads as its own evidence — two functions gone from the
CLI, and only a marginal time-to-understand cost in the parser from the generic
signature tokens (no threshold crossed):

```
  packages/cli/src/mcp/handlers/dependency-analyzer.ts
    · removed   addFuzzyMatchChunks      cognitive 9 → –
    · removed   findDependentChunks      cognitive 7 → –

  packages/parser/src/dependency-analyzer.ts
    ⚠ worsened  addFuzzyMatchChunks      time 14m → 17m
    ⚠ worsened  findDependentChunks      time 24m → 26m

  ⚠ 2 worsened · 3 files · 98 ms
```

## Dogfood

`get_dependents` through the real MCP server against this worktree
(`lien index --force` first, 349 files):

```
{"filepath":"packages/parser/src/utils/path-matching.ts"}
  dependentCount: 43   riskLevel: high   attributionCaveat: null

{"filepath":"packages/parser/src/dependency-analyzer.ts"}
  dependentCount: 38   riskLevel: high   attributionCaveat: null

{"filepath":"packages/parser/src/dependency-analyzer.ts","symbol":"findDependentChunks"}
  dependentCount: 2    riskLevel: low    attributionCaveat: null
    packages/parser/src/index.ts
    packages/cli/src/mcp/handlers/dependency-analyzer.ts
```

The third query is self-referential: it reports exactly the two edges this PR
creates. Verified independently — 4 files mention `findDependentChunks`, but the
other two are doc comments (`path-matching.ts`) and test descriptions
(`dependency-analyzer.test.ts`), correctly excluded from the count.

## Context

Found while auditing duplication across the monorepo. This is the first and
cheapest slice; it is self-contained and safe to merge on its own. Fuller
findings — including a layering inversion in the complexity analyzers, a
threshold table defined at four sites, and four match-side call paths that #886
documented as deliberately unrouted — are being written up separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated dependent-chunk matching into a shared implementation.
  * Improved type support while preserving existing dependency analysis behavior.
* **Documentation**
  * Documented the shared matching helpers and clarified that no user-visible behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR is a straightforward deduplication refactor: the `addFuzzyMatchChunks` and `findDependentChunks` helpers are now defined once in `@liendev/parser` (made generic over `<T extends CodeChunk>` and exported) and consumed by the CLI MCP handler instead of maintaining a copied implementation. The function bodies are unchanged, and the CLI call sites were correctly updated to the parser's parameter order `(normalizedTarget, importIndex)`. Typecheck, build, and the full test suite pass.
>
> - Made `addFuzzyMatchChunks` and `findDependentChunks` generic and exported from `@liendev/parser`
> - Removed the duplicated CLI copies and imported the shared helpers
> - Updated CLI call sites to match the parser's existing parameter order

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 5cd4f30. Updates automatically on new commits.</sup>
<!-- /lien-stats -->