### PR TITLE
fix(parser): Java interface private/protected methods are exported (+ Kotlin/Swift sweep)

### DIFF
--- a/.changeset/java-kotlin-swift-interface-private-members.md
+++ b/.changeset/java-kotlin-swift-interface-private-members.md
@@ -1,0 +1,56 @@
+---
+"@liendev/parser": patch
+---
+
+Fix `extractExports()` exporting explicitly non-public interface/protocol
+members in Java and Kotlin, and dropping a redundant, buggy bypass with the
+same shape in Swift (#974).
+
+`java.ts`'s `extractMemberExport` used `if (isInterface || hasPublicModifier(member))`
+— when `isInterface` is true the `||` short-circuits, so `hasPublicModifier`
+is never evaluated and every `method_declaration`/`constructor_declaration`
+in an interface body was exported, including explicitly `private` ones.
+Java 9+ permits `private` interface methods (helpers backing a `default`
+method), so this was reachable in real code:
+`public interface Repository { void save(); private void helper() {} }`
+returned `['Repository', 'save', 'helper']` — `helper` should not be there.
+
+`csharp.ts` already had the correct guard (`hasExplicitAccessModifier`,
+gating an "implicitly public" fallback to only apply when the member carries
+no explicit access modifier). Ported the same shape to `java.ts` (Java's
+modifiers are `public`/`private`/`protected` — no `internal`, unlike C#).
+
+Swept every other language whose extractor handles interfaces/protocols for
+the same defect shape ("one decision, N language files, fixed at fewer than
+N"):
+
+- **Kotlin**: same bug (`isInterface || isExported(member)`), reachable —
+  Kotlin 1.4+ allows `private` interface members. Fixed by dropping the
+  `isInterface` bypass entirely: `isExported`'s existing "public unless
+  explicitly private/internal" rule already matches interface-member
+  visibility exactly, so the bypass was both redundant for the correct case
+  (no modifier) and wrong for the explicitly-private case — no separate
+  C#-style helper was needed.
+- **Swift**: same shape (`isProtocol || isExported(member)`). `private`/
+  `fileprivate` aren't valid Swift on a real protocol requirement, but the
+  `tree-sitter-swift` grammar still parses them, so the extractor could still
+  mis-export one from malformed/non-compiling input. Fixed the same way as
+  Kotlin (dropped the bypass, relying on `isExported`) for defense in depth
+  and consistency, even though it's not reachable from valid, compiling
+  Swift.
+- **C#**: already correct (the reference implementation for this fix).
+- **Go, Rust, PHP, TypeScript/JavaScript, Python, Ruby**: verified
+  architecturally unaffected — none of them export interface/trait/protocol
+  members individually via an `isInterface`-style bypass at all. Go and Rust
+  gate purely on identifier capitalization / a `pub`/visibility-modifier
+  check at the container level and never dig into interface/trait bodies to
+  export member names separately; PHP and TypeScript/JavaScript only export
+  whole top-level declarations (PHP also can't have non-public interface
+  methods at all); Python has no interface-like construct in the export
+  extractor; Ruby's `private`/`protected` are runtime calls, not per-
+  declaration modifiers the extractor inspects.
+
+Added the C#-style regression test ("should not export explicitly non-public
+interface members") to `java.test.ts` and `kotlin.test.ts`, and the protocol
+equivalent to `swift.test.ts` — confirmed each fails on the pre-fix code and
+passes after.

--- a/packages/parser/src/ast/languages/java.test.ts
+++ b/packages/parser/src/ast/languages/java.test.ts
@@ -154,6 +154,22 @@ describe('Java Language', () => {
       expect(exports).toContain('delete');
     });
 
+    it('should not export explicitly non-public interface members', () => {
+      // Java 9+ allows `private` interface methods (helper methods backing a
+      // `default` method); `protected` is not legal on an interface member
+      // (JLS 9.4) so it isn't exercised here.
+      const code = `public interface Repository {
+    void save();
+    private void helper() {}
+    private static void staticHelper() {}
+}`;
+      const root = mustParse(code, 'java');
+      const exports = exportExtractor.extractExports(root);
+      expect(exports).toContain('save');
+      expect(exports).not.toContain('helper');
+      expect(exports).not.toContain('staticHelper');
+    });
+
     it('should extract public enum', () => {
       const code = 'public enum Status { ACTIVE, INACTIVE }';
       const root = mustParse(code, 'java');

--- a/packages/parser/src/ast/languages/java.ts
+++ b/packages/parser/src/ast/languages/java.ts
@@ -164,7 +164,12 @@ export class JavaExportExtractor implements LanguageExportExtractor {
     addExport: (name: string) => void,
   ): void {
     if (member.type === 'method_declaration' || member.type === 'constructor_declaration') {
-      if (isInterface || hasPublicModifier(member)) {
+      // Interface members without explicit modifiers are implicitly public.
+      // Java 9+ allows private interface methods (helpers for `default` methods)
+      // — only export those that are public or have no explicit visibility
+      // modifier (#974).
+      const isImplicitlyPublic = isInterface && !hasExplicitAccessModifier(member);
+      if (isImplicitlyPublic || hasPublicModifier(member)) {
         const nameNode = member.childForFieldName('name');
         if (nameNode) addExport(nameNode.text);
       }
@@ -508,6 +513,20 @@ function hasPublicModifier(node: SyntaxNode): boolean {
   const modifiers = node.children.find(child => child.type === 'modifiers');
   if (!modifiers) return false;
   return modifiers.children.some(child => child.type === 'public');
+}
+
+const ACCESS_MODIFIER_TYPES = new Set(['public', 'private', 'protected']);
+
+/**
+ * Check if a node has any explicit access modifier (public, private, protected).
+ * Java has no `internal` modifier (unlike C#). Used to distinguish implicit
+ * public interface members from explicitly non-public ones (Java 9+ private
+ * interface methods).
+ */
+function hasExplicitAccessModifier(node: SyntaxNode): boolean {
+  const modifiers = node.children.find(child => child.type === 'modifiers');
+  if (!modifiers) return false;
+  return modifiers.children.some(child => ACCESS_MODIFIER_TYPES.has(child.type));
 }
 
 /**

--- a/packages/parser/src/ast/languages/kotlin.test.ts
+++ b/packages/parser/src/ast/languages/kotlin.test.ts
@@ -106,6 +106,16 @@ describe('Kotlin Language', () => {
       expect(exports).toContain('find');
     });
 
+    it('should not export explicitly non-public interface members', () => {
+      // Kotlin 1.4+ allows `private` interface members (helper functions
+      // backing a default implementation) — only export those that are
+      // public or have no explicit visibility modifier (#974).
+      const root = parse('interface Repo {\n  fun find(): String\n  private fun helper() {}\n}\n');
+      const exports = exportExtractor.extractExports(root);
+      expect(exports).toContain('find');
+      expect(exports).not.toContain('helper');
+    });
+
     it('does not export members of a private container', () => {
       const root = parse('private class Secret {\n  fun internalApi() {}\n}\n');
       const exports = exportExtractor.extractExports(root);

--- a/packages/parser/src/ast/languages/kotlin.ts
+++ b/packages/parser/src/ast/languages/kotlin.ts
@@ -269,13 +269,18 @@ export class KotlinExportExtractor implements LanguageExportExtractor {
     const body = childByType(container, 'class_body') ?? childByType(container, 'enum_class_body');
     if (!body) return;
 
-    const isInterface = hasTokenChild(container, 'interface');
-
+    // `isExported`'s "public unless explicitly private/internal" rule already
+    // matches interface-member visibility exactly (Kotlin interface members
+    // support only `public` (implicit or explicit) and `private` — Kotlin 1.4+
+    // allows `private` helper functions backing a default implementation), so
+    // no separate interface bypass is needed here (#974 — Java's and this
+    // file's prior `isInterface ||` bypass unconditionally exported every
+    // interface member, including explicitly `private` ones).
     body.namedChildren.forEach(member => {
       if (member.type === 'function_declaration') {
-        if (isInterface || isExported(member)) addExport(functionName(member));
+        if (isExported(member)) addExport(functionName(member));
       } else if (member.type === 'property_declaration') {
-        if (isInterface || isExported(member)) addExport(this.propertyName(member));
+        if (isExported(member)) addExport(this.propertyName(member));
       } else if (member.type === 'companion_object') {
         // Companion members are reached via the enclosing class name → part of its API.
         member.namedChildren

--- a/packages/parser/src/ast/languages/swift.test.ts
+++ b/packages/parser/src/ast/languages/swift.test.ts
@@ -112,6 +112,16 @@ describe('Swift Language', () => {
       expect(exports).toContain('find');
     });
 
+    it('should not export explicitly non-public protocol members', () => {
+      // `private`/`fileprivate` aren't valid on a real protocol requirement,
+      // but the grammar still parses them — the extractor must not export
+      // them regardless (#974).
+      const root = parse('protocol Repo {\n  func find() -> String\n  private func helper()\n}\n');
+      const exports = exportExtractor.extractExports(root);
+      expect(exports).toContain('find');
+      expect(exports).not.toContain('helper');
+    });
+
     it('does not export members of a private container', () => {
       const root = parse('private struct Secret {\n  func internalApi() {}\n}\n');
       const exports = exportExtractor.extractExports(root);

--- a/packages/parser/src/ast/languages/swift.ts
+++ b/packages/parser/src/ast/languages/swift.ts
@@ -264,9 +264,15 @@ export class SwiftExportExtractor implements LanguageExportExtractor {
     const body = container.childForFieldName('body');
     if (!body) return;
 
-    // Protocol members are implicitly part of the protocol's surface.
-    const isProtocol = container.type === 'protocol_declaration';
-
+    // `isExported`'s "part of the surface unless explicitly private/
+    // fileprivate" rule already matches protocol-member visibility exactly
+    // (a `private`/`fileprivate` protocol requirement isn't valid Swift, but
+    // the grammar still parses it, and Swift only forbids restricting below
+    // the protocol's own access level — it doesn't forbid a requirement from
+    // carrying its own explicit, non-restrictive modifier), so no separate
+    // protocol bypass is needed here (#974 — Java's and this file's prior
+    // `isProtocol ||` bypass unconditionally exported every protocol member,
+    // including explicitly `private`/`fileprivate` ones).
     body.namedChildren.forEach(member => {
       switch (member.type) {
         case 'function_declaration':
@@ -274,11 +280,11 @@ export class SwiftExportExtractor implements LanguageExportExtractor {
         case 'init_declaration':
         case 'deinit_declaration':
         case 'subscript_declaration':
-          if (isProtocol || isExported(member)) addExport(functionLikeName(member));
+          if (isExported(member)) addExport(functionLikeName(member));
           break;
         case 'property_declaration':
         case 'protocol_property_declaration':
-          if (isProtocol || isExported(member)) addExport(propertyName(member));
+          if (isExported(member)) addExport(propertyName(member));
           break;
         case 'class_declaration':
         case 'protocol_declaration':


### PR DESCRIPTION
## The bug

`packages/parser/src/ast/languages/java.ts:167` used `if (isInterface || hasPublicModifier(member))`. The `||` short-circuits when `isInterface` is true, so `hasPublicModifier` is never evaluated and **every** `method_declaration`/`constructor_declaration` in an interface body was exported — including explicitly `private` ones. Java 9+ permits `private` interface methods (helpers backing a `default` method), so this is reachable in real code.

`csharp.ts` already had the correct guard (`hasExplicitAccessModifier`, gating the "implicitly public" fallback to only apply when the member carries no explicit access modifier) — that check didn't exist in `java.ts`. This PR ports the same shape to Java.

## Fix

- **Java**: added `hasExplicitAccessModifier` (public/private/protected — no `internal`, unlike C#) and gated the interface implicit-public fallback on it, mirroring `csharp.ts` exactly.
- **Kotlin**: same bug (`isInterface || isExported(member)`), reachable since Kotlin 1.4+ allows `private` interface members. Fixed by **dropping the bypass entirely** — `isExported`'s existing "public unless explicitly private/internal" rule already matches interface-member visibility exactly (no modifier → exported; `private` → not exported), so the bypass was redundant for the correct case and wrong for the buggy one. Simpler fix than porting a C#-style helper, and it also reduces complexity (see gate 6 below).
- **Swift**: same shape (`isProtocol || isExported(member)`). `private`/`fileprivate` aren't valid on a real Swift protocol requirement (compile error), but `tree-sitter-swift`'s grammar still parses them syntactically, so the extractor could still mis-export one from malformed/non-compiling input. Fixed the same way as Kotlin (dropped the bypass) for defense-in-depth and consistency, even though not reachable from valid, compiling Swift.

## Cross-language sweep (this repo's recurring defect shape: one decision, N language files, fixed at fewer than N)

| Language | Verdict | How verified |
|---|---|---|
| Java | **Fixed** (confirmed reachable, Java 9+ private interface methods) | AST dump + regression test |
| C# | Already correct | Reference implementation (`hasExplicitAccessModifier`, `csharp.test.ts:179-190`) |
| Kotlin | **Fixed** (confirmed reachable, Kotlin 1.4+ private interface members) | AST dump + regression test |
| Swift | **Fixed** (same buggy shape present, but not reachable from valid Swift — `private`/`fileprivate` on a protocol requirement is a compile error) | AST dump (grammar parses it anyway) + regression test |
| Go | Not affected | Export extractor gates purely on identifier capitalization at the container level; never digs into `interface_type` bodies to export member names individually |
| Rust | Not affected | Export extractor only exports top-level `pub` items; never recurses into `trait_item` bodies to export trait method names individually (trait items can't carry independent visibility from the trait itself anyway) |
| PHP | Not affected | Export extractor only exports whole top-level declaration names (class/trait/interface/function); doesn't dig into method bodies at all. Also, PHP itself forbids non-public interface methods |
| TypeScript/JavaScript | Not affected | Export extraction is `export`-statement-level; doesn't export interface members individually at all |
| Python | Not affected | No interface-like construct in the export extractor |
| Ruby | Not affected | `private`/`protected` are runtime method calls, not per-declaration modifiers the extractor inspects; no `isInterface`-style bypass exists |

## Test evidence (failing before, passing after)

**Java** (`java.test.ts`, new test `should not export explicitly non-public interface members`):
```
FAIL src/ast/languages/java.test.ts > Java Language > Export Extraction > should not export explicitly non-public interface members
AssertionError: expected [ Array(4) ] to not include 'helper'
```
After the fix: all 66 tests in `java.test.ts` pass.

**Kotlin** (`kotlin.test.ts`, new test `should not export explicitly non-public interface members`):
```
FAIL src/ast/languages/kotlin.test.ts > Kotlin Language > Export Extraction > should not export explicitly non-public interface members
AssertionError: expected [ 'Repo', 'find', 'helper' ] to not include 'helper'
```
After the fix: all 34 tests in `kotlin.test.ts` pass.

**Swift** (`swift.test.ts`, new test `should not export explicitly non-public protocol members`):
```
FAIL src/ast/languages/swift.test.ts > Swift Language > Export Extraction > should not export explicitly non-public protocol members
AssertionError: expected [ 'Repo', 'find', 'helper' ] to not include 'helper'
```
After the fix: all 36 tests in `swift.test.ts` pass.

Each was verified by stashing just that language's source-file fix (test file kept), confirming the FAIL above, then restoring the fix and confirming PASS.

## Gate results

```
npm run format:check   ✅ All matched files use Prettier code style
npm run lint           ✅ 0 errors (38 pre-existing warnings, none in touched files)
npm run typecheck      ✅ 0 errors
npm run build          ✅ all packages build
npm test               ✅ 5207 passed (68 test files across cli/core/parser/review/action;
                          baseline 5204 + 3 new regression tests)
lien delta             ✅ exit 0
```

`lien delta` output:
```
packages/parser/src/ast/languages/java.ts
  ⚠ worsened  JavaExportExtractor.extractMemberExport cognitive 10 → 11
  · new       hasExplicitAccessModifier cognitive – → 1

packages/parser/src/ast/languages/kotlin.ts
  ⚠ pre-exist KotlinExportExtractor.extractMembers cognitive 21 → 19

packages/parser/src/ast/languages/swift.ts
  ✓ improved  SwiftExportExtractor.extractMembers cognitive 8 → 6

⚠ 1 worsened · ✓ 1 improved · 6 files · 132 ms
```
No new-over-threshold or crossed function — the Java "worsened" line stays under threshold, and the Kotlin/Swift changes simplify existing pre-existing-violation functions rather than adding to them.

## E2E (real open-source projects)

```
npm run test:e2e:java   -w packages/cli   ✅ 14 passed (JavaPoet, 43 files)
npm run test:e2e:kotlin -w packages/cli   ✅ 14 passed (Klaxon, 103 files)
npm run test:e2e:swift  -w packages/cli   ✅ 14 passed (SwiftyJSON, 27 files)
```

## Changeset

Added `.changeset/java-kotlin-swift-interface-private-members.md` (`@liendev/parser` patch) since `packages/parser` is published.

Closes #974

---

<!-- lien-stats -->
### Lien Review

✅ **Improved!** Complexity reduced by 18. 1 pre-existing issue remains in touched files.
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | -2 |


> [!NOTE]
> **Low Risk**
>
> This PR fixes a real bug where Java/Kotlin/Swift export extractors unconditionally exported every interface/protocol member due to an `isInterface || isExported(member)` short-circuit, leaking private interface methods into the public API surface. The fixes are well-scoped: Java mirrors the existing C# `hasExplicitAccessModifier` guard, while Kotlin and Swift drop the redundant bypass and rely on their existing `isExported` visibility checks. All three changes are covered by regression tests, and the cross-language sweep correctly identifies the remaining languages as architecturally unaffected.
>
> - Java: added hasExplicitAccessModifier and gated interface implicit-public fallback on it
> - Kotlin/Swift: removed the isInterface/isProtocol bypass so private members are no longer exported
> - Added regression tests for all three languages

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 9117bc4. Updates automatically on new commits.</sup>
<!-- /lien-stats -->