### PR TITLE
fix(cli,hooks): never let session dedup outrun the #938 never-suppress policy

### DIFF
--- a/.changeset/annotate-dedup-never-suppress.md
+++ b/.changeset/annotate-dedup-never-suppress.md
@@ -1,0 +1,25 @@
+---
+"@liendev/lien": patch
+---
+
+Fix the Claude Code read-hook's per-session annotation dedup silently
+bypassing the #938 never-suppress policy for an incomplete
+dependent-attribution result, a complexity warning, or a headroom concern
+(#978).
+
+`isTrivial` and `belowRiskFloor` (`annotate-cmd.ts`) both already guarantee
+those signals are never silenced, but a THIRD gate — `annotate-read.sh`'s
+per-session dedup — ran *before* `lien annotate` on a file's second Read this
+session and exited unconditionally once its touchfile existed, with no way to
+know whether the annotation it was suppressing carried one of those signals.
+`lien annotate` now exits `2` (instead of the default `0`) whenever the
+annotation it just printed carries a never-suppress signal
+(`hasNeverSuppressSignal`, the single predicate `isTrivial`/`belowRiskFloor`
+both gate on), and the hook records that in the touchfile's *content* — `1`
+means "never dedup-skip this file again this session," so a signal-carrying
+file re-invokes `lien annotate` on every read for the rest of the session,
+while an ordinary file keeps the existing, cheap existence-only dedup.
+
+`annotateCommand` now returns whether the printed annotation carried that
+signal (previously `void`); the CLI's `process.exit` wiring moved to a new
+`annotateCli` wrapper so tests can keep calling `annotateCommand` directly.

--- a/docs/architecture/nudge-telemetry.md
+++ b/docs/architecture/nudge-telemetry.md
@@ -257,21 +257,38 @@ selective, in a data-honest way.
 The annotator already kept a per-`(session, file)` touchfile under
 `annotated-sessions/<id>/`, suppressing re-annotation for `LIEN_ANNOTATE_TTL_MIN`
 minutes (default 5). The guard **integrates with that same touchfile** rather
-than stacking a second mechanism: when the guard is on, the touchfile's mere
-existence (any age) means "already annotated this file this session" → stay
-silent. The dirs are already GC'd by the SessionStart/SessionEnd hooks, so this
-is naturally session-scoped with no new cross-session state. Guard **off**
-restores the old TTL-windowed behavior.
+than stacking a second mechanism: when the guard is on, the touchfile means
+"already annotated this file this session" → stay silent — **unless** the
+touchfile's *content* says otherwise (see below). The dirs are already GC'd by
+the SessionStart/SessionEnd hooks, so this is naturally session-scoped with no
+new cross-session state. Guard **off** restores the old TTL-windowed behavior.
+
+**Not fully independent of (b) (#978).** `lien annotate` itself never silences
+a never-suppress signal (see (b) below), but this dedup gate runs *before*
+`lien annotate` — it has to, that's the whole point of skipping the invocation
+on a repeat Read. That makes it structurally content-blind: without more,
+it would suppress a file's second Read even if a fresh `lien annotate` call
+would have printed a never-suppress signal, silently defeating (b)'s
+guarantee on every read after the first. The fix: `lien annotate` exits `2`
+(instead of the default `0`) whenever the annotation it just printed carried
+a never-suppress signal (`hasNeverSuppressSignal` in `annotate-cmd.ts`), and
+the hook records that in the touchfile's **content**, not just its
+existence — `1` means "never dedup-skip this file again this session," so a
+signal-carrying file re-invokes `lien annotate` (and re-applies its own
+carve-outs) on every read for the rest of the session, while an ordinary
+file keeps the cheap existence-only dedup unchanged.
 
 ### (b) Risk floor
 
 The annotation now passes `--min-risk <level>` to `lien annotate`
 (`LIEN_ANNOTATE_MIN_RISK`, default `medium`). Below-floor files stay silent
-**unless** they carry a complexity or headroom concern — those are the
-high-value plan-time nudges and always fire. The floor is a pure, unit-tested
-predicate (`belowRiskFloor`): `complexity/headroom present → emit`, else `risk
-rank < floor rank → suppress`. An unset or unrecognized floor never suppresses
-(fail-open), so the default (no floor) is byte-for-byte the old behavior.
+**unless** they carry a complexity or headroom concern, or an incomplete
+dependent-attribution result — those are the high-value, honest-uncertainty
+signals and always fire (`hasNeverSuppressSignal`). The floor is a pure,
+unit-tested predicate (`belowRiskFloor`): `hasNeverSuppressSignal → emit`,
+else `risk rank < floor rank → suppress`. An unset or unrecognized floor never
+suppresses (fail-open), so the default (no floor) is byte-for-byte the old
+behavior. `isTrivial` gates on the exact same predicate.
 
 #### Why `medium`, from this repo's distribution
 

--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -5,8 +5,10 @@ import * as coreModule from '@liendev/core';
 import * as dependencyAnalyzerModule from '../mcp/handlers/dependency-analyzer.js';
 import {
   annotateCommand,
+  annotateCli,
   isTrivial,
   belowRiskFloor,
+  hasNeverSuppressSignal,
   formatDependents,
   formatTests,
   formatTestReminder,
@@ -38,6 +40,28 @@ vi.mock('../mcp/handlers/dependency-analyzer.js', async () => {
     ...actual,
     findDependents: vi.fn(actual.findDependents),
   };
+});
+
+describe('hasNeverSuppressSignal', () => {
+  it('is false when nothing is present', () => {
+    expect(hasNeverSuppressSignal(0, 0, false)).toBe(false);
+  });
+
+  it('is true for a complexity warning alone', () => {
+    expect(hasNeverSuppressSignal(1, 0, false)).toBe(true);
+  });
+
+  it('is true for a headroom concern alone', () => {
+    expect(hasNeverSuppressSignal(0, 1, false)).toBe(true);
+  });
+
+  it('is true for an incomplete dependent-attribution result alone', () => {
+    expect(hasNeverSuppressSignal(0, 0, true)).toBe(true);
+  });
+
+  it('is true when all three are present', () => {
+    expect(hasNeverSuppressSignal(2, 3, true)).toBe(true);
+  });
 });
 
 describe('isTrivial', () => {
@@ -681,7 +705,7 @@ describe('annotateCommand — plan-time nudge (integration)', () => {
       scanAll: vi.fn().mockResolvedValue([overBudgetChunk]),
     } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
 
-    await annotateCommand(target);
+    const carriesSignal = await annotateCommand(target);
 
     expect(errSpy).not.toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledTimes(1);
@@ -691,6 +715,9 @@ describe('annotateCommand — plan-time nudge (integration)', () => {
       '⚠ Lien: overBudgetFn cognitive 20/15 (over) — avoid adding complexity here; prefer extraction.',
     );
     expect(printed).toContain(`Lien impact for ${target}:`);
+    // A headroom concern is a never-suppress signal (#978) — the shell
+    // hook's session dedup must never be allowed to silence this file again.
+    expect(carriesSignal).toBe(true);
   });
 
   it('stays on the non-nudge path (no leading warning line) when nothing is near budget', async () => {
@@ -716,7 +743,7 @@ describe('annotateCommand — plan-time nudge (integration)', () => {
       scanAll: vi.fn().mockResolvedValue([quietChunk]),
     } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
 
-    await annotateCommand(target);
+    const carriesSignal = await annotateCommand(target);
 
     expect(errSpy).not.toHaveBeenCalled();
     // Still non-trivial (no test coverage), so it prints — but the first line
@@ -725,6 +752,96 @@ describe('annotateCommand — plan-time nudge (integration)', () => {
     const printed = logSpy.mock.calls[0][0] as string;
     expect(printed.split('\n')[0]).toBe(`Lien impact for ${target}:`);
     expect(printed).not.toContain('avoid adding complexity');
+    // An ordinary (non-signal-carrying) annotation — safe for the shell
+    // hook's session dedup to silence on a later Read (#978).
+    expect(carriesSignal).toBe(false);
+  });
+});
+
+describe('annotateCli (CLI exit-code contract, #978)', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  // Same stable target as the plan-time-nudge block above.
+  const target = 'packages/cli/src/cli/index.ts';
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    // Never let a real process.exit tear down the test worker — annotateCli
+    // is exercised for its call arguments only.
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+    vi.mocked(coreModule.createVectorDB).mockClear();
+  });
+
+  it('exits 2 when the printed annotation carries a never-suppress signal (headroom concern)', async () => {
+    const overBudgetChunk = {
+      content: '',
+      metadata: {
+        file: target,
+        startLine: 1,
+        endLine: 20,
+        type: 'function',
+        language: 'typescript',
+        symbolName: 'overBudgetFn',
+        symbolType: 'function',
+        cognitiveComplexity: 20,
+        imports: [],
+      },
+      score: 0,
+      relevance: 'not_relevant',
+    };
+    vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      hasData: vi.fn().mockResolvedValue(true),
+      scanAll: vi.fn().mockResolvedValue([overBudgetChunk]),
+    } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
+
+    await annotateCli(target);
+
+    expect(exitSpy).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledWith(2);
+  });
+
+  it('does not call process.exit for an ordinary annotation', async () => {
+    const quietChunk = {
+      content: '',
+      metadata: {
+        file: target,
+        startLine: 1,
+        endLine: 5,
+        type: 'function',
+        language: 'typescript',
+        symbolName: 'tidyFn',
+        symbolType: 'function',
+        cognitiveComplexity: 2,
+        imports: [],
+      },
+      score: 0,
+      relevance: 'not_relevant',
+    };
+    vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      hasData: vi.fn().mockResolvedValue(true),
+      scanAll: vi.fn().mockResolvedValue([quietChunk]),
+    } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
+
+    await annotateCli(target);
+
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not call process.exit for a non-existent file (silent no-op path)', async () => {
+    await annotateCli('this/path/does/not/exist.ts');
+
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -64,18 +64,37 @@ export interface AnnotateOptions {
 const RISK_RANK: Record<string, number> = { low: 0, medium: 1, high: 2, critical: 3 };
 
 /**
+ * Single source of truth for "does this annotation carry an honest-
+ * uncertainty signal that must never be silently suppressed?" (the #938
+ * policy). A complexity or headroom concern is always high-value (the
+ * plan-time nudges this annotator exists for); an incomplete dependent-
+ * attribution result is the false-all-clear shape (#930/#936) — a file with
+ * structurally-undeterminable dependents reads as "0 dependents" i.e. low
+ * risk by construction, which is exactly what must never go silent.
+ *
+ * `isTrivial` and `belowRiskFloor` both gate on this (that's the #938 fix:
+ * `isTrivial` got the carve-out first, `belowRiskFloor` sat three lines below
+ * it and didn't). `run()` also consults it directly to decide whether the
+ * `lien annotate` process should exit 2 — the signal a THIRD site, the
+ * session-dedup shell hook (`annotate-read.sh`), reads across the process
+ * boundary so it can stop treating this class of annotation as suppressible
+ * habituation noise (#978: that hook used to run before `lien annotate` at
+ * all, so this predicate never got a chance to fire).
+ */
+export function hasNeverSuppressSignal(
+  complexityWarnings: number,
+  headroomCount: number,
+  dependentAttributionIncomplete: boolean,
+): boolean {
+  return complexityWarnings > 0 || headroomCount > 0 || dependentAttributionIncomplete;
+}
+
+/**
  * Habituation guard: is this annotation below the configured risk floor and
- * therefore suppressible? A complexity or headroom concern always clears the
- * floor (those are the high-value plan-time nudges — never suppressed). An
- * incomplete dependent-attribution result also always clears the floor: a
- * file with structurally-undeterminable dependents reads as "0 dependents"
- * (i.e. low risk by construction), which is exactly the false-all-clear
- * shape this guard must never suppress — mirrors `isTrivial`'s identical
- * carve-out for the same flag (#930/#936/#938; this parameter closes the gap
- * Lien Review flagged on #938: `isTrivial` got the carve-out, this guard sat
- * three lines below it and didn't). An unset or unrecognized floor never
- * suppresses anything (fail-open: default = current always-on behavior).
- * Pure and exported for direct unit testing.
+ * therefore suppressible? `hasNeverSuppressSignal` always clears the floor —
+ * never suppressed. An unset or unrecognized floor never suppresses anything
+ * (fail-open: default = current always-on behavior). Pure and exported for
+ * direct unit testing.
  */
 export function belowRiskFloor(
   riskLevel: string,
@@ -87,8 +106,9 @@ export function belowRiskFloor(
   if (!minRisk) return false;
   const floor = RISK_RANK[minRisk];
   if (floor === undefined) return false; // unknown floor → no suppression
-  // always emit high-value / honest-uncertainty signals
-  if (complexityWarnings > 0 || headroomCount > 0 || dependentAttributionIncomplete) return false;
+  if (hasNeverSuppressSignal(complexityWarnings, headroomCount, dependentAttributionIncomplete)) {
+    return false;
+  }
   return (RISK_RANK[riskLevel] ?? 0) < floor;
 }
 
@@ -110,13 +130,38 @@ export function belowRiskFloor(
  * NOT silent, though: a resolved project root whose index has never been
  * built (#894) prints a one-line warning instead of an empty-but-plausible
  * "no dependents"/"no test coverage" annotation — see `formatNoIndexWarning`.
+ *
+ * Returns whether the printed annotation (if any) carried a never-suppress
+ * signal per `hasNeverSuppressSignal` (false for every early-return path:
+ * unresolvable path, `--tests-only`, no index, trivial, below-floor). Kept
+ * as a plain boolean return — rather than a `process.exit` here — so tests
+ * can call this directly without tearing down the test process; the CLI
+ * wiring's `process.exit` contract lives one layer up, in `annotateCli`.
  */
-export async function annotateCommand(file: string, options?: AnnotateOptions): Promise<void> {
+export async function annotateCommand(file: string, options?: AnnotateOptions): Promise<boolean> {
   try {
-    await run(file, options);
+    return await run(file, options);
   } catch {
-    // Silent — never break the consuming hook.
+    return false; // Silent — never break the consuming hook.
   }
+}
+
+/**
+ * Commander action for `lien annotate`: same behavior as `annotateCommand`,
+ * plus the process exit-code contract the session-dedup shell hook
+ * (`annotate-read.sh`) reads to know whether this file is exempt from its
+ * own per-session suppression (#978):
+ *   - exit 2: the printed annotation carried a never-suppress signal
+ *     (`hasNeverSuppressSignal`) — the hook must not let habituation dedup
+ *     silence this file again this session.
+ *   - exit 0 (default): an ordinary annotation, or none at all — safe for
+ *     the hook's existing per-session dedup.
+ * Separate from `annotateCommand` itself specifically so its exit call never
+ * reaches the test process.
+ */
+export async function annotateCli(file: string, options?: AnnotateOptions): Promise<void> {
+  const carriesNeverSuppressSignal = await annotateCommand(file, options);
+  if (carriesNeverSuppressSignal) process.exit(2);
 }
 
 interface ResolvedPaths {
@@ -440,13 +485,19 @@ async function computeAnnotationData(
   };
 }
 
-async function run(file: string, options?: AnnotateOptions): Promise<void> {
+/**
+ * Returns whether the printed annotation carried a never-suppress signal —
+ * see `annotateCommand`'s doc comment for the full contract. Every early
+ * `return` below (unresolvable path, `--tests-only`, no index, trivial,
+ * below-floor) returns `false`: none of those paths reach `emitAnnotation`.
+ */
+async function run(file: string, options?: AnnotateOptions): Promise<boolean> {
   const paths = resolvePaths(file);
-  if (!paths) return;
+  if (!paths) return false;
 
   if (options?.testsOnly) {
     await runTestsOnly(paths);
-    return;
+    return false;
   }
 
   const { originalCwd, rootDir, filepath } = paths;
@@ -469,7 +520,7 @@ async function run(file: string, options?: AnnotateOptions): Promise<void> {
     // `formatNoIndexWarning`.
     if (!(await vectorDB.hasData())) {
       console.log(formatNoIndexWarning(rootDir));
-      return;
+      return false;
     }
 
     const data = await computeAnnotationData(vectorDB, filepath, rootDir);
@@ -483,7 +534,7 @@ async function run(file: string, options?: AnnotateOptions): Promise<void> {
         data.dependentAttributionIncomplete,
       )
     ) {
-      return;
+      return false;
     }
 
     // Habituation guard's risk floor (opt-in via --min-risk; the read hook
@@ -497,7 +548,7 @@ async function run(file: string, options?: AnnotateOptions): Promise<void> {
         data.dependentAttributionIncomplete,
       )
     ) {
-      return;
+      return false;
     }
 
     emitAnnotation(
@@ -511,6 +562,12 @@ async function run(file: string, options?: AnnotateOptions): Promise<void> {
       data.complexity,
       data.risk,
       data.headroom,
+    );
+
+    return hasNeverSuppressSignal(
+      data.complexity.warningCount,
+      data.headroom.entries.length,
+      data.dependentAttributionIncomplete ?? false,
     );
   } finally {
     if (needsChdir) process.chdir(originalCwd);
@@ -787,11 +844,14 @@ export function isTrivial(
   headroomCount = 0,
   dependentAttributionIncomplete = false,
 ): boolean {
-  // An incomplete-attribution zero is exactly the false-all-clear shape
-  // this annotation exists to warn about -- never let it go silent, the
-  // same way a complexity/headroom concern always clears the floor below.
-  if (dependentAttributionIncomplete) return false;
-  return dependentCount <= 1 && complexityWarnings === 0 && testCount > 0 && headroomCount === 0;
+  // A never-suppress signal (complexity/headroom concern, or an incomplete-
+  // attribution false-all-clear) is never trivial — see `hasNeverSuppressSignal`.
+  if (hasNeverSuppressSignal(complexityWarnings, headroomCount, dependentAttributionIncomplete)) {
+    return false;
+  }
+  // complexityWarnings and headroomCount are both guaranteed 0 here (the
+  // guard above already returned for either being nonzero).
+  return dependentCount <= 1 && testCount > 0;
 }
 
 interface ComplexitySummary {

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -13,7 +13,7 @@ import { apiDeltaCommand } from './api-delta-cmd.js';
 import { statsCommand } from './stats-cmd.js';
 import { configSetCommand, configGetCommand, configListCommand } from './config.js';
 import { pathCommand } from './path-cmd.js';
-import { annotateCommand } from './annotate-cmd.js';
+import { annotateCli } from './annotate-cmd.js';
 import { gcCommand } from './gc.js';
 import { noteEditCommand, noteRunCommand, reportCommand } from './verify-tests-cmd.js';
 import { noteShownCommand, noteSignalCommand } from './nudge-cmd.js';
@@ -181,7 +181,7 @@ program
       'level (low|medium|high|critical), unless there is a complexity/headroom concern. ' +
       'Default: no floor (low).',
   )
-  .action(annotateCommand);
+  .action(annotateCli);
 
 const verifyTestsCmd = program
   .command('verify-tests')

--- a/plugins/claude/hooks/annotate-read.sh
+++ b/plugins/claude/hooks/annotate-read.sh
@@ -5,10 +5,25 @@
 # Habituation guard (default ON; opt out with LIEN_ANNOTATE_GUARD=off):
 #   (a) per-session dedup — annotate a given file at most ONCE per session
 #       (integrates with the existing touchfile; guard OFF restores the older
-#       LIEN_ANNOTATE_TTL_MIN-minute re-annotation window instead).
+#       LIEN_ANNOTATE_TTL_MIN-minute re-annotation window instead) --
+#       UNLESS the file's last known annotation carried a never-suppress
+#       signal (#978 below).
 #   (b) risk floor — pass --min-risk (LIEN_ANNOTATE_MIN_RISK, default 'medium')
 #       so `lien annotate` stays silent for below-floor files unless they carry
 #       a complexity/headroom concern. See docs/architecture/nudge-telemetry.md.
+#
+# #978: (a) and (b) used to be describable as fully independent, but they
+# aren't — `lien annotate` itself never silences a never-suppress signal
+# (an incomplete dependent-attribution result, a complexity warning, or a
+# headroom concern; see annotate-cmd.ts's `hasNeverSuppressSignal`), yet this
+# gate ran BEFORE `lien annotate` and, on a file's second Read this session,
+# exited unconditionally — content-blind by construction, so that policy
+# never got a chance to apply. Fixed by having `lien annotate` exit 2
+# whenever the annotation it just printed carried that signal, and recording
+# that in the touchfile's CONTENT (not just its existence): '1' means "don't
+# ever dedup-skip this file again this session," so a signal-carrying file
+# re-invokes `lien annotate` on every read, while an ordinary file keeps the
+# cheap existence-only dedup.
 #
 # Also records a nudge-shown event (for the `lien stats` funnels) whenever an
 # annotation is actually emitted. Skips files outside Lien's indexed extension
@@ -96,10 +111,16 @@ if [ -f "$touchfile" ]; then
       exit 0
     fi
   else
-    # Guard ON: per-session dedup — this file was already annotated this
-    # session (ignore mtime), so stay silent for the rest of the session.
-    [ -d "$session_dir" ] && touch "$session_dir" 2>/dev/null
-    exit 0
+    # Guard ON: per-session dedup — UNLESS this file's last known annotation
+    # carried a never-suppress signal (#978), recorded in the touchfile's
+    # CONTENT ('1') by the write below. That case falls through and
+    # re-invokes `lien annotate` on every read, same as a first read, so the
+    # #938 carve-outs (`isTrivial`/`belowRiskFloor`) always get a chance to
+    # run instead of being silenced sight-unseen by this dedup gate.
+    if [ "$(cat "$touchfile" 2>/dev/null)" != "1" ]; then
+      [ -d "$session_dir" ] && touch "$session_dir" 2>/dev/null
+      exit 0
+    fi
   fi
 fi
 
@@ -110,16 +131,26 @@ if [ -n "$min_risk" ]; then
 else
   annotation="$(run_lien "${LIEN_CMD[@]}" annotate "$file_path" 2>/dev/null)"
 fi
+# exit 2 (see annotate-cmd.ts's `annotateCli`) means the annotation just
+# printed carries a never-suppress signal — anything else (0, or a crash) is
+# treated as an ordinary annotation, the fail-open default.
+annotate_exit=$?
 
 # Trivial/below-floor impact → `lien annotate` prints nothing → stay silent.
 [ -n "$annotation" ] || exit 0
 
-# Record the annotation so suppression kicks in next time. Truncating an
-# existing touchfile doesn't update the parent dir's mtime on most
-# filesystems, so touch the dir explicitly to keep SessionStart cleanup
+# Record the annotation so suppression kicks in next time — UNLESS
+# annotate_exit says this file must never be dedup-silenced (#978): the
+# touchfile's content ('1' vs anything else) is what the check above reads.
+# Truncating an existing touchfile doesn't update the parent dir's mtime on
+# most filesystems, so touch the dir explicitly to keep SessionStart cleanup
 # from GC'ing this session at the 24h threshold.
 mkdir -p "$session_dir" 2>/dev/null || exit 0
-: > "$touchfile"
+if [ "$annotate_exit" = "2" ]; then
+  printf '1' > "$touchfile"
+else
+  printf '0' > "$touchfile"
+fi
 touch "$session_dir" 2>/dev/null
 
 # Record a nudge-shown event for the `lien stats` funnels (best-effort; its own


### PR DESCRIPTION
## Summary

Fixes #978: `annotate-read.sh`'s per-session dedup gate ran *before*
`lien annotate` and, on a file's second Read in a session, exited
unconditionally once its touchfile existed — content-blind by construction,
so the #938 never-suppress carve-outs in `isTrivial`/`belowRiskFloor` never
got a chance to run for a repeat Read. Net effect: read a file once
(annotation shown, touchfile written), read it again — silence, however
incomplete the dependent-attribution/complexity/headroom situation.

## Option chosen: a hybrid of 1 and 2

Neither option as literally stated is quite right on its own:

- **Option 1** (always invoke `lien annotate`, then dedup only if the fresh
  result carries no signal) is fully correct but pays a `lien annotate`
  invocation on *every* repeat Read of *every* file, defeating the whole
  point of the touchfile dedup for the common case (files that never carry
  a never-suppress signal).
- **Option 2** as literally described ("persist a marker on first
  annotation") would freeze the file's signal status at whatever it was on
  the read that first wrote the touchfile — a file that starts ordinary and
  only later develops a complexity/headroom signal would stay dedup-
  suppressed forever, never re-checked, which is close to the same bug
  shifted one step over.

What's implemented: **`lien annotate` now exits `2`** (instead of the
default `0`) whenever the annotation it just printed carries a
never-suppress signal (`hasNeverSuppressSignal` — the same predicate
`isTrivial`/`belowRiskFloor` both gate on), and the hook **persists that
verdict in the touchfile's content**, not just its existence: `1` means
"never dedup-skip this file again this session." A signal-carrying file
re-invokes `lien annotate` — and re-runs the real carve-outs — on *every*
subsequent read for the rest of the session (paying the one invocation each
time, same cost as Option 1, but only for the subset of files where it
matters); an ordinary file keeps the existing cheap existence-only dedup
(zero extra invocations, same as Option 2's intent). This also means a
never-suppress signal that first appears on read *N* (e.g. an edit pushes a
function over its complexity threshold) gets caught on read *N+1*, not just
on files that were flagged from their very first read.

## Unification (the "strongly consider" section)

Not a single `shouldSuppressAnnotation()` function literally called from
all three sites — the shell hook can't call into the TS process without
invoking it, and invoking it just to ask "would you suppress?" is the same
cost as invoking it for real. Instead, one predicate, `hasNeverSuppressSignal`
(`packages/cli/src/cli/annotate-cmd.ts`), is now the single source of truth:

1. `isTrivial` gates on it directly (in-process).
2. `belowRiskFloor` gates on it directly (in-process).
3. `annotate-read.sh` (the shell hook) consults it **indirectly**, via the
   `lien annotate` process's exit code (`annotateCli`'s exit-2 contract) —
   the cleanest boundary-crossing mechanism available, and the same
   exit-code convention `lien delta` already uses for its own hooks.

Listing the three sites explicitly, as requested, in case this framing is
judged insufficient: `annotate-cmd.ts:isTrivial`, `annotate-cmd.ts:belowRiskFloor`,
`annotate-read.sh`'s per-session dedup block.

## Changes

- `packages/cli/src/cli/annotate-cmd.ts`: new exported `hasNeverSuppressSignal`;
  `isTrivial`/`belowRiskFloor` refactored to call it (behavior-preserving —
  all 71 pre-existing tests pass unchanged); `run()`/`annotateCommand` now
  return whether the printed annotation carried the signal (was `void`); new
  `annotateCli` wrapper owns the `process.exit(2)` CLI contract so
  `annotateCommand` itself stays safe to call directly from tests.
- `packages/cli/src/cli/index.ts`: wires `lien annotate` to `annotateCli`
  instead of `annotateCommand`.
- `plugins/claude/hooks/annotate-read.sh`: reads `lien annotate`'s exit code;
  touchfile content is now `1` (never dedup-skip again this session) or `0`
  (ordinary, dedup as before) instead of always empty.
- `docs/architecture/nudge-telemetry.md`: (a) per-session dedup and (b) risk
  floor were documented as independent; now cross-referenced with the #978
  fix.
- `.changeset/annotate-dedup-never-suppress.md`: patch changeset
  (`packages/cli/src` changed, so one is required per CLAUDE.md).
- Tests: new `hasNeverSuppressSignal` unit tests; `annotateCommand`'s
  existing headroom/quiet integration tests now also assert the return
  value; new `annotateCli` describe block asserting `process.exit(2)` only
  fires when the signal is present (mocked, never reaches the test process).

## Dogfood evidence (real PostToolUse stdin shape)

Built the CLI (`npm run build`), put a `lien` shim pointing at
`packages/cli/dist/index.js` on `PATH`, and piped the exact
`{session_id, transcript_path, cwd, hook_event_name, tool_name, tool_input,
tool_response}` JSON shape Claude Code sends into `annotate-read.sh`
directly, twice per file, same `session_id`, against this repo's own live
overlay index.

**Case 1 — file whose annotation carries `dependentAttributionIncomplete`
(a throwaway `.cs` fixture with no import-based dependents, indexed then
removed again after capture — this repo has no real C# file to use as-is):**

First read (fresh session):
```
$ cat payload1.json | bash plugins/claude/hooks/annotate-read.sh
{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"Lien impact for __dogfood_978_fixture__/Widget.cs:\n  • Dependents not determinable from imports (enclosing-namespace access).\n  • Test coverage not determinable from imports (enclosing-namespace access)."}}
```
Touchfile written with content `1` (confirmed via `cat` on the touchfile).

Second read, same session, same file:
```
$ cat payload1.json | bash plugins/claude/hooks/annotate-read.sh
{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"Lien impact for __dogfood_978_fixture__/Widget.cs:\n  • Dependents not determinable from imports (enclosing-namespace access).\n  • Test coverage not determinable from imports (enclosing-namespace access)."}}
```
**Still annotates — the bug is fixed.** (Pre-fix, this second call printed
nothing — the touchfile from the first call would have suppressed it
unconditionally.)

**Case 2 — an ordinary file (`packages/cli/src/cli/path-cmd.ts`, real
dependents/test coverage, no complexity/headroom concern, `lien annotate`
exits 0):**

First read:
```
$ cat payload2.json | bash plugins/claude/hooks/annotate-read.sh
{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"Lien impact for packages/cli/src/cli/path-cmd.ts:\n  • 2 files import this — packages/cli/src/cli/index.ts, packages/cli/src/cli/path-cmd.test.ts; risk: medium (2 callers, 1 untested).\n  • Test coverage: packages/cli/src/cli/path-cmd.test.ts."}}
```
Touchfile written with content `0`.

Second read, same session, same file:
```
$ cat payload2.json | bash plugins/claude/hooks/annotate-read.sh
$ echo "EXIT=$?"
EXIT=0
```
**Silent — dedup still works, no regression.**

**TTL / fail-open behavior, unchanged:**
- `LIEN_ANNOTATE_GUARD=off` (legacy TTL path, untouched by this fix): first
  call annotates, a second call within the 5-minute window is silent, exit 0
  — same as before.
- Malformed stdin (`not json`) and stdin missing `session_id`: both exit 0
  with no `additionalContext`, matching the pre-existing fail-open contract
  (only `jq` parse errors on stderr, which the hook already routes away from
  the model).

## Gates (all six, this worktree)

```
npm run format:check   # All matched files use Prettier code style!
npm run lint           # 0 errors, 38 pre-existing warnings (unrelated files)
npm run typecheck      # clean
npm run build          # clean (parser/core/cli/review/action)
npm test               # 5212 passing (baseline 5204 + 8 new tests), 0 failing
node packages/cli/dist/index.js delta   # exit 0 — 2 improved (isTrivial/belowRiskFloor
                                         # simplified), 2 new functions (hasNeverSuppressSignal,
                                         # annotateCli), no new threshold crossings
```

Closes #978

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes a real bug (#978) where the Claude Code read hook's per-session dedup gate suppressed repeat Reads before `lien annotate` could evaluate the #938 never-suppress carve-outs. The fix introduces a clean cross-process contract: `lien annotate` now exits 2 when the printed annotation carries a complexity/headroom/incomplete-attribution signal, and the shell hook persists that verdict in the touchfile content ('1' = always re-annotate, '0' = ordinary dedup). The implementation is well-isolated—`annotateCommand` returns a boolean, `annotateCli` owns the `process.exit(2)` call, and `hasNeverSuppressSignal` becomes the single source of truth used by `isTrivial`, `belowRiskFloor`, and the hook indirectly via exit code. All early-return paths correctly return `false`, preserving the fail-open behavior for errors, missing indexes, and below-floor files. Tests cover the new predicate, the return value, and the exit-code contract.
>
> - New `hasNeverSuppressSignal` predicate unifies the never-suppress policy across `isTrivial`, `belowRiskFloor`, and the shell-hook dedup gate.
> - `annotateCommand` now returns a boolean indicating whether the emitted annotation carried a never-suppress signal; `annotateCli` wraps it and exits 2 when true.
> - `annotate-read.sh` now writes `1` or `0` into the per-session touchfile and re-invokes `lien annotate` on every repeat Read when the last annotation carried a signal.

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 42413f2. Updates automatically on new commits.</sup>
<!-- /lien-stats -->