### PR TITLE
fix(cli,site): consolidate attributionCaveat reason prose into one source

### DIFF
--- a/.changeset/attribution-caveat-reason-prose.md
+++ b/.changeset/attribution-caveat-reason-prose.md
@@ -1,0 +1,37 @@
+---
+"@liendev/lien": patch
+---
+
+Fix `get_dependents`'s `attributionCaveat.reason` prose, which had drifted
+out of sync across its five model-facing surfaces (#980). `#941` wrote the
+explanation into three surfaces at once; `#951` fixed two of them and
+needed a second sub-commit for the third; two surfaces were never revisited
+and were still wrong at HEAD:
+
+- The `symbol` parameter's JSON Schema description (read by every MCP
+  client on connect) still had the pre-`#951` unhedged wording — it didn't
+  mention that an unconfirmed symbol may simply be a typo, a hallucinated
+  name, or a removed one, rather than always a real method/constructor.
+- The `AttributionCaveatReason` type's JSDoc (dev-facing) had the same gap.
+
+Both now carry the same hedge already present in the tool description and
+server instructions.
+
+Consolidated all four reasons' explanatory text into one exported record
+(`ATTRIBUTION_CAVEAT_REASON_TEXT` in `packages/cli/src/mcp/attribution-caveat-reasons.ts`,
+keyed by `AttributionCaveatReason` so the compiler rejects a stale entry
+count), and had the tool description, server instructions, and JSON Schema
+description all interpolate it instead of hand-writing the explanation
+again — closing off the exact drift pattern that caused this bug three
+times in a row.
+
+Also fixes the public docs page
+(`packages/site/docs/guide/mcp-tools.md`), which asserted `reason` is "one
+of" a list of exactly three names — `dependent-attribution-partial`
+(added by `#930`) appeared zero times in the file, leaving no documented
+way to interpret the `confidence: "inferred"` entries that reason implies.
+Added a test (`attribution-caveat-reasons.test.ts`) asserting the docs
+page, the server instructions, and the tool description each mention
+every member of the `AttributionCaveatReason` union, so a future fifth
+reason fails CI on any surface that isn't updated, rather than shipping
+silently incomplete.

