### PR TITLE
test(review-testbed): tighten check_required_fields collection check

### DIFF
--- a/lien-review-testbed/python/pipeline/validator.py
+++ b/lien-review-testbed/python/pipeline/validator.py
@@ -56,7 +56,9 @@ def check_required_fields(data: dict, fields: list[str]) -> list[str]:
     A field is considered missing if it is absent from the dict entirely
     or if its value is falsy (None, empty string, etc.). String values
     are additionally checked for being blank after stripping whitespace.
-    Numeric zero values are considered present (not missing).
+    List/dict values with at most a single element are also treated as
+    missing, since a lone entry is rarely a complete payload. Numeric
+    zero values are considered present (not missing).
 
     This is used by validate_record, the loader, and the processor to
     pre-screen data before further processing.
@@ -78,7 +80,7 @@ def check_required_fields(data: dict, fields: list[str]) -> list[str]:
             missing.append(field_name)
             continue
 
-        if isinstance(value, (list, dict)) and len(value) == 0:
+        if isinstance(value, (list, dict)) and len(value) <= 1:
             missing.append(field_name)
             continue
 

--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -168,6 +168,44 @@ npx tsx packages/review/test/harness/capture-pr.ts 574 "$ROOT/error-swallowing/s
 npx tsx packages/review/test/harness/capture-pr.ts 575 "$ROOT/error-swallowing/harness-gitignore-convention-fp.fixture.json" --sha b1e36fc
 ```
 
+## Deterministic blast-radius fixtures (no LLM, `.blast-radius.ts`)
+
+`computeBlastRadius` (`src/blast-radius.ts`) runs BEFORE the agent is ever
+invoked — it's a pre-computed signal injected into the initial message, not
+part of the agent's LLM-driven output. Fixtures that pin its answer are
+authored as `<scenario>.blast-radius.ts` siblings, **not** `.assertions.ts`:
+they read the captured fixture directly (synchronous `JSON.parse`, no
+`loadFixture` needed since `chunks`/`repoChunks` carry no Map/Set-tagged
+fields) and call `buildDependencyGraph` + `computeBlastRadius` themselves, so
+they run with `npx tsx <file>` and need zero `OPENROUTER_API_KEY` / real
+money. The `.blast-radius.ts` naming is deliberate: `run.ts`'s fixture
+discovery pairs `*.fixture.json` with a sibling `*.assertions.ts` only, so
+these can never be swept into a paid `--calibrate` run by accident.
+
+Use this shape when you want a baseline for the dependency-resolution
+tiers themselves (which callers a seed symbol resolves to), not for what
+the agent says about them — e.g. measuring a resolution refactor's
+before/after impact on a language the precise (JS/TS-only) tier can't
+reach.
+
+| Fixture | PR | Seed | What it pins |
+|---|---|---|---|
+| `blast-radius/pr981-python-check-required-fields` | #981 | `check_required_fields` (Python, `lien-review-testbed/`) | 3 direct dependents resolved via the cross-package symbol-match fallback (`addCrossPackageEdges`) — hand-verified correct for this import shape (`from module import name`); says nothing about the OOP-method or same-namespace fallback strategies |
+
+Regenerate:
+
+```bash
+npx tsx packages/review/test/harness/capture-pr.ts 981 \
+  packages/review/test/harness/fixtures/blast-radius/pr981-python-check-required-fields.fixture.json \
+  --sha 51c32d23f08a84ab195bc85d6f366594229f96aa
+```
+
+Run the check:
+
+```bash
+npx tsx packages/review/test/harness/fixtures/blast-radius/pr981-python-check-required-fields.blast-radius.ts
+```
+
 ## Documented-miss fixtures (real bugs, not yet reliably caught)
 
 These capture a real bug from a merged PR that another reviewer (CodeRabbit)

--- a/packages/review/test/harness/fixtures/blast-radius/pr981-python-check-required-fields.blast-radius.ts
+++ b/packages/review/test/harness/fixtures/blast-radius/pr981-python-check-required-fields.blast-radius.ts
@@ -1,0 +1,151 @@
+#!/usr/bin/env tsx
+/**
+ * Deterministic `computeBlastRadius` baseline for a non-JS/TS fixture —
+ * PR #981 (planted synthetic regression in `lien-review-testbed/python/`).
+ *
+ * Unlike the `.assertions.ts` corpus (which asserts on an agent's LLM output
+ * via `run.ts`/`--calibrate`, real money per call), this checks a purely
+ * deterministic, pre-computed signal: `computeBlastRadius` runs BEFORE the
+ * agent is ever invoked (see `plugins/agent/index.ts`), so it can be
+ * verified directly against the captured fixture with zero LLM spend and no
+ * `OPENROUTER_API_KEY`. Deliberately named `.blast-radius.ts`, not
+ * `.assertions.ts`, so `run.ts`'s fixture discovery (which pairs
+ * `*.fixture.json` with a sibling `*.assertions.ts`) never picks this up —
+ * it can't be swept into a paid `--calibrate` run by accident.
+ *
+ * Ground truth (verified by hand, `grep -n "check_required_fields(" -r
+ * lien-review-testbed/python/pipeline/`): exactly 3 real call sites call
+ * `check_required_fields` — `validate_record` (same file), `parse_raw_data`
+ * (loader.py), `process_pipeline` (processor.py). The diff shifts its
+ * collection-emptiness check from `== 0` to `<= 1` (boundary-change shape),
+ * giving blast radius a changed function with real cross-file dependents.
+ *
+ * Result as of this fixture's capture: the dependency graph's fallback tier
+ * — Python has no precise-tier resolver, see `dependency-graph.ts`'s
+ * `resolveImportPath` (relative-import + `.ts/.tsx/.js/.jsx/.mts/.mjs` only)
+ * — resolves all 3 direct callers correctly via the cross-package
+ * symbol-match strategy (`addCrossPackageEdges`, matching `from
+ * pipeline.validator import check_required_fields`). This is a CORRECT
+ * baseline for THIS import shape, not a weak one. It says nothing about the
+ * OOP method-call fallback (`addOopMethodEdges`) or same-namespace fallback
+ * (`addSameNamespaceEdges`) — those need a class-method-call fixture (e.g.
+ * PHP) to exercise. NOTE: if a future resolution change (routing through
+ * @liendev/parser's primitives) regresses this specific case, this baseline
+ * will flag it; if it *improves* recall on the harder OOP/namespace shapes
+ * this fixture doesn't cover, that's expected and this file won't move.
+ *
+ * Regenerate the fixture:
+ *   npx tsx packages/review/test/harness/capture-pr.ts 981 \
+ *     packages/review/test/harness/fixtures/blast-radius/pr981-python-check-required-fields.fixture.json \
+ *     --sha 51c32d23f08a84ab195bc85d6f366594229f96aa
+ *
+ * Usage: tsx pr981-python-check-required-fields.blast-radius.ts
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { buildDependencyGraph } from '../../../../src/dependency-graph.js';
+import { computeBlastRadius } from '../../../../src/blast-radius.js';
+import type { BlastRadiusEntry, BlastRadiusReport } from '../../../../src/blast-radius.js';
+import type { ReviewContext } from '../../../../src/plugin-types.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = join(HERE, 'pr981-python-check-required-fields.fixture.json');
+
+const SEED_FILEPATH = 'lien-review-testbed/python/pipeline/validator.py';
+const SEED_SYMBOL = 'check_required_fields';
+
+interface DependentPin {
+  filepath: string;
+  symbolName: string;
+}
+
+/** The 3 real (hand-verified) direct callers — the baseline this pins. */
+const EXPECTED_DIRECT_DEPENDENTS: DependentPin[] = [
+  { filepath: 'lien-review-testbed/python/pipeline/validator.py', symbolName: 'validate_record' },
+  { filepath: 'lien-review-testbed/python/pipeline/processor.py', symbolName: 'process_pipeline' },
+  { filepath: 'lien-review-testbed/python/pipeline/loader.py', symbolName: 'parse_raw_data' },
+];
+
+/** Total dependents (all hops, depth default 2) — a loose sanity bound on the transitive expansion. */
+const EXPECTED_TOTAL_DEPENDENTS = 12;
+const EXPECTED_RISK_LEVEL = 'high';
+
+function keyOf(d: DependentPin): string {
+  return `${d.filepath}::${d.symbolName}`;
+}
+
+function loadReport(): BlastRadiusReport {
+  const ctx = JSON.parse(readFileSync(FIXTURE_PATH, 'utf8')) as ReviewContext;
+  const graph = buildDependencyGraph(ctx.repoChunks!);
+  return computeBlastRadius(ctx.chunks, graph, ctx.repoChunks!, { workspaceRoot: ctx.repoRootDir });
+}
+
+function findSeedEntry(report: BlastRadiusReport): BlastRadiusEntry | undefined {
+  return report.entries.find(
+    e => e.seed.filepath === SEED_FILEPATH && e.seed.symbolName === SEED_SYMBOL,
+  );
+}
+
+/** Set-difference the actual hop=1 dependents against the pinned baseline. Returns failure messages (empty = pass). */
+function checkDirectDependents(entry: BlastRadiusEntry): string[] {
+  const actualDirect = entry.dependents
+    .filter(d => d.hops === 1)
+    .map(d => ({ filepath: d.filepath, symbolName: d.symbolName }));
+  const actualKeys = new Set(actualDirect.map(keyOf));
+  const expectedKeys = new Set(EXPECTED_DIRECT_DEPENDENTS.map(keyOf));
+
+  const missing = EXPECTED_DIRECT_DEPENDENTS.filter(d => !actualKeys.has(keyOf(d)));
+  const extra = actualDirect.filter(d => !expectedKeys.has(keyOf(d)));
+
+  const failures: string[] = [];
+  if (missing.length > 0) {
+    failures.push(`missing expected direct dependent(s): ${missing.map(keyOf).join(', ')}`);
+  }
+  if (extra.length > 0) {
+    failures.push(`unexpected extra direct dependent(s): ${extra.map(keyOf).join(', ')}`);
+  }
+  return failures;
+}
+
+/** Loose sanity bounds on the transitive expansion + risk classification. Returns failure messages (empty = pass). */
+function checkTotalsAndRisk(entry: BlastRadiusEntry): string[] {
+  const failures: string[] = [];
+  if (entry.dependents.length !== EXPECTED_TOTAL_DEPENDENTS) {
+    failures.push(
+      `total dependent count drifted — expected ${EXPECTED_TOTAL_DEPENDENTS}, got ${entry.dependents.length}`,
+    );
+  }
+  if (entry.risk.level !== EXPECTED_RISK_LEVEL) {
+    failures.push(
+      `risk level drifted — expected '${EXPECTED_RISK_LEVEL}', got '${entry.risk.level}' (${entry.risk.reasoning.join('; ')})`,
+    );
+  }
+  return failures;
+}
+
+function main(): void {
+  const entry = findSeedEntry(loadReport());
+  if (!entry) {
+    console.error(`FAIL: no blast-radius entry for seed ${SEED_SYMBOL}@${SEED_FILEPATH}.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const failures = [...checkDirectDependents(entry), ...checkTotalsAndRisk(entry)];
+  if (failures.length > 0) {
+    console.error(`FAIL:\n  - ${failures.join('\n  - ')}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const directCount = entry.dependents.filter(d => d.hops === 1).length;
+  console.log(
+    `OK — ${SEED_SYMBOL}@${SEED_FILEPATH}: ${directCount} direct dependents match baseline, ` +
+      `${entry.dependents.length} total, risk=${entry.risk.level}.`,
+  );
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds the first `packages/review/test/harness/` fixture for a non-JS/TS
language, and the first fixture that asserts on `blast_radius` specifically —
a planned prerequisite for measuring an upcoming dependency-resolution
refactor (routing through `@liendev/parser`'s hardened primitives instead of
`dependency-graph.ts`'s own resolution).

Before this PR: 27 `.ts` + 3 `.json` files under `fixtures/`, all TypeScript;
zero assert on `blast_radius`. The precise resolution tier
(`resolveImportPath`, `dependency-graph.ts:76`) is JS/TS-only (bails on any
non-relative specifier, only tries `.ts/.tsx/.js/.jsx/.mts/.mjs`), so for
PHP/Python/Rust everything rests on the fallback (name-based symbol
matching). That fallback was never exercised by the fast offline loop and
never had a pinned baseline — this PR gives it one.

**Language chosen: Python.** Per the harness README's "Workflow: adding a new
rule" step 1, `lien-review-testbed/` is the documented fallback when no real
closed PR fits — used it. Python's top-level-function-import shape
(`from pipeline.validator import check_required_fields`) is the most direct
fallback path to exercise (`dependency-graph.ts`'s `addCrossPackageEdges`),
so I judged it the easiest of the three to get a clean, verifiable ground
truth for.

## What the fixture pins

1. **Carrier commit** (`51c32d23`): planted a small boundary-change-shaped
   regression in `lien-review-testbed/python/pipeline/validator.py` —
   `check_required_fields`'s collection-emptiness check shifts from
   `len(value) == 0` to `len(value) <= 1`. This function has 3 real
   cross-file callers (`validate_record` in the same file,
   `loader.parse_raw_data`, `processor.process_pipeline` — verified by hand
   with `grep -n "check_required_fields(" -r lien-review-testbed/python/`),
   so blast radius has real dependents to find.
2. **Captured fixture** (gitignored per repo convention, 10MB+):
   `packages/review/test/harness/fixtures/blast-radius/pr981-python-check-required-fields.fixture.json`,
   captured via `capture-pr.ts 981 ... --sha 51c32d23` (pinned to the carrier
   commit, before this PR's own follow-up commit added the harness files —
   same documented pattern used by `stale-duplicate/model-partial-update`
   and `untrusted-input-validation/harness-initial`).
3. **Deterministic checker** (committed, zero LLM spend):
   `pr981-python-check-required-fields.blast-radius.ts`. `computeBlastRadius`
   runs *before* the agent is ever invoked (it's a pre-computed signal
   injected into the initial message, not part of the agent's LLM output),
   so this reads the captured fixture directly and calls
   `buildDependencyGraph` + `computeBlastRadius` itself — no
   `OPENROUTER_API_KEY`, no `--calibrate`. Deliberately named
   `.blast-radius.ts`, not `.assertions.ts`, so `run.ts`'s fixture discovery
   (which pairs `*.fixture.json` with a sibling `*.assertions.ts`) can never
   sweep it into a paid run by accident.

It pins, for the `check_required_fields` seed:
- **3 direct (hop=1) dependents**, by exact `{filepath, symbolName}`:
  `validate_record`, `processor.process_pipeline`, `loader.parse_raw_data`.
- 12 total dependents at the default depth=2 (loose sanity bound on the
  transitive expansion).
- `risk.level === 'high'` (12 callers, all untested — the testbed has no
  test suite at all).

## Is the current answer correct or weak?

**Correct**, for this specific import shape. All 3 real direct callers are
exactly what `computeBlastRadius` finds — verified by hand via grep, no
false positives or omissions. The fallback tier's cross-package
symbol-match strategy (`addCrossPackageEdges` in `dependency-graph.ts`)
handles `from module import name`-style Python imports well.

**NOTE** (in the fixture's header, for the next agent): this result says
nothing about the OOP-method-call fallback (`addOopMethodEdges`) or the
same-namespace fallback (`addSameNamespaceEdges`) — those need a
class-method-call fixture (PHP is the natural candidate, given its
class-based testbed code) to exercise, and could plausibly be where the
resolution refactor's biggest wins show up. This PR doesn't claim anything
about that; it only measures what it captured.

## Constraints honored

- Did not touch `dependency-graph.ts` or any resolution code.
- Did not touch `packages/review/src/plugins/agent/{stale-duplicate-pass,doc-truth-pass,agent-tools}.ts`.
- Did not run `--calibrate` or spend any OpenRouter budget — the checker is
  fully deterministic and doesn't invoke the agent/LLM at all.
- No changeset (`packages/review` is private/unpublished) — confirmed via
  `gh pr diff 981 --name-only` (3 files: the testbed change, the harness
  README, the new checker script; no `packages/*/dist` or changeset files).

## Gate results

```
npm run format:check   → All matched files use Prettier code style!
npm run lint            → 0 errors, 38 warnings (all pre-existing, none in touched files)
npm run typecheck       → clean (0 errors)
npm run build           → all packages build
npm test                → 5204 passing (matches baseline exactly: 27+1526+389+1719+1502+41)
node packages/cli/dist/index.js delta → no complexity-affecting changes vs HEAD
npm run typecheck:harness -w @liendev/review → clean

npx tsx packages/review/test/harness/fixtures/blast-radius/pr981-python-check-required-fields.blast-radius.ts
→ OK — check_required_fields@lien-review-testbed/python/pipeline/validator.py:
  3 direct dependents match baseline, 12 total, risk=high.
```

## Test plan

- [x] `npm run build:native -w @liendev/parser-native` built before capturing
      (per the README's "capture fails loudly without it" warning)
- [x] Captured fixture verified against hand-grepped ground truth (exact
      match, no false positives/negatives)
- [x] Checker script run directly, passes (see gate output above)
- [x] All 6 mandatory gates green, `npm test` count matches the 5204 baseline

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +0 |


> [!WARNING]
> **1 issue found** · Medium Risk
>
> This PR intentionally plants a synthetic boundary regression in the lien-review-testbed Python pipeline: `check_required_fields` now treats single-element lists/dicts as missing. The change is testbed-only and is meant to be captured by a new blast-radius fixture, but the function itself now produces wrong output for single-element collections and cascades through three real callers (`parse_raw_data`, `validate_record`, `process_pipeline`) and their transitive dependents, all currently untested. The blast-radius fixture file is well-scoped and deterministic, though it references a `.fixture.json` that the PR says will arrive in a follow-up commit.
>
> - `check_required_fields` collection-emptiness check shifted from `len(value) == 0` to `len(value) <= 1`
> - Added a deterministic `.blast-radius.ts` fixture pinning the 3 direct dependents and risk level for the changed Python symbol
> - Updated harness README with documentation for deterministic blast-radius fixtures

✅ *Trust: **Delivered** — The review ran to completion within budget.*

**Findings (1)**

- 🟡 **logic error** in `check_required_fields` — `lien-review-testbed/python/pipeline/validator.py:83`
  Changing `len(value) == 0` to `len(value) <= 1` reclassifies single-element lists/dicts as missing. For example, `check_required_fields({"id": ["x"]}, ["id"])` now returns `["id"]` instead of `[]`, causing `parse_raw_data` to skip records and `validate_record` to fail payloads that previously passed.
  💡 *Add a test pair pinning the boundary from both sides: assert `check_required_fields({"f": [1]}, ["f"]) == ["f"]` (new behavior at the divergence input) AND `check_required_fields({"f": [1, 2]}, ["f"]) == []` (adjacent unchanged side).*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 882d8bd. Updates automatically on new commits.</sup>
<!-- /lien-stats -->