### PR TITLE
fix(review): guard hallucinated-id loophole in stale-duplicate and doc-truth passes

### DIFF
--- a/packages/review/src/plugins/agent/doc-truth-pass.ts
+++ b/packages/review/src/plugins/agent/doc-truth-pass.ts
@@ -851,22 +851,34 @@ function hasCompleteVerdictCoverage(ids: string[], raw: RawDocClaimVerdict[]): b
 
 /**
  * Reduce the raw v2 findings array to real findings: every ad hoc finding (no `claimId`) passes
- * through unchanged, and every claimed entry is kept ONLY when its verdict is `contradicted`
- * (cleaned of the v2-only fields) — mirroring v1's rule text (stay silent unless you have proof
- * of a contradiction) and the exact inclusion-list pattern every sibling candidate-loop pass
- * uses: `stale-duplicate-pass.ts` keeps `verdict === 'stale'` only, `removed-exports-pass.ts`
- * keeps `'breaking'` only, `incomplete-handling-pass.ts` keeps `'incomplete'` only. Both
- * `accurate` and `unverifiable` are dropped rather than guess-promoted: `accurate` because the
- * claim checked out, `unverifiable` because "I couldn't check" is not proof of a contradiction —
- * promoting it made a thin-evidence claim look like a real finding (see the `accurate-doc`
- * precision-guard fixture, which this reduction previously false-fired on 3/3). Coverage
- * honesty is unaffected: `hasCompleteVerdictCoverage` (below) reads the RAW, pre-reduction list,
- * so a claim honestly verdicted `unverifiable` still counts as covered even though it never
- * surfaces here.
+ * through unchanged, and every claimed entry is kept ONLY when its `claimId` names a real
+ * worklist entry AND its verdict is `contradicted` (cleaned of the v2-only fields) — mirroring
+ * v1's rule text (stay silent unless you have proof of a contradiction) and the exact
+ * inclusion-list pattern every sibling candidate-loop pass uses: `stale-duplicate-pass.ts` keeps
+ * `verdict === 'stale'` only, `removed-exports-pass.ts` keeps `'breaking'` only,
+ * `incomplete-handling-pass.ts` keeps `'incomplete'` only. Both `accurate` and `unverifiable`
+ * are dropped rather than guess-promoted: `accurate` because the claim checked out,
+ * `unverifiable` because "I couldn't check" is not proof of a contradiction — promoting it made
+ * a thin-evidence claim look like a real finding (see the `accurate-doc` precision-guard
+ * fixture, which this reduction previously false-fired on 3/3). Coverage honesty is unaffected:
+ * `hasCompleteVerdictCoverage` (below) reads the RAW, pre-reduction list, so a claim honestly
+ * verdicted `unverifiable` still counts as covered even though it never surfaces here.
+ *
+ * The `expected.has(claimId)` check guards against the hallucinated-id loophole a code reviewer
+ * caught in PR #804 (see `docs-drift-pass.ts`'s sibling reducer): a phantom `claimId` paired
+ * with `verdict: 'contradicted'` must not leak through as a real finding just because it isn't
+ * `undefined` — an out-of-worklist `claimId` is a malformed claimed entry (same as a missing or
+ * unrecognized verdict), not a legitimate ad hoc finding, so it is dropped here exactly like
+ * `hasCompleteVerdictCoverage` already treats it as a coverage failure.
  */
