### PR TITLE
fix(parser,core): dedup normalizeFilePath + complexity thresholds (#988)

### DIFF
--- a/.changeset/dedup-complexity-thresholds-and-normalize-path.md
+++ b/.changeset/dedup-complexity-thresholds-and-normalize-path.md
@@ -1,0 +1,35 @@
+---
+"@liendev/parser": minor
+"@liendev/core": patch
+"@liendev/lien": patch
+---
+
+Fix `normalizeFilePath` mangling sibling directories that share the workspace
+root's name as a prefix, and collapse the four independent copies of the
+default complexity thresholds into one (#988).
+
+**The bug:** `normalizeFilePath` (duplicated in
+`packages/parser/src/insights/chunk-complexity.ts` and
+`packages/core/src/insights/complexity-analyzer.ts`) had a second,
+unguarded `startsWith(normalizedRoot)` fallback with no path-separator check.
+Any sibling directory whose name happened to start with the workspace root's
+name — e.g. root `/x/lien` and sibling `/x/lien-review-testbed` — was
+stripped down to a leading-`-` path (`-review-testbed/x.py`) that matches
+nothing downstream, silently dropping the chunk from complexity reporting
+instead of erroring. Both copies now delegate to `getCanonicalPath`
+(`@liendev/parser`'s `utils/path-matching.ts`), which already had only the
+boundary-safe branch — this removes the duplicate implementation and the bug
+in the same move.
+
+**The duplication:** the same
+`{ testPaths: 15, mentalLoad: 15, timeToUnderstandMinutes: 60, estimatedBugs: 1.5 }`
+threshold table was hardcoded independently in four places: `chunk-complexity.ts`'s
+`DEFAULT_THRESHOLDS`, `complexity-analyzer.ts`'s private `thresholds` field,
+`complexity-delta.ts`'s `DEFAULT_COMPLEXITY_DELTA_THRESHOLDS` (which powers
+`lien delta`'s gate), and `@liendev/core`'s `defaultConfig.complexity.thresholds`
+(the user-facing config default) — with nothing enforcing they stayed equal. A
+drift between the config default and the delta gate's own default would have
+silently enforced a threshold nobody chose. `chunk-complexity.ts` now exports
+a single `DEFAULT_COMPLEXITY_THRESHOLDS` constant (and `ComplexityThresholds`
+type); the other three sites import/alias it instead of hardcoding their own
+copy, and tests assert they stay equal.

--- a/packages/core/src/config/schema.test.ts
+++ b/packages/core/src/config/schema.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_COMPLEXITY_THRESHOLDS } from '@liendev/parser';
+import { defaultConfig } from './schema.js';
+
+describe('defaultConfig.complexity.thresholds', () => {
+  it('equals the canonical DEFAULT_COMPLEXITY_THRESHOLDS (#988: no independent copy)', () => {
+    // `defaultConfig` is the USER-FACING default that `ConfigService.load()`
+    // returns whenever a project has no `.lien.config.json`, and that
+    // `lien delta` (packages/cli/src/cli/delta-cmd.ts) ultimately gates on.
+    // This file used to hardcode its own literal
+    // `{ testPaths: 15, mentalLoad: 15, timeToUnderstandMinutes: 60, estimatedBugs: 1.5 }`
+    // with nothing enforcing agreement with the other three copies (#988). A
+    // drift here would mean the config a user believes they have (or the
+    // default they never overrode) silently diverges from what `lien delta`
+    // actually enforces. This test fails the moment that stops being true.
+    expect(defaultConfig.complexity?.thresholds).toEqual(DEFAULT_COMPLEXITY_THRESHOLDS);
+  });
+});

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_COMPLEXITY_THRESHOLDS } from '@liendev/parser';
+
 /**
  * Per-project Lien configuration (`.lien.config.json`).
  *
@@ -22,14 +24,19 @@ export interface LienConfig {
   };
 }
 
-/** Default per-project configuration. */
+/**
+ * Default per-project configuration.
+ *
+ * #988: `complexity.thresholds` values are derived from `DEFAULT_COMPLEXITY_THRESHOLDS`
+ * (`@liendev/parser`, defined once in `packages/parser/src/insights/chunk-complexity.ts`)
+ * rather than a hand-copied literal — this is the USER-FACING default that
+ * `lien delta` (via `ConfigService`) reads, so a drift from the gate's own
+ * defaults would silently enforce a threshold nobody chose. `LienConfig`'s
+ * type stays distinct (two keys optional, to allow a partial user override
+ * merged in `deepMergeConfig`) — only the values are shared.
+ */
 export const defaultConfig: LienConfig = {
   complexity: {
-    thresholds: {
-      testPaths: 15, // 🔀 Max test paths per function
-      mentalLoad: 15, // 🧠 Max mental load score
-      timeToUnderstandMinutes: 60, // ⏱️ Functions taking >1 hour to understand
-      estimatedBugs: 1.5, // 🐛 Functions estimated to have >1.5 bugs
-    },
+    thresholds: { ...DEFAULT_COMPLEXITY_THRESHOLDS },
   },
 };

--- a/packages/core/src/insights/complexity-analyzer.test.ts
+++ b/packages/core/src/insights/complexity-analyzer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ComplexityAnalyzer } from './complexity-analyzer.js';
 import type { ChunkMetadata, CodeChunk } from '@liendev/parser';
