### PR TITLE
fix(core): enrich testAssociations in ComplexityAnalyzer.analyze()

### DIFF
--- a/.changeset/complexity-test-associations.md
+++ b/.changeset/complexity-test-associations.md
@@ -1,0 +1,47 @@
+---
+"@liendev/core": patch
+"@liendev/lien": patch
+---
+
+Fix `ComplexityAnalyzer.analyze()` (the persisted-index path used by `lien
+complexity` and the `get_complexity` MCP tool) always reporting
+`testAssociations: []` for every violation, even when a real test file
+imports the offending code (#979).
+
+`packages/core/src/insights/complexity-analyzer.ts` set `testAssociations: []`
+with a "will be enriched later" comment and never enriched it — the only
+occurrence of `testAssociations` in the file. Its in-memory-chunks twin,
+`analyzeComplexityFromChunks` (`@liendev/parser`, used by the static
+`ComplexityAnalyzer.analyzeFromChunks()` and reached via `lien annotate`),
+already ran `findTestAssociationsFromChunks` and enriched the report
+correctly — a half-finished migration where the static delegating method
+was pointed at the parser implementation but the instance method's own copy
+was left behind. `get_complexity` is the tool CLAUDE.md-style agent
+instructions point at before refactoring to find hotspots; it was silently
+claiming none of them had tests.
+
+Fixed by calling the same `findTestAssociationsFromChunks` from `analyze()`
+after dependency enrichment, mirroring the parser twin. `SearchResult[]`
+(what `analyze()` has, off the persisted index) is a structural superset of
+`CodeChunk[]` (what the parser function's signature expects), so no type
+changes were needed — verified via `tsc`, not assumed.
+
+Also threaded `testAssociations` through the `get_complexity` MCP tool's
+`transformViolation()` response shape, which previously omitted the field
+from its output entirely regardless of what `analyze()` returned — without
+this, the fix would be invisible through the exact tool named in the bug
+report; the CLI's `--format json` output already included it as a
+pass-through of the whole report.
+
+Added a same-input parity test between `analyze()` (`SearchResult[]`) and
+`analyzeFromChunks()` (`CodeChunk[]`) asserting they agree on
+`testAssociations` — the check whose absence let this divergence ship
+silently (a prior commit, 93191c41, had to hand-sync an unrelated one-line
+dedup-key change across both files; nothing enforced that these two
+`testAssociations` implementations stayed in sync).
+
+Does NOT move the canonical implementation into `@liendev/parser` (the
+larger duplication-layering fix suggested in #979) — `chunk-complexity.ts`
+has no dedicated test file today and feeds `lien delta`'s complexity gate,
+so that refactor needs characterization tests first and is left for
+separate follow-up work.

--- a/packages/cli/src/mcp/handlers/get-complexity.test.ts
+++ b/packages/cli/src/mcp/handlers/get-complexity.test.ts
@@ -624,4 +624,90 @@ describe('handleGetComplexity', () => {
       expect(parsed).not.toHaveProperty('note');
     });
   });
+
+  describe('testAssociations passthrough (#979)', () => {
+    it('surfaces the file-level testAssociations on each violation', async () => {
+      const mockReport: ComplexityReport = {
+        summary: {
+          filesAnalyzed: 1,
+          avgComplexity: 25,
+          maxComplexity: 25,
+          totalViolations: 1,
+          bySeverity: { error: 0, warning: 1 },
+        },
+        files: {
+          'src/utils.ts': {
+            violations: [
+              {
+                filepath: 'src/utils.ts',
+                symbolName: 'complex',
+                symbolType: 'function',
+                startLine: 1,
+                endLine: 10,
+                complexity: 20,
+                metricType: 'cyclomatic',
+                threshold: 15,
+                severity: 'warning',
+                language: 'typescript',
+                message: 'Complexity 20 exceeds threshold 15',
+              },
+            ],
+            dependents: [],
+            testAssociations: ['src/utils.test.ts'],
+            dependentCount: 0,
+            riskLevel: 'low',
+          },
+        },
+      };
+
+      getMockAnalyze().mockResolvedValue(mockReport);
+
+      const result = await handleGetComplexity({ top: 10 }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.violations[0].testAssociations).toEqual(['src/utils.test.ts']);
+    });
+
+    it('surfaces an empty testAssociations array when the file has no associated tests', async () => {
+      const mockReport: ComplexityReport = {
+        summary: {
+          filesAnalyzed: 1,
+          avgComplexity: 25,
+          maxComplexity: 25,
+          totalViolations: 1,
+          bySeverity: { error: 0, warning: 1 },
+        },
+        files: {
+          'src/untested.ts': {
+            violations: [
+              {
+                filepath: 'src/untested.ts',
+                symbolName: 'risky',
+                symbolType: 'function',
+                startLine: 1,
+                endLine: 10,
+                complexity: 20,
+                metricType: 'cyclomatic',
+                threshold: 15,
+                severity: 'warning',
+                language: 'typescript',
+                message: 'Complexity 20 exceeds threshold 15',
+              },
+            ],
+            dependents: [],
+            testAssociations: [],
+            dependentCount: 0,
+            riskLevel: 'low',
+          },
+        },
+      };
+
+      getMockAnalyze().mockResolvedValue(mockReport);
+
+      const result = await handleGetComplexity({ top: 10 }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.violations[0].testAssociations).toEqual([]);
+    });
+  });
 });

