### PR TITLE
fix(parser): include heritage/generics in type signature for Python, PHP, Go

### DIFF
--- a/.changeset/type-signature-heritage-py-php-go.md
+++ b/.changeset/type-signature-heritage-py-php-go.md
@@ -7,8 +7,9 @@ parameters and the heritage clause (base class / interface list) — #965
 recurring in the three languages that fix missed (#976).
 
 - Python: `class Dog(Animal, Serializable):` reported `signature: "class Dog"`;
-  now `"class Dog(Animal, Serializable)"`. Also covers PEP 695 generics
-  (`class Box[T](Base):` → `"class Box[T](Base)"`).
+  now `"class Dog(Animal, Serializable)"`. PEP 695 generics are also
+  covered — a generic class with a base class keeps both its type
+  parameter and its base in the signature.
 - PHP: `class Dog extends Animal implements Serializable {}` reported
   `"class Dog"`; now `"class Dog extends Animal implements Serializable"`.
 - Go: `type Stack[T any] struct { items []T }` reported `"type Stack struct"`;

--- a/.changeset/type-signature-heritage-py-php-go.md
+++ b/.changeset/type-signature-heritage-py-php-go.md
@@ -1,0 +1,34 @@
+---
+"@liendev/parser": patch
+---
+
+Fix `signature` for Python/PHP/Go type declarations dropping generic type
+parameters and the heritage clause (base class / interface list) — #965
+recurring in the three languages that fix missed (#976).
+
+- Python: `class Dog(Animal, Serializable):` reported `signature: "class Dog"`;
+  now `"class Dog(Animal, Serializable)"`. Also covers PEP 695 generics
+  (`class Box[T](Base):` → `"class Box[T](Base)"`).
+- PHP: `class Dog extends Animal implements Serializable {}` reported
+  `"class Dog"`; now `"class Dog extends Animal implements Serializable"`.
+- Go: `type Stack[T any] struct { items []T }` reported `"type Stack struct"`;
+  now `"type Stack[T any] struct"`.
+
+Six languages (C#, Java, Kotlin, Swift, JS/TS, Rust's impl/trait blocks)
+already had this via their own `typeParamsAndX`-shaped helper, each
+explicitly documented as "the <language> analog of C#'s
+`typeParamsAndBaseList`" — the clearest possible signal the underlying rule
+should be asserted once. A new cross-language test
+(`type-declaration-signature.test.ts`) now asserts, for every language with
+a type-level symbol extractor, that a declaration exercising whichever of
+{generics, heritage} its grammar supports round-trips into `signature` —
+so a future language can't silently reintroduce this gap.
+
+Verified against real OSS source (not just synthetic snippets): Monolog's
+`FilterHandler` (PHP, 3-interface `implements` clause), Requests' `Session`
+(Python, mixin base class), and samber/lo's `switchCase[T comparable, R any]`
+(Go, two-parameter generic struct) all now report their full signature.
+
+Out of scope: Rust's `struct_item`/`enum_item` aren't symbol-extracted at
+all yet (only `impl_item`/`trait_item`, via the differently-shaped
+`extractImplInfo`) — a bigger gap tracked separately, not fixed here.

--- a/packages/parser/src/ast/languages/go.test.ts
+++ b/packages/parser/src/ast/languages/go.test.ts
@@ -506,6 +506,30 @@ import (
       expect(symbol!.signature).toBe('type Container[T any] interface');
     });
 
+    // A long type-parameter list can now push a struct/interface signature
+    // past clampSignatureLength's 200-char limit, now that the type
+    // parameters are included at all — every sibling branch (and every
+    // other language's type-declaration signature) already clamps.
+    it('should clamp a struct signature with a long generic type-parameter list', () => {
+      const names = [
+        'AAAAAAAAAAAAAAAAAAAA',
+        'BBBBBBBBBBBBBBBBBBBB',
+        'CCCCCCCCCCCCCCCCCCCC',
+        'DDDDDDDDDDDDDDDDDDDD',
+        'EEEEEEEEEEEEEEEEEEEE',
+        'FFFFFFFFFFFFFFFFFFFF',
+        'GGGGGGGGGGGGGGGGGGGG',
+        'HHHHHHHHHHHHHHHHHHHH',
+      ];
+      const typeParams = names.map(n => `${n} any`).join(', ');
+      const code = `package main\ntype Stack[${typeParams}] struct { items []int }`;
+      const root = mustParse(code, 'go');
+      const typeNode = root.namedChild(1)!;
+      const symbol = symbolExtractor.extractSymbol(typeNode, code);
+      expect(symbol!.signature.length).toBe(200);
+      expect(symbol!.signature.endsWith('...')).toBe(true);
+    });
+
     it('should extract return type from result field', () => {
       const code = 'package main\nfunc GetName() string { return "" }';
       const root = mustParse(code, 'go');

--- a/packages/parser/src/ast/languages/go.test.ts
+++ b/packages/parser/src/ast/languages/go.test.ts
@@ -487,6 +487,25 @@ import (
       expect(symbol!.signature).toBe('type Validator interface');
     });
 
+    // #976 (#965 recurring): `signature` dropped generic type parameters
+    // entirely — `type Stack[T any] struct { items []T }` came back as bare
+    // `type Stack struct`, the single most useful fact about the type.
+    it('should include generic type parameters in a struct signature', () => {
+      const code = 'package main\ntype Stack[T any] struct { items []T }';
+      const root = mustParse(code, 'go');
+      const typeNode = root.namedChild(1)!;
+      const symbol = symbolExtractor.extractSymbol(typeNode, code);
+      expect(symbol!.signature).toBe('type Stack[T any] struct');
+    });
+
+    it('should include generic type parameters in an interface signature', () => {
+      const code = 'package main\ntype Container[T any] interface { Get() T }';
+      const root = mustParse(code, 'go');
+      const typeNode = root.namedChild(1)!;
+      const symbol = symbolExtractor.extractSymbol(typeNode, code);
+      expect(symbol!.signature).toBe('type Container[T any] interface');
+    });
+
     it('should extract return type from result field', () => {
       const code = 'package main\nfunc GetName() string { return "" }';
       const root = mustParse(code, 'go');

--- a/packages/parser/src/ast/languages/go.ts
+++ b/packages/parser/src/ast/languages/go.ts
@@ -10,6 +10,7 @@ import {
   extractSignature,
   extractParameters,
   collapseWhitespace,
+  clampSignatureLength,
 } from '../extractors/symbol-helpers.js';
 import { calculateComplexity } from '../complexity/index.js';
 
@@ -388,13 +389,13 @@ export class GoSymbolExtractor implements LanguageSymbolExtractor {
     // Use concise keyword for struct/interface, actual type text for aliases/maps/etc.
     let signature: string;
     if (typeNode?.type === 'struct_type') {
-      signature = `type ${nameNode.text}${typeParams} struct`;
+      signature = clampSignatureLength(`type ${nameNode.text}${typeParams} struct`);
     } else if (typeNode?.type === 'interface_type') {
-      signature = `type ${nameNode.text}${typeParams} interface`;
+      signature = clampSignatureLength(`type ${nameNode.text}${typeParams} interface`);
     } else if (typeNode) {
-      signature = `type ${nameNode.text}${typeParams} ${typeNode.text}`;
+      signature = clampSignatureLength(`type ${nameNode.text}${typeParams} ${typeNode.text}`);
     } else {
-      signature = `type ${nameNode.text}${typeParams}`;
+      signature = clampSignatureLength(`type ${nameNode.text}${typeParams}`);
     }
 
     return {

--- a/packages/parser/src/ast/languages/go.ts
+++ b/packages/parser/src/ast/languages/go.ts
@@ -6,7 +6,11 @@ import type {
   LanguageImportExtractor,
   LanguageSymbolExtractor,
 } from '../extractors/types.js';
-import { extractSignature, extractParameters } from '../extractors/symbol-helpers.js';
+import {
+  extractSignature,
+  extractParameters,
+  collapseWhitespace,
+} from '../extractors/symbol-helpers.js';
 import { calculateComplexity } from '../complexity/index.js';
 
 // =============================================================================
@@ -379,17 +383,18 @@ export class GoSymbolExtractor implements LanguageSymbolExtractor {
     if (!nameNode) return null;
 
     const symbolType = typeNode?.type === 'interface_type' ? 'interface' : 'class';
+    const typeParams = typeParamsClause(typeSpec);
 
     // Use concise keyword for struct/interface, actual type text for aliases/maps/etc.
     let signature: string;
     if (typeNode?.type === 'struct_type') {
-      signature = `type ${nameNode.text} struct`;
+      signature = `type ${nameNode.text}${typeParams} struct`;
     } else if (typeNode?.type === 'interface_type') {
-      signature = `type ${nameNode.text} interface`;
+      signature = `type ${nameNode.text}${typeParams} interface`;
     } else if (typeNode) {
-      signature = `type ${nameNode.text} ${typeNode.text}`;
+      signature = `type ${nameNode.text}${typeParams} ${typeNode.text}`;
     } else {
-      signature = `type ${nameNode.text}`;
+      signature = `type ${nameNode.text}${typeParams}`;
     }
 
     return {
@@ -405,6 +410,28 @@ export class GoSymbolExtractor implements LanguageSymbolExtractor {
 // =============================================================================
 // HELPERS
 // =============================================================================
+
+/**
+ * Generic type parameters, exactly as declared in source — the Go analog of
+ * C#'s `typeParamsAndBaseList`/Java's `typeParamsAndHeritage` (same
+ * underlying bug: `signature` for a type declaration reported only its bare
+ * keyword and name, dropping `[T any]` entirely — #976, #965 recurring).
+ * Unlike the C#/Java/Kotlin/Swift/JS analogs this only extracts the
+ * type-parameters half: Go structs/interfaces have no heritage clause
+ * (`extends`/`implements`) — composition is via embedded fields/interfaces,
+ * a structural concept distinct from the nominal inheritance those
+ * languages express as part of a type's declaration head. `type_parameters`
+ * is a registered field on `type_spec` (Go 1.18+ generics), concatenated
+ * directly onto the name with no separator since that matches the source
+ * exactly (`Stack[T any]`, no space before `[`).
+ *
+ * Whitespace is collapsed to a single line (matching `extractSignature`'s
+ * convention, see `collapseWhitespace`) in case it spans multiple physical
+ * lines.
+ */
+function typeParamsClause(typeSpec: SyntaxNode): string {
+  return collapseWhitespace(typeSpec.childForFieldName('type_parameters')?.text);
+}
 
 /**
  * Check if a Go identifier is exported (starts with uppercase).

--- a/packages/parser/src/ast/languages/php.test.ts
+++ b/packages/parser/src/ast/languages/php.test.ts
@@ -454,6 +454,19 @@ class User {
       }
     });
 
+    // #976 (#965 recurring): `signature` dropped the extends/implements
+    // heritage clause entirely — `class Dog extends Animal implements
+    // Serializable {}` came back as bare `class Dog`, the single most
+    // useful fact about the class.
+    it('should include the extends/implements heritage clause in a class signature', () => {
+      const code = '<?php\nclass Dog extends Animal implements Serializable {}';
+      const root = mustParse(code, 'php');
+      const classNode = root.namedChildren.find(child => child.type === 'class_declaration');
+      expect(classNode).not.toBeUndefined();
+      const symbol = symbolExtractor.extractSymbol(classNode!, code);
+      expect(symbol!.signature).toBe('class Dog extends Animal implements Serializable');
+    });
+
     it('should extract call site from function call', () => {
       const code = '<?php\nhelper();';
       const root = mustParse(code, 'php');

--- a/packages/parser/src/ast/languages/php.ts
+++ b/packages/parser/src/ast/languages/php.ts
@@ -11,6 +11,8 @@ import {
   extractSignature,
   extractParameters,
   extractReturnType,
+  clampSignatureLength,
+  collapseWhitespace,
 } from '../extractors/symbol-helpers.js';
 import { calculateComplexity } from '../complexity/index.js';
 
@@ -475,9 +477,41 @@ export class PHPSymbolExtractor implements LanguageSymbolExtractor {
       type: 'class',
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
-      signature: `class ${nameNode.text}`,
+      signature: clampSignatureLength(`class ${nameNode.text}${heritageClause(node)}`),
     };
   }
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+/**
+ * Extends/implements heritage clause, exactly as declared in source — the
+ * PHP analog of C#'s `typeParamsAndBaseList`/Java's `typeParamsAndHeritage`
+ * (same underlying bug: `signature` for a class reported only its bare
+ * keyword and name, dropping `extends Animal implements Serializable`
+ * entirely — #976, #965 recurring). PHP has no generic type parameters, so
+ * unlike the C#/Java/Kotlin/Swift/JS analogs this only extracts the
+ * heritage half. Neither `base_clause` (single class, `extends Animal`) nor
+ * `class_interface_clause` (`implements Serializable, ...`) is a registered
+ * grammar field on `class_declaration` (only `name`/`body`/`attributes`
+ * are), so both are found by scanning `namedChildren`, mirroring C#/Java's
+ * fallback-scan case.
+ *
+ * Whitespace is collapsed to a single line (matching `extractSignature`'s
+ * convention, see `collapseWhitespace`) in case either clause spans
+ * multiple physical lines.
+ */
+function heritageClause(node: SyntaxNode): string {
+  const baseClause = collapseWhitespace(
+    node.namedChildren.find(child => child.type === 'base_clause')?.text,
+  );
+  const interfaceClause = collapseWhitespace(
+    node.namedChildren.find(child => child.type === 'class_interface_clause')?.text,
+  );
+  const heritage = [baseClause, interfaceClause].filter(Boolean).join(' ');
+  return heritage ? ` ${heritage}` : '';
 }
 
 // =============================================================================

--- a/packages/parser/src/ast/languages/python.test.ts
+++ b/packages/parser/src/ast/languages/python.test.ts
@@ -437,6 +437,26 @@ describe('Python Language', () => {
       expect(symbol!.signature).toBe('class Calculator');
     });
 
+    // #976 (#965 recurring): `signature` dropped the base-class list
+    // entirely — `class Dog(Animal, Serializable):` came back as bare
+    // `class Dog`, the single most useful fact about the class.
+    it('should include the base-class list in a class signature', () => {
+      const code = 'class Dog(Animal, Serializable):\n    pass\n';
+      const root = mustParse(code, 'python');
+      const classNode = root.namedChild(0)!;
+      const symbol = symbolExtractor.extractSymbol(classNode, code);
+      expect(symbol!.signature).toBe('class Dog(Animal, Serializable)');
+    });
+
+    // PEP 695 (Python 3.12+) generic class syntax.
+    it('should include generic type parameters and base classes in a class signature', () => {
+      const code = 'class Box[T](Base, Serializable):\n    pass\n';
+      const root = mustParse(code, 'python');
+      const classNode = root.namedChild(0)!;
+      const symbol = symbolExtractor.extractSymbol(classNode, code);
+      expect(symbol!.signature).toBe('class Box[T](Base, Serializable)');
+    });
+
     // #949: a nested class declared directly inside another class's body
     // previously reported parentClass: undefined regardless of nesting —
     // extractClassInfo didn't accept the parameter at all, even though

--- a/packages/parser/src/ast/languages/python.ts
+++ b/packages/parser/src/ast/languages/python.ts
@@ -11,6 +11,7 @@ import {
   extractSignature,
   extractParameters,
   clampSignatureLength,
+  collapseWhitespace,
 } from '../extractors/symbol-helpers.js';
 import { calculateComplexity } from '../complexity/index.js';
 
@@ -525,9 +526,38 @@ export class PythonSymbolExtractor implements LanguageSymbolExtractor {
       startLine: node.startPosition.row + 1,
       endLine: node.endPosition.row + 1,
       parentClass,
-      signature: `class ${nameNode.text}`,
+      signature: clampSignatureLength(`class ${nameNode.text}${typeParamsAndBases(node)}`),
     };
   }
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+/**
+ * Generic type parameters and base-class list, exactly as declared in
+ * source — the Python analog of C#'s `typeParamsAndBaseList`/Java's
+ * `typeParamsAndHeritage` (same underlying bug: `signature` for a class
+ * reported only its bare keyword and name, dropping `(Animal, Serializable)`
+ * entirely — #976, #965 recurring). Both pieces are registered grammar
+ * fields on `class_definition`: `type_parameters` (PEP 695, `class Box[T]:`,
+ * Python 3.12+) and `superclasses` (the parenthesized base/metaclass-keyword
+ * list, e.g. `(Animal, Serializable)` or `(Base, metaclass=Meta)`).
+ *
+ * Unlike the C#/Java/Kotlin/Swift/JS analogs, no separator is inserted
+ * between the pieces: Python's own grammar never puts whitespace between
+ * the class name, `[T]`, and `(Bases)` (`class Box[T](Base):`), so
+ * concatenating verbatim reproduces the source exactly.
+ *
+ * Whitespace is collapsed to a single line (matching `extractSignature`'s
+ * convention, see `collapseWhitespace`) in case either piece spans multiple
+ * physical lines.
+ */
+function typeParamsAndBases(node: SyntaxNode): string {
+  const typeParams = collapseWhitespace(node.childForFieldName('type_parameters')?.text);
+  const bases = collapseWhitespace(node.childForFieldName('superclasses')?.text);
+  return `${typeParams}${bases}`;
 }
 
 // =============================================================================

--- a/packages/parser/src/ast/languages/type-declaration-signature.test.ts
+++ b/packages/parser/src/ast/languages/type-declaration-signature.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { mustParse } from '../test/helpers/parse-fixture.js';
+import type { SyntaxNode } from '../types.js';
+import type { SupportedLanguage } from './registry.js';
+import type { LanguageSymbolExtractor } from '../extractors/types.js';
+import { CSharpSymbolExtractor } from './csharp.js';
+import { JavaSymbolExtractor } from './java.js';
+import { KotlinSymbolExtractor } from './kotlin.js';
+import { SwiftSymbolExtractor } from './swift.js';
+import { TypeScriptSymbolExtractor } from './javascript.js';
+import { PythonSymbolExtractor } from './python.js';
+import { PHPSymbolExtractor } from './php.js';
+import { GoSymbolExtractor } from './go.js';
+import { RubySymbolExtractor } from './ruby.js';
+
+/**
+ * Cross-language regression test for #976 (#965 recurring).
+ *
+ * Six languages (C#, Java, Kotlin, Swift, JS/TS, and Rust for impl/trait
+ * blocks) independently grew a `typeParamsAndX`-shaped helper so that a type
+ * declaration's `signature` carries its generic type parameters and
+ * heritage clause (base class / interface list), not just its bare keyword
+ * and name. Their doc comments explicitly cross-reference each other
+ * (java.ts:529 calls itself "the Java analog of C#'s typeParamsAndBaseList")
+ * — six files independently documenting that they implement the same rule
+ * is the clearest possible signal the RULE should be asserted once, even
+ * though the grammar-specific extraction stays per-language. #976 then
+ * found the rule had never been applied to Python, PHP, or Go.
+ *
+ * This table is that single assertion: for every language whose type-level
+ * symbol extractor exists, a declaration exercising whichever of
+ * {generics, heritage} that language's grammar supports must round-trip
+ * into `signature` — not just the bare `<keyword> <name>`. A 10th language
+ * that copies the bare-keyword-and-name shape without reading this file
+ * will fail here immediately, the same way Python/PHP/Go's gaps would have
+ * been caught immediately had this table existed before #965.
+ *
+ * Rust is deliberately excluded: `struct_item`/`enum_item` aren't
+ * symbol-extracted at all yet (only `impl_item`/`trait_item`, via
+ * `extractImplInfo` — a different shape, since Rust's generics/heritage
+ * live on the `impl`/`trait` block, not a type declaration keyword). That
+ * gap is bigger and different in kind, and is tracked separately, not fixed
+ * here.
+ */
+
+function findNode(node: SyntaxNode, type: string): SyntaxNode | null {
+  if (node.type === type) return node;
+  for (const child of node.namedChildren) {
+    const found = findNode(child, type);
+    if (found) return found;
+  }
+  return null;
+}
+
+interface TypeSignatureCase {
+  language: SupportedLanguage;
+  extractor: LanguageSymbolExtractor;
+  nodeType: string;
+  code: string;
+  expectedSignature: string;
+  covers: string;
+}
+
+const cases: TypeSignatureCase[] = [
+  {
+    language: 'csharp',
+    extractor: new CSharpSymbolExtractor(),
+    nodeType: 'class_declaration',
+    code: 'public class Constrained<T> : Base where T : class, new() {}',
+    expectedSignature: 'class Constrained<T> : Base',
+    covers: 'generics + base list',
+  },
+  {
+    language: 'java',
+    extractor: new JavaSymbolExtractor(),
+    nodeType: 'class_declaration',
+    code: 'class Foo<T extends Comparable<T>> extends Bar<T> implements Baz, Qux {}',
+    expectedSignature: 'class Foo<T extends Comparable<T>> extends Bar<T> implements Baz, Qux',
+    covers: 'generics + extends/implements',
+  },
+  {
+    language: 'kotlin',
+    extractor: new KotlinSymbolExtractor(),
+    nodeType: 'class_declaration',
+    code: 'class Foo<T> : Bar<T>(), Baz',
+    expectedSignature: 'class Foo<T> : Bar<T>(), Baz',
+    covers: 'generics + supertypes',
+  },
+  {
+    language: 'swift',
+    extractor: new SwiftSymbolExtractor(),
+    nodeType: 'class_declaration',
+    code: 'class Foo<T>: Bar, Baz {}',
+    expectedSignature: 'class Foo<T>: Bar, Baz',
+    covers: 'generics + inheritance clause',
+  },
+  {
+    language: 'typescript',
+    extractor: new TypeScriptSymbolExtractor(),
+    nodeType: 'class_declaration',
+    code: 'class Foo<T> extends Bar<T> implements Baz, Qux {}',
+    expectedSignature: 'class Foo<T> extends Bar<T> implements Baz, Qux',
+    covers: 'generics + extends/implements',
+  },
+  {
+    // #976: signature was `class Dog`, dropping `[T]` and `(Base, Serializable)`.
+    language: 'python',
+    extractor: new PythonSymbolExtractor(),
+    nodeType: 'class_definition',
+    code: 'class Box[T](Base, Serializable):\n    pass\n',
+    expectedSignature: 'class Box[T](Base, Serializable)',
+    covers: 'generics (PEP 695) + base classes',
+  },
+  {
+    // #976: signature was `class Dog`, dropping `extends Animal implements
+    // Serializable` entirely. PHP has no generic type parameters.
+    language: 'php',
+    extractor: new PHPSymbolExtractor(),
+    nodeType: 'class_declaration',
+    code: '<?php\nclass Dog extends Animal implements Serializable {}',
+    expectedSignature: 'class Dog extends Animal implements Serializable',
+    covers: 'heritage only (no generics in PHP)',
+  },
+  {
+    // #976: signature was `type Stack struct`, dropping `[T any]` entirely.
+    // Go structs/interfaces have no heritage clause (composition is via
+    // embedded fields/interfaces, not extends/implements).
+    language: 'go',
+    extractor: new GoSymbolExtractor(),
+    nodeType: 'type_declaration',
+    code: 'package main\ntype Stack[T any] struct { items []T }',
+    expectedSignature: 'type Stack[T any] struct',
+    covers: 'generics only (no heritage clause in Go)',
+  },
+  {
+    // Already correct pre-#976 — Ruby has no generics, and its superclass
+    // handling (`class Dog < Animal`) was never dropped. Included so the
+    // table covers every language with a type-level extractor, not just the
+    // ones that needed fixing.
+    language: 'ruby',
+    extractor: new RubySymbolExtractor(),
+    nodeType: 'class',
+    code: 'class Dog < Animal\nend\n',
+    expectedSignature: 'class Dog < Animal',
+    covers: 'superclass only (no generics in Ruby)',
+  },
+];
+
+describe('Cross-language: type declaration signature carries generics + heritage (#976)', () => {
+  it.each(cases)(
+    '$language ($covers): signature is not just bare keyword + name',
+    ({ language, extractor, nodeType, code, expectedSignature }) => {
+      const root = mustParse(code, language);
+      const node = findNode(root, nodeType);
+      expect(node, `expected to find a "${nodeType}" node parsing ${language} fixture`).not.toBe(
+        null,
+      );
+
+      const symbol = extractor.extractSymbol(node!, code);
+      expect(symbol).not.toBeNull();
+      expect(symbol!.signature).toBe(expectedSignature);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

`signature` for a type declaration in Python, PHP, and Go reported only the
bare keyword and name, dropping generic type parameters and the heritage
clause (base class / interface list) entirely. #965 fixed this for six
languages (C#, Java, Kotlin, Swift, JS/TS, and Rust's `impl`/`trait`
blocks) — this PR covers the three it missed.

| language | input | before | after |
|---|---|---|---|
| Python | `class Dog(Animal, Serializable): pass` | `"class Dog"` | `"class Dog(Animal, Serializable)"` |
| PHP | `class Dog extends Animal implements Serializable {}` | `"class Dog"` | `"class Dog extends Animal implements Serializable"` |
| Go | `type Stack[T any] struct { items []T }` | `"type Stack struct"` | `"type Stack[T any] struct"` |

Python also gets PEP 695 generic-class support as a side effect of using the
grammar's own `type_parameters` field (`class Box[T](Base):` →
`"class Box[T](Base)"`).

## Approach

Each of the six already-fixed languages independently grew a
`typeParamsAndX`-shaped helper, and their doc comments explicitly
cross-reference each other (`java.ts:529` calls itself "the Java analog of
C#'s `typeParamsAndBaseList`"). Followed the same shape rather than
inventing a third:

- `python.ts`: `typeParamsAndBases()` — both `type_parameters` and
  `superclasses` are registered fields on `class_definition`, concatenated
  with no separator (matches Python's own grammar, which never puts
  whitespace between the name, `[T]`, and `(Bases)`).
- `php.ts`: `heritageClause()` — PHP has no generic type parameters, so this
  only extracts the heritage half. Neither `base_clause` nor
  `class_interface_clause` is a registered field on `class_declaration`, so
  both are found by scanning `namedChildren` (mirrors C#/Java's
  fallback-scan case).
- `go.ts`: `typeParamsClause()` — Go structs/interfaces have no heritage
  clause at all (composition is via embedded fields/interfaces, not
  `extends`/`implements`), so this only extracts the type-parameters half.
  `type_parameters` is a registered field on `type_spec`.

All three wrap their signature construction in `clampSignatureLength` (and
`collapseWhitespace` for the extracted clauses) from `symbol-helpers.ts`,
same as the existing six — see "Review fix" below for a gap caught in Go's
four branches during review.

## The cross-language test (the durable deliverable)

Six files independently documenting "this implements the same rule as
C#'s `typeParamsAndBaseList`" is the clearest possible signal the rule
itself should be asserted once, even though the grammar-specific extraction
correctly stays per-language. Added
`packages/parser/src/ast/languages/type-declaration-signature.test.ts`: a
table-driven test asserting, for every language with a type-level symbol
extractor (C#, Java, Kotlin, Swift, TypeScript, Python, PHP, Go, Ruby — 9
rows), that a declaration exercising whichever of {generics, heritage} that
language's grammar supports round-trips into `signature`, not just the bare
`<keyword> <name>`. Ruby is included even though it needed no fix (its
superclass handling was already correct) so the table covers every
extractor, not just the three that had gaps. A future language whose
type-declaration extractor copies the bare-keyword-and-name shape will fail
this test immediately.

Also added dedicated per-language regression tests (mirroring the existing
per-language style) in `python.test.ts`, `php.test.ts`, and `go.test.ts` for
the exact repro cases above plus PEP 695 / interface variants.

## Review fix: Go wasn't clamping

Lien Review flagged that `GoSymbolExtractor.extractTypeInfo`'s four new
signature branches were built without `clampSignatureLength`, unlike
`python.ts`/`php.ts` in this same PR and all six previously-fixed languages.
Adding the type-parameter list *lengthens* Go signatures, so this is exactly
when the missing clamp starts to matter — a long generic parameter list
could now blow past the 200-char limit every other language respects.
Fixed: all four branches now wrap in `clampSignatureLength`, plus a new
regression test (`go.test.ts`) with an 8-parameter generic struct whose raw
signature is 225 chars, asserting the result is clamped to exactly 200
chars ending in `"..."`.

**Follow-up candidate (not fixed here):** Kotlin's `extractClassInfo`/
`extractObjectInfo` (`kotlin.ts`) has zero `clampSignatureLength` uses on
`main` — pre-existing, not introduced by this PR, same shape as the rest of
this campaign ("one decision, N languages, applied at fewer than N"). Worth
its own follow-up issue.

## Out of scope

Rust's `struct_item`/`enum_item` aren't symbol-extracted at all yet — only
`impl_item`/`trait_item` are, via the differently-shaped `extractImplInfo`
(generics/heritage live on the `impl`/`trait` block, not a type-declaration
keyword). That's a bigger, different gap; not fixed here, per the issue.

## Verification

Real-world dogfood (not just synthetic snippets), running the actual shipped
parser (`packages/parser/dist`) against real cloned OSS source:

```
PHP (real: Monolog, src/Monolog/Handler/FilterHandler.php):
  signature: "class FilterHandler extends Handler implements ProcessableHandlerInterface, ResettableInterface, FormattableHandlerInterface"

Python (real: Requests, src/requests/sessions.py, class Session(SessionRedirectMixin)):
  signature: "class Session(SessionRedirectMixin)"

Go (real: samber/lo, condition.go, type switchCase[T comparable, R any] struct):
  signature: "type switchCase[T comparable, R any] struct"
```

Plus the E2E suite (real clone → index → complexity → search → reindex,
no mocks) against Requests (Python), Monolog (PHP), and Chi (Go) — all green.

### Gates (all six, from a fresh worktree: `npm ci && npm run build && npm run build:native -w @liendev/parser-native`)

```
npm run format:check   PASS
npm run lint           PASS (0 errors; pre-existing warnings only, none touch changed files' new code)
npm run typecheck      PASS
npm run build          PASS
npm test               PASS — 5305 passed (baseline 5204 + 15 new tests: 2 python, 1 php, 3 go incl. the clamp regression, 9 cross-language)
node packages/cli/dist/index.js delta --base origin/main   exit 0 (only advisory "worsened" time-to-understand notes, no threshold crossings)
```

### Cross-language E2E (per CLAUDE.md: "cross-language AST changes should also run the relevant test:e2e:<lang>")

```
npm run test:e2e:python -w packages/cli   PASS (14 passed, 140 skipped — Requests real clone)
npm run test:e2e:php -w packages/cli      PASS (14 passed, 140 skipped — Monolog real clone)
npm run test:e2e:go -w packages/cli       PASS (14 passed, 140 skipped — Chi real clone, re-run after the clamp fix)
```

Changeset added (`@liendev/parser`: patch).

Also rebased onto `main` after 6 upstream merges landed mid-PR (through
#987) — no conflicts; #986 touched `java.ts`/`kotlin.ts`/`swift.ts` export
logic (unrelated to signature-building) and #987 moved
`getLienHome`/`getIndexDir`/`extractRepoId` out of `@liendev/parser`
(unrelated files).

Closes #976

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes type-declaration signatures for Python, PHP, and Go so they include generic type parameters and heritage clauses instead of just the bare keyword and name. The implementation follows the established pattern used by the six already-fixed languages, uses the shared `collapseWhitespace` and `clampSignatureLength` helpers consistently, and is well-covered by per-language regression tests plus a new cross-language table-driven test. No bugs or breaking changes were found in the changed code.
>
> - Python `extractClassInfo` now appends PEP 695 `type_parameters` and `superclasses` to class signatures.
> - PHP `extractClassInfo` now appends `extends`/`implements` clauses scanned from `namedChildren`.
> - Go `extractTypeInfo` now appends generic `type_parameters` to struct/interface/type-alias signatures and clamps all branches.
> - New cross-language regression test covers all nine type-level symbol extractors.

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 2ab910a. Updates automatically on new commits.</sup>
<!-- /lien-stats -->