-function reduceDocTruthV2Findings(raw: RawDocClaimVerdict[]): AgentFinding[] {
+function reduceDocTruthV2Findings(
+  raw: RawDocClaimVerdict[],
+  expected: Set<string>,
+): AgentFinding[] {
   return raw
-    .filter(f => f.claimId === undefined || f.verdict === 'contradicted')
+    .filter(
+      f => f.claimId === undefined || (expected.has(f.claimId) && f.verdict === 'contradicted'),
+    )
     .map(f => (f.claimId !== undefined ? toCleanDocTruthFinding(f) : f));
 }
 
@@ -898,13 +910,14 @@ export function postProcessDocTruthResult(
   const ceiling = affordableCandidateCeiling(budget, DOC_TRUTH_TOKENS_PER_CLAIM);
   const { worklist, deferredCount, deferredIds } = capClaimWorklistToCeiling(full, ceiling);
   const ids = allClaimIds(worklist);
+  const expected = new Set(ids);
   const raw = result.findings as RawDocClaimVerdict[];
   const coverageIncomplete = !hasCompleteVerdictCoverage(ids, raw);
   const wasAlreadyIncomplete = result.incomplete;
 
   return {
     ...result,
-    findings: reduceDocTruthV2Findings(raw),
+    findings: reduceDocTruthV2Findings(raw, expected),
     incomplete: wasAlreadyIncomplete || coverageIncomplete,
     stopReason:
       !wasAlreadyIncomplete && coverageIncomplete ? 'incomplete_verdict' : result.stopReason,

--- a/packages/review/src/plugins/agent/stale-duplicate-pass.ts
+++ b/packages/review/src/plugins/agent/stale-duplicate-pass.ts
@@ -557,16 +557,23 @@ function hasCompleteVerdictCoverage(ids: string[], raw: RawVerdictFinding[]): bo
 /**
  * Reduce this pass's raw per-candidate verdict array (still carried inside
  * `result.findings`, tagged with `candidateId`/`verdict` — see module doc)
- * down to real findings (`verdict === 'stale'` only, cleaned of the loop-
- * only fields), and mark the result honestly incomplete when the verdict
- * array doesn't cleanly cover the worklist (see `hasCompleteVerdictCoverage`)
- * — the pr658 Finding-A lesson made machine-checkable: a coverage gap is a
- * completeness failure the harness can assert on directly, not a semantic
- * judgment call. When the underlying client result was ALREADY incomplete
- * for a real reason (budget/max_turns/error), that reason is kept as-is
- * (more specific than the generic coverage-gap marker); `incomplete_verdict`
- * is only used when the model otherwise returned a syntactically complete
- * verdict.
+ * down to real findings (`verdict === 'stale'` AND `candidateId` names a real
+ * worklist entry only, cleaned of the loop-only fields), and mark the result
+ * honestly incomplete when the verdict array doesn't cleanly cover the
+ * worklist (see `hasCompleteVerdictCoverage`) — the pr658 Finding-A lesson
+ * made machine-checkable: a coverage gap is a completeness failure the
+ * harness can assert on directly, not a semantic judgment call. When the
+ * underlying client result was ALREADY incomplete for a real reason
+ * (budget/max_turns/error), that reason is kept as-is (more specific than the
+ * generic coverage-gap marker); `incomplete_verdict` is only used when the
+ * model otherwise returned a syntactically complete verdict.
+ *
+ * The candidateId check guards against the hallucinated-id loophole a code
+ * reviewer caught in PR #804 (see `docs-drift-pass.ts`'s sibling reducer): a
+ * phantom candidate id must not leak through as a real finding just because
+ * it carries `verdict: 'stale'` — `hasCompleteVerdictCoverage` marks the
+ * result incomplete in that case, but incompleteness alone doesn't stop a
+ * finding already sitting in `raw` from being published.
  *
  * Coverage is checked against the RANK-AND-CAPPED worklist (`ids`, from
  * `computeStaleDuplicateWorklist(context, budget)`), not the full pre-cap
@@ -584,13 +591,19 @@ export function postProcessStaleDuplicateResult(
 ): AgentResult {
   const { candidates, deferredCount, deferredIds } = computeStaleDuplicateWorklist(context, budget);
   const ids = candidateIds(candidates);
+  const expected = new Set(ids);
   const raw = result.findings as RawVerdictFinding[];
   const coverageIncomplete = !hasCompleteVerdictCoverage(ids, raw);
   const wasAlreadyIncomplete = result.incomplete;
 
   return {
     ...result,
-    findings: raw.filter(f => f.verdict === 'stale').map(toCleanFinding),
+    findings: raw
+      .filter(
+        f =>
+          f.verdict === 'stale' && typeof f.candidateId === 'string' && expected.has(f.candidateId),
+      )
+      .map(toCleanFinding),
     incomplete: wasAlreadyIncomplete || coverageIncomplete,
     stopReason:
       !wasAlreadyIncomplete && coverageIncomplete ? 'incomplete_verdict' : result.stopReason,

--- a/packages/review/test/plugins-agent-doc-truth-pass.test.ts
+++ b/packages/review/test/plugins-agent-doc-truth-pass.test.ts
@@ -967,7 +967,7 @@ describe('postProcessDocTruthResult', () => {
     expect(processed.stopReason).toBe('incomplete_verdict');
   });
 
-  it('is incomplete when an entry names a claimId outside the worklist', () => {
+  it('is incomplete when an entry names a claimId outside the worklist, and the phantom never leaks through', () => {
     process.env.LIEN_DOC_TRUTH_V2 = 'on';
     const result = fakeResult([
       verdictFinding({ claimId: 'claim-1', verdict: 'accurate' }),
@@ -976,6 +976,7 @@ describe('postProcessDocTruthResult', () => {
     const processed = postProcessDocTruthResult(result, singleClaimCtx());
     expect(processed.incomplete).toBe(true);
     expect(processed.stopReason).toBe('incomplete_verdict');
+    expect(processed.findings).toHaveLength(0);
   });
 
   it('keeps the ORIGINAL stopReason when the client was already incomplete for a real reason', () => {

--- a/packages/review/test/plugins-agent-stale-duplicate-pass.test.ts
+++ b/packages/review/test/plugins-agent-stale-duplicate-pass.test.ts
@@ -499,7 +499,7 @@ describe('postProcessStaleDuplicateResult', () => {
     expect(result.stopReason).toBe('incomplete_verdict');
   });
 
-  it('is incomplete when an entry names a candidate id outside the worklist', () => {
+  it('is incomplete when an entry names a candidate id outside the worklist, and the phantom never leaks through', () => {
     const raw = fakeResult({
       findings: [
         finding({ candidateId: 'candidate-1', verdict: 'unverifiable' }),
@@ -509,6 +509,7 @@ describe('postProcessStaleDuplicateResult', () => {
     const result = postProcessStaleDuplicateResult(raw, eligibleContext());
     expect(result.incomplete).toBe(true);
     expect(result.stopReason).toBe('incomplete_verdict');
+    expect(result.findings).toHaveLength(0);
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two candidate-loop reducers filtered published findings on **verdict value only**, never checking that the entry's `candidateId`/`claimId` is actually a member of this run's worklist. A model that invents an id and pairs it with a reportable verdict gets that phantom finding published as a real inline PR comment.

- `packages/review/src/plugins/agent/stale-duplicate-pass.ts` — `postProcessStaleDuplicateResult` kept `raw.filter(f => f.verdict === 'stale')` with no id check.
- `packages/review/src/plugins/agent/doc-truth-pass.ts` — `reduceDocTruthV2Findings` kept any claimed entry with `verdict === 'contradicted'`, with no id check.

Three sibling passes (`docs-drift-pass.ts`, `removed-exports-pass.ts`, `incomplete-handling-pass.ts`) already guard this exact loophole and cite it by name in their comments: *"the hallucinated-id loophole a code reviewer caught in PR #804."* It was missed on these two.

## Fix

Ported the `expected.has(id)` guard from `docs-drift-pass.ts` to both:

- `stale-duplicate-pass.ts`: `postProcessStaleDuplicateResult` did not already have an `expected` set in scope (the only one lived inside `hasCompleteVerdictCoverage`) — constructed one locally and added it to the filter.
- `doc-truth-pass.ts`: `reduceDocTruthV2Findings` took **no worklist parameter at all**, so this isn't a one-line port — its signature now threads an `expected: Set<string>` through from `postProcessDocTruthResult`. This pass's contract intentionally stays open beyond the worklist (an ad hoc finding with no `claimId` is still legal, per the rule's "claim not listed" allowance) — that behavior is preserved; only a *claimed* entry with an out-of-worklist id is now dropped.

**Deliberately left the consolidation for a follow-up.** There are 5 byte-adjacent copies of `hasCompleteVerdictCoverage` (`doc-truth-pass.ts:834`, `stale-duplicate-pass.ts:540`, `removed-exports-pass.ts:608`, `docs-drift-pass.ts:552`, `incomplete-handling-pass.ts:599`) plus the id-guard pattern duplicated across all 5 reducers. A shared helper would be worth doing, but `doc-truth-pass.ts`'s "ad hoc findings stay open beyond the worklist" contract differs from the other 4 (fully closed worklist), so a generic extraction isn't a pure mechanical move — it would touch 3 files that have nothing to do with this bug (the other passes already work correctly) and balloon this diff. Filed as a follow-up rather than bundled here.

## Test evidence (mandatory — before/after)

Extended both passes' existing out-of-worklist tests (which asserted only `incomplete`/`stopReason`, never `.findings` — that gap is why this shipped) to also assert `expect(result.findings).toHaveLength(0)`, matching the already-fixed sibling's assertion (`docs-drift-pass.test.ts:492`).

**Before the fix** (stashed the two source changes, kept the new test assertions) — both fail, phantom finding present:

```
 FAIL  packages/review/test/plugins-agent-doc-truth-pass.test.ts > postProcessDocTruthResult > is incomplete when an entry names a claimId outside the worklist, and the phantom never leaks through
AssertionError: expected [ { …(9) } ] to have a length of +0 but got 1

- Expected
+ Received

- 0
+ 1

 ❯ packages/review/test/plugins-agent-doc-truth-pass.test.ts:979:32

 FAIL  packages/review/test/plugins-agent-stale-duplicate-pass.test.ts > postProcessStaleDuplicateResult > is incomplete when an entry names a candidate id outside the worklist, and the phantom never leaks through
AssertionError: expected [ { …(9) } ] to have a length of +0 but got 1

- Expected
+ Received

- 0
+ 1

 ❯ packages/review/test/plugins-agent-stale-duplicate-pass.test.ts:512:29

 Test Files  2 failed (2)
      Tests  2 failed | 144 skipped (146)
```

**After the fix** (source restored) — both pass:

```
 ✓ test/plugins-agent-stale-duplicate-pass.test.ts (56 tests | 55 skipped) 3ms
 ✓ test/plugins-agent-doc-truth-pass.test.ts (90 tests | 89 skipped) 4ms

 Test Files  2 passed (2)
      Tests  2 passed | 144 skipped (146)
```

Full sibling-file regression check (no collateral breakage in the passes that already had this guard):

```
 ✓ test/docs-drift-pass.test.ts (58 tests)
 ✓ test/plugins-agent-stale-duplicate-pass.test.ts (56 tests)
 ✓ test/plugins-agent-doc-truth-pass.test.ts (90 tests)

 Test Files  3 passed (3)
      Tests  204 passed (204)
```

## Gate results (all six)

```
$ npm run format:check
All matched files use Prettier code style!

$ npm run lint
✖ 38 problems (0 errors, 38 warnings)   ← pre-existing baseline warnings, 0 errors

$ npm run typecheck
(clean — tsc --noEmit passes for cli, review, action)

$ npm run build
(clean — parser, core, review, cli, action all build)

$ npm test
@liendev/parser-native  Test Files  1 passed   Tests    27 passed
@liendev/parser         Test Files 52 passed   Tests  1526 passed
@liendev/core           Test Files 37 passed   Tests   389 passed
@liendev/review         Test Files 58 passed   Tests  1719 passed
@liendev/lien (cli)     Test Files 68 passed   Tests  1502 passed
@liendev/action         Test Files  5 passed   Tests    41 passed
                                    -------              ----
Total                              221 files           5204 tests, 0 failed
(exit code 0)

$ node packages/cli/dist/index.js delta
lien delta — complexity vs HEAD
  packages/review/src/plugins/agent/doc-truth-pass.ts
    ⚠ worsened  reduceDocTruthV2Findings  cognitive 2 → 3
    ⚠ worsened  postProcessDocTruthResult  time 15m → 17m
  packages/review/src/plugins/agent/stale-duplicate-pass.ts
    ⚠ worsened  postProcessStaleDuplicateResult  cognitive 4 → 5
  ⚠ 3 worsened · 4 files · 432 ms
(exit code 0 — advisory "worsened" only; no new-over-threshold crossing)
```

`npm test` total (5204 passing) matches the pre-existing baseline exactly — no regressions.

## Dogfood

This is a pure logic fix inside `packages/review`'s deterministic, LLM-free reducer functions — no CLI/MCP surface, no hook, no prompt change. The dogfood-equivalent evidence for this kind of change is the before/after unit-test proof above (production code, `postProcessStaleDuplicateResult`/`reduceDocTruthV2Findings`, exercised directly — not a mock), which is what the issue itself asked to reproduce "by executing production code."

## Harness evidence (deterministic fixture-comparison census — no OpenRouter spend)

This PR is caught by `.github/workflows/harness-attestation.yml` because it touches `packages/review/src/plugins/agent/**`. A full `--calibrate 10` run isn't warranted here: the change is entirely inside two **post-processing** functions (`postProcessStaleDuplicateResult`, `reduceDocTruthV2Findings`) that filter an already-returned model verdict array — it touches no prompt text, no rule wording, and no eligibility gate. `test/harness/build-prompts.ts` never imports either changed function (only `shouldRun*Pass`/`build*PassPrompts`/`*PassBudget`/`applyStaleDuplicateMainOverride`), so its output is provably unaffected by this diff at the import level, not just empirically.

**Method:** ran `build-prompts.ts` against every fixture with a committed `.fixture.json` in this repo, once on `origin/main` (14a34a2f) and once on this branch (288dcf5f), and compared with `sha256`.

```
$ shasum -a 256 main/*.json branch/*.json | sort -k2

d5e4b064b77d1015208602879bfe41313baeeb438e0cd167443d3d4fef836780  branch/accurate-doc.json
107dd78dcdf96d115c50e28ac8a31753b014611c472759f4b8ac5c6252b769e1  branch/placeholder.json
0ee03ed8f9a6361611243664eac7d38bfe641efc52201f4b575763b341dedd44  branch/renamed-stale-claim.json
d5e4b064b77d1015208602879bfe41313baeeb438e0cd167443d3d4fef836780  main/accurate-doc.json
107dd78dcdf96d115c50e28ac8a31753b014611c472759f4b8ac5c6252b769e1  main/placeholder.json
0ee03ed8f9a6361611243664eac7d38bfe641efc52201f4b575763b341dedd44  main/renamed-stale-claim.json
```

All three hashes are **byte-identical** between `main` and this branch (`diff -q` confirms zero-byte diffs on all three pairs). `accurate-doc.fixture.json` and `renamed-stale-claim.fixture.json` both exercise `docTruthPass.fires: true`, so `buildDocTruthPassPrompts`'s output — the prompt-construction sibling of the reducer I changed, in the same file — is directly covered.

**Coverage gap, stated honestly:** the only `stale-duplicate` fixture in the repo (`stale-duplicate/model-partial-update.assertions.ts`) has no committed `.fixture.json` (its capture command pulls PR #539 from GitHub at runtime, which this offline census didn't do), so no fixture here exercises `staleDuplicatePass.fires: true`. The byte-identical claim for that pass therefore rests on the import-level argument above (`build-prompts.ts` doesn't call `postProcessStaleDuplicateResult` or anything it depends on), not on an empirical run of a firing fixture — noting this rather than implying broader empirical coverage than actually ran.

Closes #975

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR closes a real hallucinated-id loophole in two candidate-loop reducers. The fix ports the existing `expected.has(id)` guard from the three sibling passes to `stale-duplicate-pass.ts` and `doc-truth-pass.ts`, so a model-invented `candidateId`/`claimId` paired with a reportable verdict can no longer leak through as a published finding. The doc-truth change correctly preserves its ad-hoc-finding allowance (entries with no `claimId` still pass through), while stale-duplicate now requires a valid in-worklist string id. Tests were extended to assert the phantom finding is dropped, and the change is consistent with the already-hardened sibling passes.
>
> - stale-duplicate-pass.ts now filters findings on `verdict === 'stale' && typeof candidateId === 'string' && expected.has(candidateId)`
> - doc-truth-pass.ts threads an `expected: Set<string>` into `reduceDocTruthV2Findings` and keeps claimed entries only when `expected.has(claimId) && verdict === 'contradicted'`
> - Both passes' out-of-worklist tests now assert `findings` has length 0, matching the sibling passes' coverage

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 288dcf5. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid or hallucinated findings from appearing when verdicts reference items outside the expected review worklist.
  * Improved incomplete-result reporting when verdicts do not fully cover the applicable worklist.

* **Tests**
  * Expanded coverage to verify phantom findings are discarded and results are correctly marked incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