+import { DEFAULT_COMPLEXITY_THRESHOLDS } from '@liendev/parser';
 import type { SearchResult, VectorDBInterface } from '../vectordb/types.js';
 
 describe('ComplexityAnalyzer', () => {
@@ -973,6 +974,102 @@ describe('ComplexityAnalyzer', () => {
         mentalLoad: 10,
       });
       expect(customReport.summary.totalViolations).toBe(2); // cyclomatic + cognitive
+    });
+  });
+
+  describe('normalizeFilePath sibling-directory fix (#988)', () => {
+    it('does not mangle a chunk file in a sibling directory sharing the workspace root as a name prefix', async () => {
+      // #988: normalizeFilePath used to have an unguarded second branch
+      // (`startsWith(normalizedRoot)` with no separator check) that stripped
+      // the root off any path merely starting with the same characters —
+      // including a sibling directory like `<root>-review-testbed`, which
+      // produced a leading-`-` path matching nothing downstream and silently
+      // dropping the file from the report. Now delegates to getCanonicalPath,
+      // which requires the boundary, so an out-of-root sibling passes through
+      // unchanged (still reported, under its own full path) instead of being
+      // mangled.
+      const root = process.cwd();
+      const siblingFile = `${root}-review-testbed/x.py`;
+
+      const chunks = [
+        {
+          content: 'def f(): pass',
+          metadata: {
+            file: siblingFile,
+            startLine: 1,
+            endLine: 5,
+            type: 'function',
+            language: 'python',
+            symbolName: 'f',
+            symbolType: 'function',
+            complexity: 20,
+          } as ChunkMetadata,
+          score: 1.0,
+          relevance: 'highly_relevant' as const,
+        },
+      ];
+      vi.mocked(mockVectorDB.scanAll).mockResolvedValue(chunks);
+
+      const report = await new ComplexityAnalyzer(mockVectorDB).analyze();
+
+      const reportedPaths = Object.keys(report.files);
+      expect(reportedPaths).toEqual([siblingFile]);
+      expect(reportedPaths.some(p => p.startsWith('-'))).toBe(false);
+    });
+  });
+
+  describe('threshold single source of truth (#988)', () => {
+    it('analyze() gates exactly at DEFAULT_COMPLEXITY_THRESHOLDS.testPaths, not an independent hardcoded copy', async () => {
+      // ComplexityAnalyzer.thresholds used to be its own hardcoded
+      // `{ testPaths: 15, ... }` literal, duplicated from (and only kept in
+      // sync with) chunk-complexity.ts's DEFAULT_THRESHOLDS by convention.
+      // This test derives the expected gate value from the canonical
+      // DEFAULT_COMPLEXITY_THRESHOLDS constant at run time, so it fails if
+      // ComplexityAnalyzer's private `thresholds` field is ever
+      // re-hardcoded to a different, independent value.
+      const t = DEFAULT_COMPLEXITY_THRESHOLDS.testPaths;
+
+      const belowThreshold = [
+        {
+          content: 'function f() { }',
+          metadata: {
+            file: 'src/t.ts',
+            startLine: 1,
+            endLine: 5,
+            type: 'function',
+            language: 'typescript',
+            symbolName: 'f',
+            symbolType: 'function',
+            complexity: t - 1,
+          } as ChunkMetadata,
+          score: 1.0,
+          relevance: 'highly_relevant' as const,
+        },
+      ];
+      vi.mocked(mockVectorDB.scanAll).mockResolvedValue(belowThreshold);
+      const belowReport = await new ComplexityAnalyzer(mockVectorDB).analyze();
+      expect(belowReport.summary.totalViolations).toBe(0);
+
+      const atThreshold = [
+        {
+          content: 'function f() { }',
+          metadata: {
+            file: 'src/t.ts',
+            startLine: 1,
+            endLine: 5,
+            type: 'function',
+            language: 'typescript',
+            symbolName: 'f',
+            symbolType: 'function',
+            complexity: t,
+          } as ChunkMetadata,
+          score: 1.0,
+          relevance: 'highly_relevant' as const,
+        },
+      ];
+      vi.mocked(mockVectorDB.scanAll).mockResolvedValue(atThreshold);
+      const atReport = await new ComplexityAnalyzer(mockVectorDB).analyze();
+      expect(atReport.summary.totalViolations).toBe(1);
     });
   });
 });