--- a/packages/cli/src/mcp/attribution-caveat-reasons.test.ts
+++ b/packages/cli/src/mcp/attribution-caveat-reasons.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  ATTRIBUTION_CAVEAT_REASONS,
+  ATTRIBUTION_CAVEAT_REASON_TEXT,
+} from './attribution-caveat-reasons.js';
+import { SERVER_INSTRUCTIONS } from './instructions.js';
+import { tools } from './tools.js';
+
+/**
+ * Guards the #980 failure mode: a model/user-facing prose surface silently
+ * omitting a member of the `AttributionCaveatReason` union. #930 added
+ * `dependent-attribution-partial` to the union; it never made it into
+ * `site/docs/guide/mcp-tools.md`, which even asserted "reason is one of"
+ * followed by only three names. Neither the "Docs Truth" CI check nor the
+ * docs-drift review pass caught the omission -- both check the *accuracy*
+ * of what's written, not its *completeness* against the union.
+ *
+ * If a fifth reason is ever added to `AttributionCaveatReason`, the tests
+ * below fail loudly on every surface that hasn't been updated to mention it
+ * -- rather than silently shipping documentation describing fewer reasons
+ * than actually exist. (`ATTRIBUTION_CAVEAT_REASONS` itself can't silently
+ * fall behind the union either -- see its doc comment in
+ * `attribution-caveat-reasons.ts`.)
+ */
+
+/** Walk up from `startDir` looking for the repo root (has `packages/site/docs`). */
+function findRepoRoot(startDir: string): string | null {
+  let dir = startDir;
+  for (let i = 0; i < 10; i++) {
+    if (existsSync(join(dir, 'packages', 'site', 'docs', 'guide', 'mcp-tools.md'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+  return null;
+}
+
+const repoRoot = findRepoRoot(dirname(fileURLToPath(import.meta.url)));
+
+const getDependentsTool = tools.find(t => t.name === 'get_dependents');
+if (!getDependentsTool) {
+  throw new Error('get_dependents tool definition not found in tools.ts');
+}
+const getDependentsDescription = getDependentsTool.description;
+
+describe('AttributionCaveatReason union completeness across prose surfaces', () => {
+  it('ATTRIBUTION_CAVEAT_REASON_TEXT has an entry for every reason (sanity check)', () => {
+    for (const reason of ATTRIBUTION_CAVEAT_REASONS) {
+      expect(ATTRIBUTION_CAVEAT_REASON_TEXT[reason]).toBeTruthy();
+    }
+  });
+
+  it.each(ATTRIBUTION_CAVEAT_REASONS)(
+    'SERVER_INSTRUCTIONS (instructions.ts) mentions "%s"',
+    reason => {
+      expect(SERVER_INSTRUCTIONS).toContain(reason);
+    },
+  );
+
+  it.each(ATTRIBUTION_CAVEAT_REASONS)(
+    'the get_dependents tool description (tools.ts) mentions "%s"',
+    reason => {
+      expect(getDependentsDescription).toContain(reason);
+    },
+  );
+
+  if (!repoRoot) {
+    it.skip('SKIPPED: repo root not found by walking up from this file — not running inside a lien repo checkout', () => {});
+  } else {
+    const docsPath = join(repoRoot, 'packages', 'site', 'docs', 'guide', 'mcp-tools.md');
+    const docsText = readFileSync(docsPath, 'utf8');
+
+    it.each(ATTRIBUTION_CAVEAT_REASONS)(
+      'the public docs page (site/docs/guide/mcp-tools.md) mentions "%s"',
+      reason => {
+        expect(docsText).toContain(reason);
+      },
+    );
+  }
+});

--- a/packages/cli/src/mcp/attribution-caveat-reasons.ts
+++ b/packages/cli/src/mcp/attribution-caveat-reasons.ts
@@ -1,0 +1,94 @@
+/**
+ * Why a `get_dependents` answer's counts can't be trusted as a verified
+ * clear (#940). Exactly one reason can ever apply to a given response --
+ * see `buildAttributionCaveat`'s doc comment in `handlers/get-dependents.ts`
+ * for why these four are mutually exclusive by construction:
+ *
+ * - `unresolved-target`: `filepath` isn't resolvable in the index at all
+ *   (not in the manifest, or has zero chunks in the current scan -- #927,
+ *   #928, #937). Every count in the response is then a deliberate `0`, not
+ *   a fuzzy-matched answer.
+ * - `symbol-attribution-degraded`: `symbol` isn't a top-level export of
+ *   `filepath` (the shape of a method or constructor -- #931). It may also
+ *   be a typo'd/hallucinated/removed name -- those look identical on that
+ *   signal alone, so the response widens to file-level dependents instead
+ *   of asserting an unverifiable symbol-scoped count.
+ * - `dependent-attribution-partial`: a file-level query (no `symbol`) found
+ *   zero import-based dependents, but the C# type-reference-matching
+ *   fallback recovered one or more (#930 part 2) -- those entries are
+ *   tagged `confidence: 'inferred'` in `dependents`, and the counts are a
+ *   recovered lower bound, not a verified/complete answer.
+ * - `dependent-attribution-incomplete`: a file-level query (no `symbol`)
+ *   came back with zero dependents in a language where the import graph
+ *   structurally can't see every real usage, e.g. C#'s `global using` /
+ *   implicit enclosing-namespace access (#930, #936), EVEN AFTER the
+ *   type-reference-matching fallback also found nothing.
+ *
+ * This is the SINGLE SOURCE for the model/user-facing explanation of each
+ * reason (`ATTRIBUTION_CAVEAT_REASON_TEXT` below). #941 hand-wrote this
+ * prose into three model-facing surfaces at once; #951 fixed two and
+ * needed a second sub-commit for the third; #980 found the remaining two
+ * (a JSON schema description read by every MCP client on connect, and the
+ * public docs page, which also omitted `dependent-attribution-partial`
+ * entirely) still wrong at HEAD. Every prose surface -- tool description
+ * (`tools.ts`), server instructions (`instructions.ts`), schema description
+ * (`schemas/dependents.schema.ts`), and the docs page
+ * (`site/docs/guide/mcp-tools.md`) -- MUST interpolate the text below
+ * rather than hand-writing this explanation again. A JSDoc comment can't
+ * interpolate a runtime value, so `handlers/get-dependents.ts`'s doc
+ * comment on `buildAttributionCaveat` points back here instead of
+ * re-deriving the wording.
+ */
+export type AttributionCaveatReason =
+  | 'unresolved-target'
+  | 'symbol-attribution-degraded'
+  | 'dependent-attribution-partial'
+  | 'dependent-attribution-incomplete';
+
+/**
+ * One canonical, hedged sentence per reason -- what it means for the caller
+ * and what to do about it. Interpolate this into every prose surface; never
+ * hand-write the explanation again at a new call site.
+ *
+ * `Record<AttributionCaveatReason, string>` makes the compiler reject this
+ * object literal unless it has EXACTLY the union's members as keys -- add a
+ * fifth reason to the union and this line fails to compile until its text
+ * is added here too.
+ */
+export const ATTRIBUTION_CAVEAT_REASON_TEXT: Record<AttributionCaveatReason, string> = {
+  'unresolved-target':
+    "filepath isn't resolvable in the index at all (never indexed, misspelled, or a typo'd " +
+    'directory prefix) — every count in the response is a deliberate 0, not a confirmed empty ' +
+    'dependency graph. Try search_code or list_functions to find the real path, or run "lien ' +
+    'index" if the file was added recently.',
+
+  'symbol-attribution-degraded':
+    "symbol isn't a top-level export and its call sites couldn't be confirmed — it may be a " +
+    "real method/constructor, or it may be a typo'd/hallucinated/removed name (the note says " +
+    'which); either way, dependentCount/riskLevel/dependents become the file-level answer ' +
+    '(every file that imports filepath), not a verified count for symbol itself.',
+
+  'dependent-attribution-partial':
+    'a file-level query (no symbol) found zero import-based dependents, but a lower-confidence ' +
+    'text-matching fallback recovered some dependents anyway (those entries carry ' +
+    'confidence: "inferred"). Treat the counts as a recovered floor, not a complete answer — ' +
+    'the fallback can still miss a real dependent reached via an alias, a generic type ' +
+    'argument, or reflection.',
+
+  'dependent-attribution-incomplete':
+    'a file-level query (no symbol) came back with zero dependents in a language where the ' +
+    "import graph structurally can't see every real usage (e.g. C#'s global using / implicit " +
+    'enclosing-namespace access), even after the text-matching fallback above also found ' +
+    'nothing. Treat dependentCount: 0 and riskLevel: "low" as a floor, not a finding — verify ' +
+    'with grep before concluding the file is unused.',
+};
+
+/**
+ * Every `AttributionCaveatReason`, in the order prose surfaces list them.
+ * Derived from `ATTRIBUTION_CAVEAT_REASON_TEXT`'s keys rather than
+ * hand-listed again, so this array can never silently fall out of sync with
+ * the union the way the docs page did in #980.
+ */
+export const ATTRIBUTION_CAVEAT_REASONS = Object.keys(
+  ATTRIBUTION_CAVEAT_REASON_TEXT,
+) as AttributionCaveatReason[];

--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -4,6 +4,7 @@ import { GetDependentsSchema } from '../schemas/index.js';
 import { findUnindexedPaths, formatUnindexedPathsNote } from '../utils/unindexed-paths.js';
 import type { ToolContext, MCPToolResult } from '../types.js';
 import { computeBlastRadiusRisk, type BlastRadiusRisk } from '@liendev/parser';
+import type { AttributionCaveatReason } from '../attribution-caveat-reasons.js';
 import {
   findDependents,
   type DependencyAnalysisResult,
@@ -24,36 +25,12 @@ interface IndexInfo {
   indexDate: string;
 }
 
-/**
- * Why a `get_dependents` answer's counts can't be trusted as a verified
- * clear (#940). Exactly one reason can ever apply to a given response --
- * see `buildAttributionCaveat`'s doc comment for why these four are
- * mutually exclusive by construction:
- *
- * - `unresolved-target`: `filepath` isn't resolvable in the index at all
- *   (not in the manifest, or has zero chunks in the current scan -- #927,
- *   #928, #937). Every count in the response is then a deliberate `0`, not
- *   a fuzzy-matched answer.
- * - `symbol-attribution-degraded`: `symbol` isn't a top-level export of
- *   `filepath` (the shape of a method or constructor -- #931), so the
- *   response was widened to file-level dependents instead of asserting an
- *   unverifiable symbol-scoped count.
- * - `dependent-attribution-partial`: a file-level query (no `symbol`) found
- *   zero import-based dependents, but the C# type-reference-matching
- *   fallback recovered one or more (#930 part 2) -- those entries are
- *   tagged `confidence: 'inferred'` in `dependents`, and the counts are a
- *   recovered lower bound, not a verified/complete answer.
- * - `dependent-attribution-incomplete`: a file-level query (no `symbol`)
- *   came back with zero dependents in a language where the import graph
- *   structurally can't see every real usage, e.g. C#'s `global using` /
- *   implicit enclosing-namespace access (#930, #936), EVEN AFTER the
- *   type-reference-matching fallback also found nothing.
- */
-export type AttributionCaveatReason =
-  | 'unresolved-target'
-  | 'symbol-attribution-degraded'
-  | 'dependent-attribution-partial'
-  | 'dependent-attribution-incomplete';
+// `AttributionCaveatReason` and its doc comment (which four reasons exist,
+// what triggers each, and why they're mutually exclusive) now live in
+// `../attribution-caveat-reasons.js` -- the single source that every
+// model/user-facing prose surface interpolates from (#980). Re-exported here
+// for callers that already import the type from this handler.
+export type { AttributionCaveatReason };
 
 export interface AttributionCaveat {
   reason: AttributionCaveatReason;

--- a/packages/cli/src/mcp/instructions.ts
+++ b/packages/cli/src/mcp/instructions.ts
@@ -1,3 +1,5 @@
+import { ATTRIBUTION_CAVEAT_REASON_TEXT } from './attribution-caveat-reasons.js';
+
 /**
  * MCP server instructions returned on `initialize`.
  *
@@ -35,20 +37,10 @@ symbol:
   If a result carries attributionCaveat, dependentCount/riskLevel cannot be
   trusted as a verified clear — never treat a low count (especially 0) as
   "safe" or "unused" without checking it first. Its reason tells you why:
-  "unresolved-target" means filepath isn't in the index at all (never
-  indexed, misspelled, or a typo'd directory prefix) — fix the path (try
-  search_code or list_functions) before trusting anything else in the
-  result. "symbol-attribution-degraded" means symbol isn't a top-level
-  export and its call sites couldn't be confirmed — it may be a real
-  method/constructor, or it may be a typo'd/hallucinated/removed name (the
-  note says which); either way the counts are the wider file-level answer,
-  not a verified count for symbol itself.
-  "dependent-attribution-partial" means the import graph found nothing but
-  a lower-confidence text-matching fallback recovered some dependents
-  anyway (those entries carry confidence: "inferred") — treat the counts as
-  a recovered floor, not a complete answer. "dependent-attribution-incomplete"
-  means Lien could not SEE real callers in this language (e.g. C#) even
-  after that fallback ran — grep before concluding the file is unused.
+  "unresolved-target" means ${ATTRIBUTION_CAVEAT_REASON_TEXT['unresolved-target']}
+  "symbol-attribution-degraded" means ${ATTRIBUTION_CAVEAT_REASON_TEXT['symbol-attribution-degraded']}
+  "dependent-attribution-partial" means ${ATTRIBUTION_CAVEAT_REASON_TEXT['dependent-attribution-partial']}
+  "dependent-attribution-incomplete" means ${ATTRIBUTION_CAVEAT_REASON_TEXT['dependent-attribution-incomplete']}
   (The latter two reasons only fire for FILE-level queries, i.e. no "symbol"
   argument.) riskLevel is not adjusted for any of the latter three and may
   still read "low"; attributionCaveat is the authoritative signal in all

--- a/packages/cli/src/mcp/schemas/dependents.schema.ts
+++ b/packages/cli/src/mcp/schemas/dependents.schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import path from 'path';
+import { ATTRIBUTION_CAVEAT_REASON_TEXT } from '../attribution-caveat-reasons.js';
 
 /**
  * Schema for get_dependents tool input.
@@ -38,11 +39,10 @@ export const GetDependentsSchema = z.object({
         'When provided, returns call sites instead of just importing files.\n\n' +
         "Example: 'validateEmail' to find where validateEmail() is called.\n\n" +
         "Response includes 'usages' array showing which functions call this symbol.\n\n" +
-        "Also accepts a method or constructor name (e.g. '__construct', 'moveUp').\n" +
-        "Those aren't top-level exports, so when call sites for one can't be " +
-        "confirmed, the response sets attributionCaveat.reason: 'symbol-attribution-degraded' " +
-        'and widens dependentCount/riskLevel to the file-level answer rather than asserting an ' +
-        'unverifiable symbol-scoped count — check for attributionCaveat before trusting a low count.',
+        "Also accepts a method or constructor name (e.g. '__construct', 'moveUp'). When " +
+        "provided, the response sets attributionCaveat.reason: 'symbol-attribution-degraded' " +
+        `if ${ATTRIBUTION_CAVEAT_REASON_TEXT['symbol-attribution-degraded']} Check for ` +
+        'attributionCaveat before trusting a low count.',
     ),
 
   depth: z

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -7,6 +7,7 @@ import {
   GetDependentsSchema,
   GetComplexitySchema,
 } from './schemas/index.js';
+import { ATTRIBUTION_CAVEAT_REASON_TEXT } from './attribution-caveat-reasons.js';
 
 /**
  * MCP tool definitions with Zod-generated schemas.
@@ -159,26 +160,10 @@ Returns:
   can't be trusted as a verified clear. ALWAYS check for this field before treating
   a low dependentCount (especially 0) as "safe to edit" or "unused". \`reason\` is
   one of:
-  - "unresolved-target": \`filepath\` isn't resolvable in the index at all (typo,
-    wrong directory prefix/case, or not indexed yet) — every count is a deliberate
-    0, not a confirmed empty dependency graph. Try search_code or list_functions to
-    find the real path, or run "lien index" if the file was added recently.
-  - "symbol-attribution-degraded": \`symbol\` isn't a top-level export and its call
-    sites couldn't be confirmed — may be a real method/constructor, or a
-    typo'd/hallucinated/removed name (\`note\` says which); dependentCount/
-    riskLevel are the file-level answer (every importer of filepath), not a
-    verified count of callers of symbol itself.
-  - "dependent-attribution-partial": a file-level query (no \`symbol\`) found ZERO
-    import-based dependents, but a lower-confidence text-matching fallback
-    recovered one or more (tagged \`confidence: "inferred"\` in dependents[], see
-    above). Treat dependentCount/riskLevel as a recovered FLOOR, not a
-    verified/complete answer — the fallback can still miss a real dependent that
-    references the type via an alias, a generic type argument, or reflection.
-  - "dependent-attribution-incomplete": a file-level query (no \`symbol\`) returned
-    ZERO dependents even after the fallback above also found nothing, in a
-    language whose callers need no per-file import (C# today: enclosing-namespace
-    access under a \`global using\`). Treat dependentCount 0 and riskLevel "low" as
-    a FLOOR, not a finding — verify with grep before concluding the file is unused.
+  - "unresolved-target": ${ATTRIBUTION_CAVEAT_REASON_TEXT['unresolved-target']}
+  - "symbol-attribution-degraded": ${ATTRIBUTION_CAVEAT_REASON_TEXT['symbol-attribution-degraded']}
+  - "dependent-attribution-partial": ${ATTRIBUTION_CAVEAT_REASON_TEXT['dependent-attribution-partial']}
+  - "dependent-attribution-incomplete": ${ATTRIBUTION_CAVEAT_REASON_TEXT['dependent-attribution-incomplete']}
   At most one reason ever fires per response.`,
   ),
   toMCPToolSchema(

--- a/packages/site/docs/guide/mcp-tools.md
+++ b/packages/site/docs/guide/mcp-tools.md
@@ -328,7 +328,7 @@ When `symbol` is provided, the response also includes `totalUsageCount` (number 
 
 ### `attributionCaveat`
 
-Three unrelated situations can each make `dependentCount`/`riskLevel` untrustworthy as a verified clear. Rather than three differently-named flags, the response carries a single optional field:
+Four unrelated situations can each make `dependentCount`/`riskLevel` untrustworthy as a verified clear. Rather than four differently-named flags, the response carries a single optional field:
 
 ```json
 {
@@ -342,8 +342,9 @@ Three unrelated situations can each make `dependentCount`/`riskLevel` untrustwor
 `reason` is one of:
 
 - **`unresolved-target`** — `filepath` isn't resolvable in the index at all: never indexed, misspelled, or a typo'd directory prefix. `dependentCount: 0` / `riskLevel: "low"` then means "the path is unresolved," not "confirmed zero dependents." (Two independent checks can produce this — the index manifest has no entry for the path at all, or the path resolves in the manifest but has zero chunks in the current scan — but only one `attributionCaveat` is ever returned, never two competing explanations of the same zero.)
-- **`symbol-attribution-degraded`** — `symbol` also accepts a method or constructor name (e.g. `__construct`, `moveUp`); those aren't top-level exports, so when call sites for one can't be confirmed, the response widens `dependentCount`/`riskLevel` to the file-level answer (every file that imports `filepath`) rather than asserting an unverifiable symbol-scoped count.
-- **`dependent-attribution-incomplete`** — a file-level query (no `symbol`) found zero dependents in a language where the import graph structurally can't see every real usage — C#'s enclosing-namespace access, where a `global using` lets a real caller reach `filepath`'s exports with no per-file import at all (#930). `dependentCount: 0` / `riskLevel: "low"` here means "the import graph found nothing," not "nothing depends on this file."
+- **`symbol-attribution-degraded`** — `symbol` also accepts a method or constructor name (e.g. `__construct`, `moveUp`); those aren't top-level exports, so when call sites for one can't be confirmed, the response widens `dependentCount`/`riskLevel` to the file-level answer (every file that imports `filepath`) rather than asserting an unverifiable symbol-scoped count. The unconfirmed symbol may genuinely be a method/constructor, or it may be a typo'd/hallucinated/removed name — the `note` field says which.
+- **`dependent-attribution-partial`** — a file-level query (no `symbol`) found zero import-based dependents, but a lower-confidence text-matching fallback (matching a uniquely-declared type name against other files' source text — today only for C#) recovered one or more dependents anyway. Those entries carry `confidence: "inferred"` in `dependents[]`. Treat `dependentCount`/`riskLevel` as a recovered floor, not a verified/complete answer — the fallback can still miss a real dependent reached via an alias, a generic type argument, or reflection.
+- **`dependent-attribution-incomplete`** — a file-level query (no `symbol`) found zero dependents in a language where the import graph structurally can't see every real usage — C#'s enclosing-namespace access, where a `global using` lets a real caller reach `filepath`'s exports with no per-file import at all (#930) — even after the `dependent-attribution-partial` fallback above also found nothing. `dependentCount: 0` / `riskLevel: "low"` here means "the import graph found nothing," not "nothing depends on this file."
 
 At most one reason ever applies to a given response. Always check for `attributionCaveat` before treating a low (especially zero) `dependentCount` as a verified all-clear.
 


### PR DESCRIPTION
## Summary

`get_dependents`'s `attributionCaveat.reason` explanation was hand-written at five model-facing surfaces. #941 wrote it into three at once; #951 fixed two and needed a second sub-commit for the third. Two surfaces were never revisited and were wrong at HEAD:

- `packages/cli/src/mcp/schemas/dependents.schema.ts` (`symbol` field description, read by every MCP client on connect) still had the pre-#951 unhedged wording for `symbol-attribution-degraded` — no mention that the symbol may be a typo/hallucinated/removed name rather than always a real method/constructor.
- `packages/cli/src/mcp/handlers/get-dependents.ts`'s `AttributionCaveatReason` JSDoc had the same unhedged gap (dev-facing).
- `packages/site/docs/guide/mcp-tools.md` said `reason` is "one of" a list, then named only **three** of the four members — `dependent-attribution-partial` (added by #930) appeared **zero times** in the file, leaving no documented way to interpret `confidence: "inferred"` entries.

## Fix

Rather than re-wording five places by hand again (which is exactly how this happened three times), added `packages/cli/src/mcp/attribution-caveat-reasons.ts` as the single source: one canonical, hedged sentence per reason in `ATTRIBUTION_CAVEAT_REASON_TEXT: Record<AttributionCaveatReason, string>` — the `Record` type means the compiler rejects the object literal if a reason is ever added to the union without adding its text here. `tools.ts`, `instructions.ts`, and `dependents.schema.ts` now interpolate this text instead of hand-writing the explanation. `handlers/get-dependents.ts`'s doc comment (a JSDoc comment can't interpolate a runtime value) now points back at the shared module instead of re-deriving the wording, with the hedge fixed inline too.

The docs page got the missing fourth reason added with accurate wording, and the (already-present) `symbol-attribution-degraded` entry there also got the same hedge fix.

### Consolidated wording, as it now renders on each surface

**`unresolved-target`**
> filepath isn't resolvable in the index at all (never indexed, misspelled, or a typo'd directory prefix) — every count in the response is a deliberate 0, not a confirmed empty dependency graph. Try search_code or list_functions to find the real path, or run "lien index" if the file was added recently.

**`symbol-attribution-degraded`**
> symbol isn't a top-level export and its call sites couldn't be confirmed — it may be a real method/constructor, or it may be a typo'd/hallucinated/removed name (the note says which); either way, dependentCount/riskLevel/dependents become the file-level answer (every file that imports filepath), not a verified count for symbol itself.

**`dependent-attribution-partial`**
> a file-level query (no symbol) found zero import-based dependents, but a lower-confidence text-matching fallback recovered some dependents anyway (those entries carry confidence: "inferred"). Treat the counts as a recovered floor, not a complete answer — the fallback can still miss a real dependent reached via an alias, a generic type argument, or reflection.

**`dependent-attribution-incomplete`**
> a file-level query (no symbol) came back with zero dependents in a language where the import graph structurally can't see every real usage (e.g. C#'s global using / implicit enclosing-namespace access), even after the text-matching fallback above also found nothing. Treat dependentCount: 0 and riskLevel: "low" as a floor, not a finding — verify with grep before concluding the file is unused.

Verified by directly importing each surface (`tsx -e "..."`) and printing its rendered text, not just reading source.

## The test that would have caught it

Added `packages/cli/src/mcp/attribution-caveat-reasons.test.ts`: for every member of `AttributionCaveatReason`, asserts it's mentioned in the docs page, `SERVER_INSTRUCTIONS`, and the `get_dependents` tool description. The repo's "Docs Truth" CI check and its docs-drift review pass both check *accuracy* of existing prose, not *completeness* against the union — neither caught the missing `dependent-attribution-partial` in the docs page. This test fails loudly the next time a reason is added anywhere it isn't documented.

## Gates

- `npm run format:check` — pass
- `npm run lint` — 0 errors (pre-existing warnings only, none in touched files)
- `npm run typecheck` — pass
- `npm run build` — pass
- `npm test` — 5217 passed (baseline 5204 + 13 new tests in `attribution-caveat-reasons.test.ts`)
- `node packages/cli/dist/index.js delta` — exit 0, no new crossings
- `npm run docs:build` — pass; read the rendered `guide/mcp-tools.html` output directly and confirmed all four reasons render with the corrected wording

## Changeset

`.changeset/attribution-caveat-reason-prose.md` — patch on `@liendev/lien` (shipped tool/schema/instructions text changed). `packages/site` is private, no changeset needed there.

Closes #980

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR consolidates the `get_dependents` attribution-caveat prose into a single source-of-truth module (`attribution-caveat-reasons.ts`) and interpolates it into the tool description, server instructions, and JSON schema. It also fixes the public docs page to include the previously-missing `dependent-attribution-partial` reason and adds a completeness test. The type move from `handlers/get-dependents.ts` is handled via a re-export, so existing callers are preserved. No runtime logic was changed; the risk is limited to documentation/test surface area.
>
> - Created `packages/cli/src/mcp/attribution-caveat-reasons.ts` as the single source for `AttributionCaveatReason` and `ATTRIBUTION_CAVEAT_REASON_TEXT`
> - Updated `tools.ts`, `instructions.ts`, and `dependents.schema.ts` to interpolate shared prose instead of hand-writing it
> - Added `attribution-caveat-reasons.test.ts` asserting every reason appears in docs, instructions, and tool description
> - Fixed `packages/site/docs/guide/mcp-tools.md` to document all four reasons with hedged wording

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 20dd5e3. Updates automatically on new commits.</sup>
<!-- /lien-stats -->