--- a/packages/cli/src/mcp/handlers/get-complexity.ts
+++ b/packages/cli/src/mcp/handlers/get-complexity.ts
@@ -41,6 +41,7 @@ function transformViolation(v: ComplexityViolation, fileData: FileComplexityData
     message: v.message,
     dependentCount: fileData.dependentCount || 0,
     riskLevel: fileData.riskLevel,
+    testAssociations: fileData.testAssociations,
     ...(v.halsteadDetails && { halsteadDetails: v.halsteadDetails }),
   };
 }

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -204,7 +204,7 @@ Examples:
 
 Returns:
 - summary: { filesAnalyzed, avgComplexity, maxComplexity, violationCount, bySeverity: { error, warning } }
-- violations[]: { filepath, symbolName, symbolType, complexity, metricType, threshold, severity, riskLevel, dependentCount }
+- violations[]: { filepath, symbolName, symbolType, complexity, metricType, threshold, severity, riskLevel, dependentCount, testAssociations }
 - metricType: "cyclomatic" | "cognitive" | "halstead_effort" | "halstead_bugs"
 - severity: "error" | "warning"
 - note?: present and explicit when a requested \`files\` entry has no index entry at all — filesAnalyzed silently excludes it otherwise`,

--- a/packages/core/src/insights/complexity-analyzer.test.ts
+++ b/packages/core/src/insights/complexity-analyzer.test.ts
@@ -728,6 +728,138 @@ describe('ComplexityAnalyzer', () => {
     });
   });
 