--- a/packages/core/src/insights/complexity-analyzer.ts
+++ b/packages/core/src/insights/complexity-analyzer.ts
@@ -12,6 +12,7 @@ import { RISK_ORDER } from '@liendev/parser';
 import { analyzeDependencies } from '@liendev/parser';
 import { analyzeComplexityFromChunks } from '@liendev/parser';
 import { findTestAssociationsFromChunks } from '@liendev/parser';
+import { getCanonicalPath, DEFAULT_COMPLEXITY_THRESHOLDS } from '@liendev/parser';
 
 /**
  * Hardcoded severity multipliers:
@@ -24,13 +25,10 @@ const SEVERITY = { warning: 1.0, error: 2.0 } as const;
  * Analyzer for code complexity based on indexed codebase
  */
 export class ComplexityAnalyzer {
-  // Default complexity thresholds (no config needed)
-  private readonly thresholds = {
-    testPaths: 15,
-    mentalLoad: 15,
-    timeToUnderstandMinutes: 60,
-    estimatedBugs: 1.5,
-  };
+  // Default complexity thresholds (no config needed). #988: single source of
+  // truth is `DEFAULT_COMPLEXITY_THRESHOLDS` (packages/parser/src/insights/chunk-complexity.ts) —
+  // this used to be an independent hardcoded copy.
+  private readonly thresholds = DEFAULT_COMPLEXITY_THRESHOLDS;
 
   constructor(private vectorDB: VectorDBInterface) {}
 
@@ -77,23 +75,18 @@ export class ComplexityAnalyzer {
   }
 
   /**
-   * Normalize a file path to a consistent relative format
-   * Converts absolute paths to relative paths from workspace root
+   * Normalize a file path to a consistent relative format.
+   * Converts absolute paths to relative paths from workspace root.
+   *
+   * Delegates to `getCanonicalPath` (`@liendev/parser`) — see the parser
+   * twin's identical delegation in `chunk-complexity.ts`'s `normalizeFilePath`
+   * for the full #988 rationale (this method used to have its own unguarded
+   * second branch that mangled sibling directories sharing the workspace
+   * root's name prefix).
    */
   private normalizeFilePath(filepath: string): string {
-    const workspaceRoot = process.cwd();
-    // Convert to forward slashes first
-    const normalized = filepath.replace(/\\/g, '/');
-    const normalizedRoot = workspaceRoot.replace(/\\/g, '/');
-
-    // Convert absolute paths to relative
-    if (normalized.startsWith(normalizedRoot + '/')) {
-      return normalized.slice(normalizedRoot.length + 1);
-    }
-    if (normalized.startsWith(normalizedRoot)) {
-      return normalized.slice(normalizedRoot.length);
-    }
-    return normalized;
+    const workspaceRoot = process.cwd().replace(/\\/g, '/');
+    return getCanonicalPath(filepath, workspaceRoot);
   }
 
   /**

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -196,7 +196,11 @@ export type { FileComplexityInfo, DependencyAnalysisResult } from './dependency-
 // COMPLEXITY ANALYSIS (chunk-based, no VectorDB)
 // =============================================================================
 
-export { analyzeComplexityFromChunks } from './insights/chunk-complexity.js';
+export {
+  analyzeComplexityFromChunks,
+  DEFAULT_COMPLEXITY_THRESHOLDS,
+} from './insights/chunk-complexity.js';
+export type { ComplexityThresholds } from './insights/chunk-complexity.js';
 
 // Complexity delta (before/after content → per-function verdicts) — shared by
 // the `lien delta` CLI and (as a follow-up) the PR-review engine.

--- a/packages/parser/src/insights/chunk-complexity.test.ts
+++ b/packages/parser/src/insights/chunk-complexity.test.ts
@@ -14,6 +14,7 @@ import {
   buildReport,
   enrichWithDependencies,
   analyzeComplexityFromChunks,
+  DEFAULT_COMPLEXITY_THRESHOLDS,
 } from './chunk-complexity.js';
 import type { ChunkMetadata, CodeChunk } from '../types.js';
 
@@ -59,14 +60,39 @@ describe('normalizeFilePath', () => {
     expect(normalizeFilePath('src/foo.ts')).toBe('src/foo.ts');
   });
 
-  it('strips the root even without a trailing slash boundary', () => {
-    // NOTE: this branch strips `normalizedRoot` with no separator check, so a
-    // path that merely starts with the same characters as cwd (not an actual
-    // path-boundary match) would also be stripped. Not exercised by real
-    // callers today (paths always come from the same workspace), but it's a
-    // looser check than the `+ '/'` branch above it.
+  it('does NOT strip the root without a trailing slash boundary (#988 fix)', () => {
+    // Fixed in #988: normalizeFilePath used to have a second, unguarded
+    // `startsWith(normalizedRoot)` branch with no separator check, so any
+    // string merely starting with the same characters as cwd — not an actual
+    // path-boundary match — was stripped too. It now delegates entirely to
+    // `getCanonicalPath` (../utils/path-matching.ts), which only strips at a
+    // real `/` boundary, so a non-boundary "match" like this passes through
+    // unchanged instead of being mangled.
     const abs = process.cwd() + 'x/weird.ts';
-    expect(normalizeFilePath(abs)).toBe('x/weird.ts');
+    expect(normalizeFilePath(abs)).toBe(abs);
+  });
+
+  it('does not mangle a sibling directory sharing the root name as a prefix (#988)', () => {
+    // The real-world shape #988 reported: workspace root `.../lien` and a
+    // sibling `.../lien-review-testbed` — the old unguarded branch stripped
+    // `.../lien` off the front regardless of the missing `/` boundary,
+    // producing a leading-`-` path ("-review-testbed/x.py") that matches
+    // nothing downstream, silently dropping the chunk from complexity
+    // reporting. The fix (delegating to getCanonicalPath) leaves any path
+    // that isn't actually under the root unchanged.
+    const root = process.cwd();
+    const sibling = `${root}-review-testbed/x.py`;
+    expect(normalizeFilePath(sibling)).toBe(sibling);
+
+    const otherSibling = `${root}-other/y.ts`;
+    expect(normalizeFilePath(otherSibling)).toBe(otherSibling);
+  });
+
+  it('still strips a real path under the root sharing a sibling-like suffix', () => {
+    // Sanity check alongside the sibling-prefix case above: an actual file
+    // under the root is still stripped correctly.
+    const abs = `${process.cwd()}/lien-review-testbed/x.py`;
+    expect(normalizeFilePath(abs)).toBe('lien-review-testbed/x.py');
   });
 });
 
@@ -546,11 +572,22 @@ describe('analyzeComplexityFromChunks — entry point', () => {
     expect(report.files['src/a.ts'].violations[0].symbolName).toBe('complex');
   });
 
-  it('DEFAULT_THRESHOLDS gate at testPaths=15, mentalLoad=15, timeToUnderstandMinutes=60, estimatedBugs=1.5', () => {
-    const chunks = [chunk({ file: 'src/a.ts', complexity: 14 })]; // just under default
+  it('DEFAULT_COMPLEXITY_THRESHOLDS gates at testPaths=15, mentalLoad=15, timeToUnderstandMinutes=60, estimatedBugs=1.5', () => {
+    expect(DEFAULT_COMPLEXITY_THRESHOLDS).toEqual({
+      testPaths: 15,
+      mentalLoad: 15,
+      timeToUnderstandMinutes: 60,
+      estimatedBugs: 1.5,
+    });
+
+    // Reads the threshold from the canonical constant rather than a
+    // hardcoded literal (#988), so this fails if analyzeComplexityFromChunks
+    // ever stops actually gating at DEFAULT_COMPLEXITY_THRESHOLDS.testPaths.
+    const t = DEFAULT_COMPLEXITY_THRESHOLDS.testPaths;
+    const chunks = [chunk({ file: 'src/a.ts', complexity: t - 1 })]; // just under default
     expect(analyzeComplexityFromChunks(chunks).summary.totalViolations).toBe(0);
 
-    const chunks2 = [chunk({ file: 'src/a.ts', complexity: 15 })]; // at default
+    const chunks2 = [chunk({ file: 'src/a.ts', complexity: t })]; // at default
     expect(analyzeComplexityFromChunks(chunks2).summary.totalViolations).toBe(1);
   });
 
@@ -577,8 +614,8 @@ describe('analyzeComplexityFromChunks — entry point', () => {
   // maps a single CLI `--threshold` flag onto testPaths+mentalLoad, so in
   // practice Halstead thresholds are permanently pinned to the defaults.
   // Additionally, the restriction is TYPE-ONLY: the implementation does a plain
-  // object spread (`{ ...DEFAULT_THRESHOLDS, ...thresholdOverrides }`) with no
-  // runtime validation, so a caller that defeats the type (via `as any`) CAN
+  // object spread (`{ ...DEFAULT_COMPLEXITY_THRESHOLDS, ...thresholdOverrides }`)
+  // with no runtime validation, so a caller that defeats the type (via `as any`) CAN
   // still override the Halstead thresholds too, as this test demonstrates. This
   // looks like an unintentionally narrow public type rather than a deliberate
   // guard — worth filing separately.

--- a/packages/parser/src/insights/chunk-complexity.ts
+++ b/packages/parser/src/insights/chunk-complexity.ts
@@ -9,6 +9,7 @@ import { RISK_ORDER } from './types.js';
 import type { ChunkMetadata, CodeChunk } from '../types.js';
 import { analyzeDependencies } from '../dependency-analyzer.js';
 import { findTestAssociationsFromChunks } from '../test-associations.js';
+import { getCanonicalPath } from '../utils/path-matching.js';
 
 /**
  * Hardcoded severity multipliers:
@@ -17,30 +18,58 @@ import { findTestAssociationsFromChunks } from '../test-associations.js';
  */
 const SEVERITY = { warning: 1.0, error: 2.0 } as const;
 
-/** Default complexity thresholds */
-const DEFAULT_THRESHOLDS = {
+/**
+ * Complexity thresholds shape shared by chunk-based analysis (`findViolations`
+ * below), `lien delta`'s complexity gate (`complexity-delta.ts`), and the
+ * user-facing config default (`@liendev/core`'s `LienConfig.complexity.thresholds`).
+ *
+ * #988: these four sites used to each hardcode their own copy of the same
+ * `{ testPaths: 15, mentalLoad: 15, timeToUnderstandMinutes: 60, estimatedBugs: 1.5 }`
+ * object with nothing enforcing agreement. This file is the single source of
+ * truth now (this is the reference `analyzeComplexityFromChunks` already read,
+ * and the one `complexity-delta.ts`'s own comment already pointed to) — export
+ * via `index.ts`, import everywhere else, same pattern as `COMPLEXITY_THRESHOLDS`
+ * in `../dependency-analyzer.ts`.
+ */
+export interface ComplexityThresholds {
+  testPaths: number;
+  mentalLoad: number;
+  timeToUnderstandMinutes: number;
+  estimatedBugs: number;
+}
+
+/** Default complexity thresholds — the single source of truth (#988). */
+export const DEFAULT_COMPLEXITY_THRESHOLDS: ComplexityThresholds = {
   testPaths: 15,
   mentalLoad: 15,
   timeToUnderstandMinutes: 60,
   estimatedBugs: 1.5,
-} as const;
+};
 
 /**
  * Normalize a file path to a consistent relative format.
  * Converts absolute paths to relative paths from workspace root.
+ *
+ * Delegates to `getCanonicalPath` (`../utils/path-matching.ts`) — the module
+ * that already owns this exact decision for dependency analysis. #988: this
+ * function used to have its own second, unguarded `startsWith(normalizedRoot)`
+ * fallback (no separator check), which silently mangled any sibling directory
+ * sharing the workspace root's name prefix (e.g. root `/x/lien` mangling
+ * `/x/lien-other/y.ts` into `-other/y.ts`, a leading-`-` path that matches
+ * nothing downstream, so the chunk was silently dropped from complexity
+ * reporting). `getCanonicalPath` has only the boundary-safe branch, fixing the
+ * bug and removing the duplicate implementation in the same move.
+ *
+ * The one behavioral difference: the old unguarded branch also mapped a path
+ * EXACTLY equal to the workspace root (no trailing separator) to `''`.
+ * `getCanonicalPath` does not special-case that (it requires the `/`
+ * separator), so such a path now passes through unchanged. No real caller
+ * hits this: `metadata.file`/`violation.filepath` always name an actual file
+ * under the root, never the bare root directory itself.
  */
 export function normalizeFilePath(filepath: string): string {
-  const workspaceRoot = process.cwd();
-  const normalized = filepath.replace(/\\/g, '/');
-  const normalizedRoot = workspaceRoot.replace(/\\/g, '/');
-
-  if (normalized.startsWith(normalizedRoot + '/')) {
-    return normalized.slice(normalizedRoot.length + 1);
-  }
-  if (normalized.startsWith(normalizedRoot)) {
-    return normalized.slice(normalizedRoot.length);
-  }
-  return normalized;
+  const workspaceRoot = process.cwd().replace(/\\/g, '/');
+  return getCanonicalPath(filepath, workspaceRoot);
 }
 
 /**
@@ -257,13 +286,6 @@ export function getUniqueFunctionChunks(
   return result;
 }
 
-interface ComplexityThresholds {
-  testPaths: number;
-  mentalLoad: number;
-  timeToUnderstandMinutes: number;
-  estimatedBugs: number;
-}
-
 /**
  * Find all complexity violations based on thresholds.
  */
@@ -410,7 +432,7 @@ export function analyzeComplexityFromChunks(
   files?: string[],
   thresholdOverrides?: { testPaths?: number; mentalLoad?: number },
 ): ComplexityReport {
-  const thresholds = { ...DEFAULT_THRESHOLDS, ...thresholdOverrides };
+  const thresholds = { ...DEFAULT_COMPLEXITY_THRESHOLDS, ...thresholdOverrides };
 
   // Filter to specified files if provided
   const filtered = files ? chunks.filter(c => matchesAnyFile(c.metadata.file, files)) : chunks;

--- a/packages/parser/src/insights/complexity-delta.test.ts
+++ b/packages/parser/src/insights/complexity-delta.test.ts
@@ -10,6 +10,7 @@ import {
   type FunctionComplexityDelta,
   type MetricComplexityDelta,
 } from './complexity-delta.js';
+import { DEFAULT_COMPLEXITY_THRESHOLDS } from './chunk-complexity.js';
 
 // Fixture bodies with known metrics (measured against the real chunker):
 //   trivial   cyclo 1  cog 0
@@ -221,6 +222,19 @@ describe('thresholds', () => {
       ...DEFAULT_COMPLEXITY_DELTA_THRESHOLDS,
       mentalLoad: 3,
     });
+  });
+
+  it("DEFAULT_COMPLEXITY_DELTA_THRESHOLDS is the SAME object as chunk-complexity.ts's DEFAULT_COMPLEXITY_THRESHOLDS (#988: no independent copy)", () => {
+    // `lien delta` (this module) and `analyzeComplexityFromChunks`
+    // (chunk-complexity.ts) used to each hardcode their own copy of the same
+    // defaults, with only a comment ("mirror DEFAULT_THRESHOLDS in
+    // chunk-complexity.ts") asking a human to keep them in sync by hand. A
+    // drift here would mean `lien delta` silently enforces a threshold
+    // different from the one `analyzeComplexityFromChunks`/the user-facing
+    // config default use. Asserting reference equality (not just deep
+    // equality) makes a future re-introduction of an independent literal
+    // fail immediately, rather than only failing once someone edits a value.
+    expect(DEFAULT_COMPLEXITY_DELTA_THRESHOLDS).toBe(DEFAULT_COMPLEXITY_THRESHOLDS);
   });
 
   it('default thresholds gate cognitive at 15 (the motivating incident)', () => {

--- a/packages/parser/src/insights/complexity-delta.ts
+++ b/packages/parser/src/insights/complexity-delta.ts
@@ -19,30 +19,31 @@
 import { chunkFile } from '../chunker.js';
 import type { ChunkMetadata } from '../types.js';
 import type { ComplexityMetricType } from './types.js';
-import { effortToMinutes } from './chunk-complexity.js';
+import {
+  effortToMinutes,
+  DEFAULT_COMPLEXITY_THRESHOLDS,
+  type ComplexityThresholds,
+} from './chunk-complexity.js';
 
 /**
  * Complexity thresholds — same shape and defaults as the config
  * `complexity.thresholds` block that `analyzeComplexityFromChunks` reads.
+ *
+ * #988: kept as a distinct exported name (many call sites/tests import
+ * `ComplexityDeltaThresholds` by name) but is now a plain alias of the
+ * canonical `ComplexityThresholds` shape (chunk-complexity.ts) rather than an
+ * independent duplicate.
  */
-export interface ComplexityDeltaThresholds {
-  /** Cyclomatic complexity (config: testPaths). */
-  testPaths: number;
-  /** Cognitive complexity (config: mentalLoad). */
-  mentalLoad: number;
-  /** Halstead effort, expressed as minutes-to-understand (config: timeToUnderstandMinutes). */
-  timeToUnderstandMinutes: number;
-  /** Halstead estimated bugs (config: estimatedBugs). */
-  estimatedBugs: number;
-}
+export type ComplexityDeltaThresholds = ComplexityThresholds;
 
-/** Default thresholds — mirror `DEFAULT_THRESHOLDS` in chunk-complexity.ts. */
-export const DEFAULT_COMPLEXITY_DELTA_THRESHOLDS: ComplexityDeltaThresholds = {
-  testPaths: 15,
-  mentalLoad: 15,
-  timeToUnderstandMinutes: 60,
-  estimatedBugs: 1.5,
-};
+/**
+ * Default thresholds — the canonical `DEFAULT_COMPLEXITY_THRESHOLDS`
+ * (chunk-complexity.ts). #988: this used to be an independent hardcoded copy
+ * that this file's own comment admitted was meant to "mirror" the other one —
+ * nothing enforced that. Now the same object, so it structurally can't drift.
+ */
+export const DEFAULT_COMPLEXITY_DELTA_THRESHOLDS: ComplexityDeltaThresholds =
+  DEFAULT_COMPLEXITY_THRESHOLDS;
 
 export type ComplexityDeltaVerdict =
   /** FAILS gate: function added and already over threshold. */


### PR DESCRIPTION
## Summary

Two related de-duplication fixes in the same two complexity files
(`packages/parser/src/insights/chunk-complexity.ts` and
`packages/core/src/insights/complexity-analyzer.ts`), bundled because both are
"one decision implemented at N sites."

## Part 1 — #988: `normalizeFilePath`'s unguarded second branch

**Bug:** both copies of `normalizeFilePath` had a second `startsWith(normalizedRoot)`
branch with no `/` boundary check, so any sibling directory whose name starts
with the workspace root's name got mangled (root `/x/lien` + sibling
`/x/lien-other/y.ts` → `"-other/y.ts"`, a leading-`-` path that matches
nothing downstream — the chunk silently drops out of complexity reporting).

**Decision: delegate, don't patch.** I checked semantics against
`getCanonicalPath` (`packages/parser/src/utils/path-matching.ts`) before
choosing:

- Both branches are byte-for-byte identical to `getCanonicalPath`'s single
  guarded branch (root-stripping, backslash normalization, relative-path
  passthrough all match).
- The **only** behavioral difference: the old unguarded branch also mapped a
  path *exactly equal* to the workspace root (no trailing separator) to `''`.
  `getCanonicalPath` has no such special case, so that input now passes
  through unchanged.
- That case is unreachable in practice: `metadata.file`/`violation.filepath`
  always name an actual file under the root (has a name, an extension), never
  the bare root directory itself. No test pinned it, and I couldn't construct
  a real caller that hits it.

Since the only divergence is dead code for every real caller, I delegated
both copies to `getCanonicalPath` instead of the minimal
exact-equality-branch fix — this removes the duplicate implementation *and*
the bug in the same move, per the issue's stated preference.

**#985 characterization test updated:** the `// NOTE:` test "strips the root
even without a trailing slash boundary" in
`packages/parser/src/insights/chunk-complexity.test.ts` pinned the buggy
behavior (`process.cwd() + 'x/weird.ts'` → `'x/weird.ts'`). Renamed to "does
NOT strip the root without a trailing slash boundary (#988 fix)" and the
assertion now expects the input unchanged. Added two new regression tests:
the exact sibling-prefix repro from the issue
(`lien` / `lien-review-testbed`, `lien-other`) and a sanity check that a real
child directory sharing that name is still stripped correctly. Mirrored with
an equivalent regression test in `packages/core/src/insights/complexity-analyzer.test.ts`
(private method, exercised through `analyze()`).

## Part 2 — one threshold table instead of four

Confirmed all four sites had the identical shape and values before touching
anything:

| Site | Outcome |
|---|---|
| `chunk-complexity.ts`'s `DEFAULT_THRESHOLDS` | **Promoted to the canonical source.** Renamed/exported as `DEFAULT_COMPLEXITY_THRESHOLDS` + `ComplexityThresholds` interface, exported via `parser`'s `index.ts` — same pattern as `COMPLEXITY_THRESHOLDS` in `dependency-analyzer.ts`. This file was already the one `complexity-delta.ts`'s own comment pointed to, and is slated (per #988) to become the canonical complexity implementation. |
| `complexity-delta.ts`'s `DEFAULT_COMPLEXITY_DELTA_THRESHOLDS` (powers `lien delta`, gate 6) | **Aliased**, not just deep-equal: `ComplexityDeltaThresholds` is now `type ComplexityDeltaThresholds = ComplexityThresholds` and `DEFAULT_COMPLEXITY_DELTA_THRESHOLDS = DEFAULT_COMPLEXITY_THRESHOLDS` (same object reference). Kept the distinct exported name since other call sites/tests import it by that name. |
| `complexity-analyzer.ts`'s private `thresholds` class field | **Imports the shared constant directly** (`private readonly thresholds = DEFAULT_COMPLEXITY_THRESHOLDS`) — no independent literal left. |
| `core/config/schema.ts`'s `defaultConfig.complexity.thresholds` (user-facing config default) | **Derived, not aliased.** `LienConfig`'s type intentionally stays distinct (`timeToUnderstandMinutes`/`estimatedBugs` optional, to allow a partial user override merged in `deepMergeConfig`) — this is genuinely a different type from the other three (all-required). Only the *values* are shared: `thresholds: { ...DEFAULT_COMPLEXITY_THRESHOLDS }`. |

**Divergence tests added** (fail if any site stops agreeing):
- `chunk-complexity.test.ts`: `DEFAULT_COMPLEXITY_THRESHOLDS` literal-value test, and the entry-point gate test now derives its threshold from the constant instead of a hardcoded `15`/`20`.
- `complexity-delta.test.ts`: `expect(DEFAULT_COMPLEXITY_DELTA_THRESHOLDS).toBe(DEFAULT_COMPLEXITY_THRESHOLDS)` — reference equality, not just deep equality.
- `complexity-analyzer.test.ts` (new describe block "threshold single source of truth (#988)"): behavioral test that derives the expected gate value from `DEFAULT_COMPLEXITY_THRESHOLDS.testPaths` at run time, so it fails if `ComplexityAnalyzer`'s private field is ever re-hardcoded independently.
- `core/config/schema.test.ts` (new file): `expect(defaultConfig.complexity?.thresholds).toEqual(DEFAULT_COMPLEXITY_THRESHOLDS)` — catches drift between the user-facing default and the canonical constant.

## `lien delta` gate — verified both directions

Ran `lien delta` against this change (only improvements — both
`normalizeFilePath` functions got structurally simpler):

```
lien delta — complexity vs HEAD

  packages/core/src/insights/complexity-analyzer.ts
    ✓ improved  ComplexityAnalyzer.normalizeFilePath cognitive 2 → 0

  packages/parser/src/insights/chunk-complexity.ts
    ✓ improved  normalizeFilePath        cognitive 2 → 0

  ✓ 2 improved · 9 files · 110 ms
```
Exit code: `0`.

Then verified the gate still **fails** on a genuine new crossing: temporarily
appended a deliberately-complex function to an untouched file
(`packages/cli/src/utils/banner.ts`), ran `lien delta` again:

```
  packages/cli/src/utils/banner.ts
    ✗ new>limit  __gate6TestFn            cognitive – → 16 (limit 15)
  ...
  ✗ 1 new crossing · ✓ 2 improved · 10 files · 156 ms
  → new complexity crossings introduced.
```
Exit code: `1`. Reverted (`git checkout --`) and re-ran — back to exit `0`/clean.
This confirms the gate still enforces real crossings and isn't just always
green because of this PR's own thresholds change.

## Dogfood (before/after)

Built the worktree fresh (`npm ci && npm run build && npm run build:native -w @liendev/parser-native`),
then measured `lien complexity`/`lien delta` against this repo with the
change reverted (`git checkout HEAD --` on the 5 touched source files only,
tests kept as-is) vs. restored:

**Before** (HEAD):
```
Files analyzed: 687
Violations: 92 (16 errors, 76 warnings)
Average complexity: 3.2
Max complexity: 31
```

**After** (this PR):
```
Files analyzed: 687
Violations: 92 (16 errors, 76 warnings)
Average complexity: 3.2
Max complexity: 31
```

Identical — the only diff in the full report output is line-number shifts
for 3 pre-existing violations inside the two files this PR edits
(`complexity-delta.ts`, `complexity-analyzer.ts`), from added doc comments —
same violations, same thresholds, no new/removed ones. This repo has no
sibling directory sharing its own name as a prefix, so #988's fix doesn't
surface any newly-reported paths here (as expected — the fix is dogfooded
via the added unit tests, which construct the exact sibling-prefix shape).

`lien delta` before and after: both exit `0`, no new crossings (see gate
output above for "after"; "before" was `no complexity changes across 4
file(s) vs HEAD` — just the touched test files at that point).

## Gate results

All six mandatory gates green:
- `npm run format:check` — pass
- `npm run lint` — 0 errors (37 pre-existing warnings, unrelated to this change)
- `npm run typecheck` — pass
- `npm run build` — pass
- `npm test` — **5309 tests passed**, 0 failed (baseline ~5230+, all new tests included)
- `node packages/cli/dist/index.js delta` — exit `0`, 2 improved, 0 new crossings

## Changeset

Added `.changeset/dedup-complexity-thresholds-and-normalize-path.md`:
`@liendev/parser: minor` (new exports: `DEFAULT_COMPLEXITY_THRESHOLDS`,
`ComplexityThresholds`), `@liendev/core: patch` (bug fix + internal dedup),
`@liendev/lien: patch` (downstream users of `lien complexity`/`lien delta`
get the sibling-path fix).

Closes #988

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 2 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR deduplicates two related pieces of complexity logic: it replaces two copies of `normalizeFilePath` with delegation to `getCanonicalPath` (fixing the sibling-directory-prefix mangling bug from #988) and collapses four independent copies of the default complexity thresholds into a single canonical `DEFAULT_COMPLEXITY_THRESHOLDS` exported from `@liendev/parser`. The changes are well-scoped, thoroughly tested with regression and divergence tests, and the blast radius is limited to complexity reporting and `lien delta` gating. No callers are broken, no stale duplicates of the threshold literal survive, and the one documented behavioral divergence (a path exactly equal to the workspace root now passes through instead of returning `''`) is correctly identified as unreachable.
>
> - Both `normalizeFilePath` implementations now delegate to `getCanonicalPath`, eliminating the unguarded `startsWith` fallback that mangled sibling directories sharing the root prefix.
> - Four independent threshold literals are replaced by a single `DEFAULT_COMPLEXITY_THRESHOLDS` source of truth in `chunk-complexity.ts`, exported via `@liendev/parser` and imported/aliased by `complexity-analyzer.ts`, `complexity-delta.ts`, and `core/config/schema.ts`.

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit a358562. Updates automatically on new commits.</sup>
<!-- /lien-stats -->