### PR TITLE
fix(review): compose agent get_dependents risk via computeBlastRadiusRisk

### DIFF
--- a/packages/review/src/plugins/agent/agent-tools.ts
+++ b/packages/review/src/plugins/agent/agent-tools.ts
@@ -12,7 +12,13 @@ import fs from 'fs/promises';
 import type { Dirent } from 'fs';
 import path from 'path';
 
-import { analyzeComplexityFromChunks, createGitignoreFilter } from '@liendev/parser';
+import type { BlastRadiusRisk, CodeChunk } from '@liendev/parser';
+import {
+  analyzeComplexityFromChunks,
+  createGitignoreFilter,
+  computeBlastRadiusRisk,
+  findTestAssociationsFromChunks,
+} from '@liendev/parser';
 
 import type { AgentToolContext } from './types.js';
 
@@ -70,6 +76,96 @@ export function getFilesContext(input: Record<string, unknown>, ctx: AgentToolCo
 // get_dependents
 // ---------------------------------------------------------------------------
 
+/**
+ * Complexity threshold above which an uncovered dependent escalates risk.
+ * Matches the review-side blast-radius default (`blast-radius.ts`'s
+ * DEFAULT_HIGH_COMPLEXITY_THRESHOLD) and the MCP get_dependents handler's
+ * own constant (cli's get-dependents.ts) — every consumer of
+ * `computeBlastRadiusRisk` agrees on this number.
+ */
+const HIGH_COMPLEXITY_THRESHOLD = 15;
+
+/** A caller's identity, independent of whether it came from a symbol- or file-scoped lookup. */
+interface DependentIdentity {
+  filepath: string;
+  symbolName: string;
+}
+
+function chunkComplexity(chunk: CodeChunk): number {
+  return chunk.metadata.cognitiveComplexity ?? chunk.metadata.complexity ?? 0;
+}
+
+/**
+ * Index chunks by file::symbolName, keeping the highest-complexity chunk for
+ * a given key. Mirrors `blast-radius.ts`'s `buildChunkIndex` (same key shape,
+ * same tie-break) so overload/partial-class duplicates resolve identically to
+ * the review-side `<blast_radius>` injection.
+ */
+function buildChunkIndex(chunks: CodeChunk[]): Map<string, CodeChunk> {
+  const index = new Map<string, CodeChunk>();
+  for (const chunk of chunks) {
+    const key = `${chunk.metadata.file}::${chunk.metadata.symbolName ?? ''}`;
+    const existing = index.get(key);
+    if (!existing || chunkComplexity(chunk) > chunkComplexity(existing)) {
+      index.set(key, chunk);
+    }
+  }
+  return index;
+}
+
+/**
+ * Compose blast-radius risk for a set of dependents, overlaying complexity
+ * and test coverage from `ctx.repoChunks` — the same overlay `blast-
+ * radius.ts`'s `buildEntry` runs for the review-side `<blast_radius>`
+ * injection, and the primitive's own module doc names as an intended
+ * consumer alongside that injection. Before this, `getDependents` fed only a
+ * raw dependent count into a local count-only threshold ladder, so the same
+ * PR could get a "high" risk signal from the blast-radius injection and a
+ * "low" one from this tool for the very same symbol (#977).
+ */
+function computeDependentsRisk(
+  callers: DependentIdentity[],
+  ctx: AgentToolContext,
+): BlastRadiusRisk {
+  const dependentFiles = Array.from(new Set(callers.map(c => c.filepath)));
+  const coveredFiles =
+    dependentFiles.length === 0
+      ? new Set<string>()
+      : new Set(
+          Array.from(
+            findTestAssociationsFromChunks(
+              dependentFiles,
+              ctx.repoChunks,
+              ctx.repoRootDir,
+            ).entries(),
+          )
+            .filter(([, tests]) => tests.length > 0)
+            .map(([file]) => file),
+        );
+
+  const chunkIndex = buildChunkIndex(ctx.repoChunks);
+  let maxDependentComplexity = 0;
+  let uncoveredDependents = 0;
+  let hasHighComplexityUncovered = false;
+
+  for (const caller of callers) {
+    const chunk = chunkIndex.get(`${caller.filepath}::${caller.symbolName}`);
+    const complexity = chunk ? chunkComplexity(chunk) : 0;
+    if (complexity > maxDependentComplexity) maxDependentComplexity = complexity;
+    if (!coveredFiles.has(caller.filepath)) {
+      uncoveredDependents += 1;
+      if (complexity >= HIGH_COMPLEXITY_THRESHOLD) hasHighComplexityUncovered = true;
+    }
+  }
+
+  return computeBlastRadiusRisk({
+    dependentCount: callers.length,
+    uncoveredDependents,
+    maxDependentComplexity: maxDependentComplexity > 0 ? maxDependentComplexity : undefined,
+    hasHighComplexityUncovered,
+  });
+}
+
 export function getDependents(input: Record<string, unknown>, ctx: AgentToolContext): string {
   try {
     const filepath = input.filepath as string;
@@ -79,13 +175,17 @@ export function getDependents(input: Record<string, unknown>, ctx: AgentToolCont
 
     if (symbol) {
       const callers = ctx.graph.getCallers(filepath, symbol);
-      const riskLevel = getRiskLevel(callers.length);
+      const risk = computeDependentsRisk(
+        callers.map(c => ({ filepath: c.caller.filepath, symbolName: c.caller.symbolName })),
+        ctx,
+      );
 
       return JSON.stringify({
         filepath,
         symbol,
         dependentCount: callers.length,
-        riskLevel,
+        riskLevel: risk.level,
+        riskReasoning: risk.reasoning,
         callers: callers.map(c => ({
           filepath: c.caller.filepath,
           symbolName: c.caller.symbolName,
@@ -124,24 +224,18 @@ export function getDependents(input: Record<string, unknown>, ctx: AgentToolCont
       }
     }
 
-    const riskLevel = getRiskLevel(allCallers.length);
+    const risk = computeDependentsRisk(allCallers, ctx);
 
     return JSON.stringify({
       filepath,
       dependentCount: allCallers.length,
-      riskLevel,
+      riskLevel: risk.level,
+      riskReasoning: risk.reasoning,
       callers: allCallers,
     });
   } catch (err) {
     return JSON.stringify({ error: `get_dependents failed: ${(err as Error).message}` });
   }
-}
-
-function getRiskLevel(count: number): 'low' | 'medium' | 'high' | 'critical' {
-  if (count >= 20) return 'critical';
-  if (count >= 10) return 'high';
-  if (count >= 5) return 'medium';
-  return 'low';
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/review/test/plugins-agent-getdependents-risk.test.ts
+++ b/packages/review/test/plugins-agent-getdependents-risk.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import type { CodeChunk } from '@liendev/parser';
+import { computeBlastRadiusRisk } from '@liendev/parser';
+
+import { getDependents } from '../src/plugins/agent/agent-tools.js';
+import { buildDependencyGraph } from '../src/dependency-graph.js';
+import { computeBlastRadius } from '../src/blast-radius.js';
+import { createTestChunk, silentLogger } from '../src/test-helpers.js';
+import type { AgentToolContext } from '../src/plugins/agent/types.js';
+
+/** Parsed shape of getDependents' JSON return. */
+interface GetDependentsResult {
+  dependentCount?: number;
+  riskLevel?: string;
+  riskReasoning?: string[];
+  callers?: unknown[];
+  error?: string;
+}
+
+function ctxWith(repoChunks: CodeChunk[]): AgentToolContext {
+  return {
+    repoChunks,
+    repoRootDir: '/tmp/does-not-matter',
+    graph: buildDependencyGraph(repoChunks),
+    logger: silentLogger,
+  };
+}
+
+function seedChunk(file: string, symbol: string): CodeChunk {
+  return createTestChunk({
+    metadata: {
+      file,
+      startLine: 1,
+      endLine: 10,
+      type: 'function',
+      symbolName: symbol,
+      symbolType: 'function',
+      language: 'typescript',
+      exports: [symbol],
+      complexity: 3,
+      cognitiveComplexity: 3,
+    },
+  });
+}
+
+function callerChunk(
+  file: string,
+  symbol: string,
+  target: { file: string; symbol: string; importPath: string },
+  complexity: number,
+): CodeChunk {
+  return createTestChunk({
+    metadata: {
+      file,
+      startLine: 1,
+      endLine: 10,
+      type: 'function',
+      symbolName: symbol,
+      symbolType: 'function',
+      language: 'typescript',
+      exports: [symbol],
+      importedSymbols: { [target.importPath]: [target.symbol] },
+      callSites: [{ symbol: target.symbol, line: 5 }],
+      complexity,
+      cognitiveComplexity: complexity,
+    },
+  });
+}
+
+function testChunkFor(testFile: string, importedSrc: string): CodeChunk {
+  return createTestChunk({
+    content: `import { x } from '${importedSrc}';\ntest("x", () => {});`,
+    metadata: {
+      file: testFile,
+      startLine: 1,
+      endLine: 5,
+      type: 'block',
+      language: 'typescript',
+      imports: [importedSrc],
+    },
+  });
+}
+
+/** 3 dependents of `seed`, all with complexity 40 and no test coverage. */
+function threeUntestedHighComplexityCallers(): CodeChunk[] {
+  return Array.from({ length: 3 }, (_, i) =>
+    callerChunk(
+      `src/caller${i}.ts`,
+      `caller${i}`,
+      { file: 'src/seed.ts', symbol: 'seed', importPath: './seed' },
+      40,
+    ),
+  );
+}
+
+describe('getDependents — risk composed via computeBlastRadiusRisk (#977)', () => {
+  it('matches computeBlastRadiusRisk\'s "high" verdict for 3 untested, complexity-40 dependents', () => {
+    // The issue's worked counter-example: a count-only ladder returns 'low'
+    // for 3 dependents (its next tier needs >= 5), while computeBlastRadiusRisk
+    // — fed the very same shape — returns 'high' because an untested dependent
+    // crosses the high-complexity threshold.
+    const seed = seedChunk('src/seed.ts', 'seed');
+    const callers = threeUntestedHighComplexityCallers();
+    const repoChunks = [seed, ...callers];
+
+    const result = JSON.parse(
+      getDependents({ filepath: 'src/seed.ts', symbol: 'seed' }, ctxWith(repoChunks)),
+    ) as GetDependentsResult;
+
+    expect(result.error).toBeUndefined();
+    expect(result.dependentCount).toBe(3);
+
+    const primitiveVerdict = computeBlastRadiusRisk({
+      dependentCount: 3,
+      uncoveredDependents: 3,
+      maxDependentComplexity: 40,
+      hasHighComplexityUncovered: true,
+    });
+
+    expect(primitiveVerdict.level).toBe('high');
+    expect(result.riskLevel).toBe(primitiveVerdict.level);
+    expect(result.riskReasoning).toContain('untested high-complexity dependent');
+  });
+
+  it('agrees with the review-side <blast_radius> injection (computeBlastRadius) for the same fixture', () => {
+    // Same PR, same seed symbol — the agent's own get_dependents tool and the
+    // pre-computed blast-radius block injected into its initial message must
+    // never disagree on risk (#977). depth:1 matches getCallers' direct
+    // (non-transitive) lookup so the two computations walk the same edges.
+    const seed = seedChunk('src/seed.ts', 'seed');
+    const callers = threeUntestedHighComplexityCallers();
+    const repoChunks = [seed, ...callers];
+    const graph = buildDependencyGraph(repoChunks);
+
+    const blastRadiusReport = computeBlastRadius([seed], graph, repoChunks, { depth: 1 });
+    const toolResult = JSON.parse(
+      getDependents({ filepath: 'src/seed.ts', symbol: 'seed' }, ctxWith(repoChunks)),
+    ) as GetDependentsResult;
+
+    expect(blastRadiusReport.entries).toHaveLength(1);
+    expect(toolResult.riskLevel).toBe(blastRadiusReport.entries[0].risk.level);
+  });
+
+  it('does not escalate when the same high-complexity dependents are fully tested', () => {
+    const seed = seedChunk('src/seed.ts', 'seed');
+    const callers = threeUntestedHighComplexityCallers();
+    const tests = callers.map((_, i) => testChunkFor(`src/caller${i}.test.ts`, `./caller${i}`));
+    const repoChunks = [seed, ...callers, ...tests];
+
+    const result = JSON.parse(
+      getDependents({ filepath: 'src/seed.ts', symbol: 'seed' }, ctxWith(repoChunks)),
+    ) as GetDependentsResult;
+
+    const primitiveVerdict = computeBlastRadiusRisk({
+      dependentCount: 3,
+      uncoveredDependents: 0,
+      maxDependentComplexity: 40,
+      hasHighComplexityUncovered: false,
+    });
+
+    expect(result.riskLevel).toBe(primitiveVerdict.level);
+    expect(result.riskLevel).not.toBe('high');
+  });
+
+  it('composes risk the same way for the file-level (no symbol) branch', () => {
+    const seed = seedChunk('src/seed.ts', 'seed');
+    const callers = Array.from({ length: 6 }, (_, i) =>
+      callerChunk(
+        `src/caller${i}.ts`,
+        `caller${i}`,
+        { file: 'src/seed.ts', symbol: 'seed', importPath: './seed' },
+        2,
+      ),
+    );
+    const repoChunks = [seed, ...callers];
+
+    const result = JSON.parse(
+      getDependents({ filepath: 'src/seed.ts' }, ctxWith(repoChunks)),
+    ) as GetDependentsResult;
+
+    const primitiveVerdict = computeBlastRadiusRisk({
+      dependentCount: 6,
+      uncoveredDependents: 6,
+      maxDependentComplexity: 2,
+      hasHighComplexityUncovered: false,
+    });
+
+    expect(result.dependentCount).toBe(6);
+    expect(result.riskLevel).toBe(primitiveVerdict.level);
+  });
+});


### PR DESCRIPTION
## Summary

`getDependents` in `packages/review/src/plugins/agent/agent-tools.ts` classified risk from a raw dependent count alone (`getRiskLevel`), ignoring the complexity and test-coverage signals that were already in scope via `ctx.repoChunks`. This let the same PR/symbol get a "high" risk signal from the review-side `<blast_radius>` injection and a "low" one from the agent's own `get_dependents` tool call — contradicting the documented guarantee that a high-complexity untested dependent always lifts `riskLevel` above `"low"`.

Fixed by composing risk through the shared `computeBlastRadiusRisk` primitive (`packages/parser/src/risk/blast-radius-risk.ts`), overlaying complexity and test coverage from `ctx.repoChunks` the same way `review/src/blast-radius.ts`'s `buildEntry` already does for the review-side injection. This is the same primitive the other three call sites already use (`review/src/blast-radius.ts` x2, `cli/src/mcp/handlers/get-dependents.ts`) — `agent-tools.ts` was the one MCP-shaped surface that bypassed it.

## Before / after — the issue's worked counter-example

3 dependents of a symbol, all untested, max complexity 40:

| | riskLevel |
|---|---|
| **Before** (`getRiskLevel(3)`, count-only) | `low` |
| **After** (`computeDependentsRisk` → `computeBlastRadiusRisk`) | `high` |
| `computeBlastRadiusRisk` called directly with the same shape | `high` |

Now verified equal by a regression test (`packages/review/test/plugins-agent-getdependents-risk.test.ts`), which also cross-checks the tool's verdict against `computeBlastRadius` (the actual review-side `<blast_radius>` injection) on the same fixture, and confirms the verdict does **not** escalate when the same high-complexity dependents are fully tested.

## Gate results (all six, from a fresh worktree — `npm ci && npm run build && npm run build:native -w @liendev/parser-native`)

1. `npm run format:check` — pass
2. `npm run lint` — 0 errors, 38 pre-existing warnings (unrelated files)
3. `npm run typecheck` — pass
4. `npm run build` — pass
5. `npm test` — 5208 passing (5204 baseline + 4 new tests in `plugins-agent-getdependents-risk.test.ts`)
6. `node packages/cli/dist/index.js delta` — exit 0, no new-over-threshold crossings (`computeDependentsRisk` lands at cognitive complexity 13, no warning marker)

## Harness evidence (deterministic fixture-comparison census, no OpenRouter spend)

This PR touches `packages/review/src/plugins/agent/agent-tools.ts`, so it's in scope for the harness-attestation gate. The change is a tool-implementation/risk-formula fix, not a rule/prompt change, so I ran the deterministic `build-prompts.ts` census instead of a paid `--calibrate` run.

**Method:** `npm run test:harness:build-prompts -w @liendev/review -- <fixture>` (via `npx tsx test/harness/build-prompts.ts <fixture>`), run against all three fixtures that are actually tracked in git (the rest are gitignored 10MB+ captures per `.gitignore:105-115`, not present in a clean checkout): `fixtures/boundary-change/placeholder.fixture.json`, `fixtures/doc-truth/accurate-doc.fixture.json`, `fixtures/doc-truth/renamed-stale-claim.fixture.json`. Ran once on this branch (`fix/agent-get-dependents-risk-977`, commit 4ab41d9), then again with the worktree detached to `origin/main` tip (same working directory, no rebuild needed — `tsx` reads source directly), then `sha256`'d both sets of output.

**Result — byte-identical (sha256) on all 3 fixtures:**

| Fixture | sha256 (branch) | sha256 (origin/main) |
|---|---|---|
| `boundary-change/placeholder` | `3c32fa2692fbb529011c6605944c41674e9b92c4a10d3207341aff1b83f3ace1` | identical |
| `doc-truth/accurate-doc` | `a4af5f8b741a55183ec133f4a81e62026272d227bbf8803bc4643ae1f8880fdb` | identical |
| `doc-truth/renamed-stale-claim` | `d435ef1fb23c8773c354fa54a9335c5258e4dee7cfba0f1d6efe7a0ee71d6a6c` | identical |

**Why this is expected, not a coincidence:** `build-prompts.ts` builds `systemPrompt` (from `rules.ts` + `system-prompt.ts`) and `initialMessage` (from the fixture's `ReviewContext`, with `blastRadius: null`) — neither path calls `getDependents` or any other tool implementation from `agent-tools.ts` at runtime. Nothing in this PR changes tool *descriptions* (`AGENT_TOOLS` in `tools.ts`, untouched) or rule selection, so byte-identical prompts are the correct outcome.

**Honest limitation — what this census does NOT cover:** `build-prompts.ts` never invokes a tool call, so it cannot and does not exercise the actual code this PR changes. The `get_dependents` tool's *response shape* did change: it now includes a `riskReasoning` array, and `riskLevel` is computed differently (composed via `computeBlastRadiusRisk` instead of the old count-only ladder) — that's the entire point of the fix. That behavioral change is real, intentional, and is verified instead by the 4 targeted unit tests added in `plugins-agent-getdependents-risk.test.ts` (see the before/after table above), not by this prompt-identity census. I'm not claiming "nothing changed" — only that prompt *construction* is provably unchanged, which is the part `build-prompts.ts` can actually attest to.

## Known test flakiness (unrelated to this change)

One full `npm test` run earlier showed `1 failed | 1501 passed (1502)` in the `packages/cli` workspace. I did not capture the specific failing test's name at the time (only grepped the summary line, not the full output — a mistake on my part). I have since re-run `packages/cli`'s suite 4 more times (plus 1 more full root `npm test`) and it passed clean at 1502/1502 every time — the flake has not reproduced, so I can't name the specific test or file it with confidence. This PR touches only `packages/review`, not `packages/cli`, so it's very unlikely to be related to this change; flagging it here per request rather than filing a report I can't substantiate with an actual test name.

## Changeset

None — only `packages/review` (private/unpublished) is touched; confirmed via `git diff --name-only origin/main...HEAD`.

Closes #977

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 4 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 4 | +20 |


> [!NOTE]
> **Low Risk**
>
> This PR unifies the agent `get_dependents` tool's risk scoring with the review-side blast-radius injection by routing it through the shared `computeBlastRadiusRisk` primitive and overlaying dependent complexity and test coverage from `ctx.repoChunks`. The change is additive (adds `riskReasoning` to the tool response) and is backed by targeted regression tests that pin the divergence case (3 untested high-complexity dependents → `high`) and the non-escalation case (same dependents fully tested → not `high`). No breaking changes, silent error swallowing, or stale duplicates that affect runtime behavior were found.
>
> - Replaced count-only `getRiskLevel` ladder with `computeDependentsRisk`, which mirrors `blast-radius.ts` by indexing chunks, computing test coverage via `findTestAssociationsFromChunks`, and calling `computeBlastRadiusRisk`.
> - Added `riskReasoning` to the `get_dependents` JSON response alongside `riskLevel`.
> - Added regression tests covering the high-complexity/untested escalation, full-coverage non-escalation, parity with `computeBlastRadius`, and the file-level (no symbol) branch.

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 4ab41d9. Updates automatically on new commits.</sup>
<!-- /lien-stats -->