+  describe('test association enrichment (#979)', () => {
+    it('should populate testAssociations for a violation with an importing test file', async () => {
+      const chunks: SearchResult[] = [
+        {
+          content: 'function complex() { }',
+          metadata: {
+            file: 'src/utils.ts',
+            startLine: 1,
+            endLine: 10,
+            type: 'function',
+            language: 'typescript',
+            symbolName: 'complex',
+            symbolType: 'function',
+            complexity: 20, // Above threshold
+          } as ChunkMetadata,
+          score: 1.0,
+          relevance: 'highly_relevant' as const,
+        },
+        {
+          content: "import { complex } from './utils';",
+          metadata: {
+            file: 'src/utils.test.ts',
+            startLine: 1,
+            endLine: 5,
+            type: 'function',
+            language: 'typescript',
+            imports: ['src/utils.ts'],
+          } as ChunkMetadata,
+          score: 1.0,
+          relevance: 'highly_relevant' as const,
+        },
+      ];
+
+      vi.mocked(mockVectorDB.scanAll).mockResolvedValue(chunks);
+
+      const analyzer = new ComplexityAnalyzer(mockVectorDB);
+      const report = await analyzer.analyze();
+
+      expect(report.files['src/utils.ts'].testAssociations).toEqual(['src/utils.test.ts']);
+    });
+
+    it('should not enrich files without violations', async () => {
+      const chunks: SearchResult[] = [
+        {
+          content: 'function simple() { }',
+          metadata: {
+            file: 'src/simple.ts',
+            startLine: 1,
+            endLine: 5,
+            type: 'function',
+            language: 'typescript',
+            symbolName: 'simple',
+            symbolType: 'function',
+            complexity: 5, // Below threshold
+          } as ChunkMetadata,
+          score: 1.0,
+          relevance: 'highly_relevant' as const,
+        },
+        {
+          content: "import { simple } from './simple';",
+          metadata: {
+            file: 'src/simple.test.ts',
+            startLine: 1,
+            endLine: 5,
+            type: 'function',
+            language: 'typescript',
+            imports: ['src/simple.ts'],
+          } as ChunkMetadata,
+          score: 1.0,
+          relevance: 'highly_relevant' as const,
+        },
+      ];
+
+      vi.mocked(mockVectorDB.scanAll).mockResolvedValue(chunks);
+
+      const analyzer = new ComplexityAnalyzer(mockVectorDB);
+      const report = await analyzer.analyze();
+
+      expect(report.files['src/simple.ts'].testAssociations).toEqual([]);
+    });
+
+    it('analyze() (SearchResult[] / persisted-index path) and analyzeFromChunks() (CodeChunk[] / in-memory path) must agree on testAssociations for the same input — the parity check whose absence let #979 ship', async () => {
+      const rawChunks = [
+        {
+          content: 'function complex() { }',
+          metadata: {
+            file: 'src/shared.ts',
+            startLine: 1,
+            endLine: 10,
+            type: 'function',
+            language: 'typescript',
+            symbolName: 'complex',
+            symbolType: 'function',
+            complexity: 20, // Above threshold
+          } as ChunkMetadata,
+        },
+        {
+          content: "import { complex } from './shared';",
+          metadata: {
+            file: 'src/shared.test.ts',
+            startLine: 1,
+            endLine: 5,
+            type: 'function',
+            language: 'typescript',
+            imports: ['src/shared.ts'],
+          } as ChunkMetadata,
+        },
+      ];
+
+      // analyze(): SearchResult[] off a persisted index (adds score/relevance)
+      const searchResultChunks: SearchResult[] = rawChunks.map(c => ({
+        ...c,
+        score: 1.0,
+        relevance: 'highly_relevant' as const,
+      }));
+      vi.mocked(mockVectorDB.scanAll).mockResolvedValue(searchResultChunks);
+      const analyzer = new ComplexityAnalyzer(mockVectorDB);
+      const instanceReport = await analyzer.analyze();
+
+      // analyzeFromChunks(): plain in-memory CodeChunk[]
+      const codeChunks: CodeChunk[] = rawChunks;
+      const staticReport = ComplexityAnalyzer.analyzeFromChunks(codeChunks);
+
+      expect(instanceReport.files['src/shared.ts'].testAssociations).toEqual(
+        staticReport.files['src/shared.ts'].testAssociations,
+      );
+      expect(instanceReport.files['src/shared.ts'].testAssociations).toEqual([
+        'src/shared.test.ts',
+      ]);
+    });
+  });
+
   describe('analyzeFromChunks', () => {
     it('should find violations from in-memory chunks', () => {
       const chunks: CodeChunk[] = [

--- a/packages/core/src/insights/complexity-analyzer.ts
+++ b/packages/core/src/insights/complexity-analyzer.ts
@@ -11,6 +11,7 @@ import type {
 import { RISK_ORDER } from '@liendev/parser';
 import { analyzeDependencies } from '@liendev/parser';
 import { analyzeComplexityFromChunks } from '@liendev/parser';
+import { findTestAssociationsFromChunks } from '@liendev/parser';
 
 /**
  * Hardcoded severity multipliers:
@@ -56,6 +57,9 @@ export class ComplexityAnalyzer {
 
     // 5. Enrich files with violations with dependency data
     this.enrichWithDependencies(report, allChunks as SearchResult[]);
+
+    // 6. Enrich files with violations with test association data
+    this.enrichWithTestAssociations(report, allChunks);
 
     return report;
   }
@@ -462,6 +466,27 @@ export class ComplexityAnalyzer {
           maxComplexity: depAnalysis.complexityMetrics.maxComplexity,
           filesWithComplexityData: depAnalysis.complexityMetrics.filesWithComplexityData,
         };
+      }
+    }
+  }
+
+  /**
+   * Enrich files with violations with test association data (#979).
+   * Mirrors the parser twin's inline enrichment in
+   * `analyzeComplexityFromChunks` (packages/parser/src/insights/chunk-complexity.ts)
+   * so both the persisted-index path (here) and the in-memory-chunks path
+   * report the same testAssociations for the same input.
+   */
+  private enrichWithTestAssociations(report: ComplexityReport, allChunks: SearchResult[]): void {
+    const filesWithViolations = Object.keys(report.files).filter(
+      f => report.files[f].violations.length > 0,
+    );
+    if (filesWithViolations.length === 0) return;
+
+    const testMap = findTestAssociationsFromChunks(filesWithViolations, allChunks);
+    for (const [filepath, testFiles] of testMap) {
+      if (report.files[filepath]) {
+        report.files[filepath].testAssociations = testFiles;
       }
     }
   }


### PR DESCRIPTION
## Summary

`ComplexityAnalyzer.analyze()` in `packages/core/src/insights/complexity-analyzer.ts` set `testAssociations: [], // Will be enriched later if needed` at line 380 and never enriched it — the only occurrence of `testAssociations` in the file. This is the path used by both `lien complexity` and the `get_complexity` MCP tool, so both always reported zero test coverage for every violation.

The parser twin (`analyzeComplexityFromChunks` in `packages/parser/src/insights/chunk-complexity.ts`, reached via the static `ComplexityAnalyzer.analyzeFromChunks()` and `lien annotate`) already ran `findTestAssociationsFromChunks` and enriched the report correctly — a half-finished migration where the static delegating method was pointed at the parser implementation but the instance method's own copy was left behind.

## Fix

- `packages/core/src/insights/complexity-analyzer.ts`: added a private `enrichWithTestAssociations()` method, called from `analyze()` after dependency enrichment, mirroring the parser twin's logic exactly. `SearchResult[]` (what `analyze()` has, off the persisted index) is a structural superset of `CodeChunk[]` (what `findTestAssociationsFromChunks` expects) — verified via `tsc`, not assumed.
- Added a same-input parity test asserting `analyze()` (`SearchResult[]`) and `analyzeFromChunks()` (`CodeChunk[]`) agree on `testAssociations` for identical input — the check whose absence let this divergence ship silently (commit `93191c41` had to hand-sync an unrelated one-line dedup-key change across both files; nothing enforced these two `testAssociations` implementations stayed in sync).

**Deliberately out of scope:** moving the canonical implementation into `@liendev/parser` (the larger duplication-layering fix suggested in the issue). `chunk-complexity.ts` has no dedicated test file today and feeds `lien delta`'s complexity gate, so that refactor needs characterization tests first and is left for separate follow-up work.

### Scope note: why two CLI files also changed

The issue's own table names the `get_complexity` MCP tool as an affected surface, and the required dogfood evidence explicitly asks to show a before/after `testAssociations` value "via the `get_complexity` MCP tool." Fixing `analyze()` alone does not achieve that:

- `packages/cli/src/mcp/handlers/get-complexity.ts` — `transformViolation()` never included `testAssociations` in its output shape at all (confirmed by reading the code and by a live before/after MCP round-trip below). Even with `analyze()` fixed, the MCP tool's JSON response would still omit the field entirely — not `[]`, just absent. One line added to thread it through, mirroring the existing `dependentCount`/`riskLevel` pass-through pattern immediately above it.
- `packages/cli/src/mcp/tools.ts` — the tool's own natural-language `Returns:` doc lists the response shape (`{ filepath, symbolName, ..., riskLevel, dependentCount }`); updated to include `testAssociations` so the tool description matches its actual output.

Both are one-line, low-risk additions necessary to make the fix observable through the tool named in the bug report, not part of the larger refactor that's out of scope.

## Dogfood evidence (real tool, before → after)

### `lien complexity --format json` (real CLI process, real index, this repo)

**Before** (pre-fix code, indexed + queried):
```json
"packages/core/src/insights/complexity-analyzer.ts": {
  "violations": [{ "symbolName": "buildReport", "metricType": "halstead_effort", ... }],
  "dependents": [ "...", "packages/core/src/insights/complexity-analyzer.test.ts", "..." ],
  "testAssociations": [],
  "riskLevel": "medium"
}
```

**After** (this PR's code, reindexed + requeried):
```json
"packages/core/src/insights/complexity-analyzer.ts": {
  "violations": [{ "symbolName": "buildReport", "metricType": "halstead_effort", ... }],
  "dependents": [ "...", "packages/core/src/insights/complexity-analyzer.test.ts", "..." ],
  "testAssociations": [
    "packages/core/src/insights/complexity-analyzer.test.ts"
  ],
  "riskLevel": "medium"
}
```

Whole-repo before/after: files with violations AND a non-empty `testAssociations` went from **0 of 40** to **25 of 40**.

### `get_complexity` MCP tool (real `lien serve` process, real JSON-RPC `tools/call` round trip over stdio, this repo's index)

**Before** (pre-fix code) — field absent entirely, not `[]`:
```json
{
  "filepath": "packages/core/src/insights/complexity-analyzer.ts",
  "symbolName": "buildReport",
  "metricType": "halstead_effort",
  "dependentCount": 10,
  "riskLevel": "medium",
  "halsteadDetails": { "volume": 2596.74, "difficulty": 40.98, "effort": 106420, "bugs": 0.749 }
}
```

**After** (this PR, on commit `af57209a`, the exact commit this PR opens from):
```json
{
  "filepath": "packages/core/src/insights/complexity-analyzer.ts",
  "symbolName": "buildReport",
  "metricType": "halstead_effort",
  "dependentCount": 12,
  "riskLevel": "medium",
  "testAssociations": [
    "packages/core/src/insights/complexity-analyzer.test.ts"
  ],
  "halsteadDetails": { "volume": 2596.74, "difficulty": 40.98, "effort": 106420, "bugs": 0.749 }
}
```

## Gate results (rebased onto `origin/main` @ 14a34a2f, this PR's tip is `af57209a`)

- `npm run format:check` — pass
- `npm run lint` — 0 errors (38 pre-existing warnings, unrelated to this change)
- `npm run typecheck` — pass
- `npm run build` — pass
- `npm test` — **5209 passed / 0 failed** (5204 baseline + 5 new tests: 3 in `complexity-analyzer.test.ts`, 2 in `get-complexity.test.ts`)
- `node packages/cli/dist/index.js delta --base origin/main` — **exit 0**: 2 advisory "worsened but still under threshold" notices (`ComplexityAnalyzer.analyze` and `transformViolation` time estimates), one new low-complexity helper (`enrichWithTestAssociations`, cognitive 4) — no new threshold crossings.

## Changeset

Added `.changeset/complexity-test-associations.md` with a patch bump for both `@liendev/core` (the actual fix) and `@liendev/lien` (the CLI/MCP handler + tool-doc change) — both are published packages and both ship changed behavior.

Closes #979

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR fixes a half-finished migration where `ComplexityAnalyzer.analyze()` (persisted-index path) never enriched `testAssociations`, while the in-memory parser twin already did. The fix adds a private `enrichWithTestAssociations()` method that mirrors `analyzeComplexityFromChunks`, threads the field through the `get_complexity` MCP response, and updates the tool description. The change is low-risk: it reuses the existing, tested `findTestAssociationsFromChunks` helper, `SearchResult[]` is structurally compatible with the expected `CodeChunk[]`, and the new parity test pins agreement between the two code paths. No breaking changes or logic errors were found.
>
> - Added `enrichWithTestAssociations()` to `ComplexityAnalyzer.analyze()` using `findTestAssociationsFromChunks`
> - Added `testAssociations` to the `get_complexity` MCP tool response via `transformViolation()`
> - Updated `get_complexity` tool documentation and added parity/passthrough tests

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit af57209. Updates automatically on new commits.</sup>
<!-- /lien-stats -->