### PR TITLE
test(review-testbed): tighten PricingService and Config guards

### DIFF
--- a/lien-review-testbed/php/app/Services/PricingService.php
+++ b/lien-review-testbed/php/app/Services/PricingService.php
@@ -50,6 +50,12 @@ class PricingService
      */
     public function applyDiscount(float $total, string $code): float
     {
+        // A negative total means an upstream calculation error — applying a
+        // discount on top of it would silently produce a nonsensical result.
+        if ($total < 0) {
+            return $total;
+        }
+
         $normalizedCode = strtoupper(trim($code));
 
         if (!isset(self::DISCOUNT_CODES[$normalizedCode])) {

--- a/lien-review-testbed/php/app/Services/PricingService.php
+++ b/lien-review-testbed/php/app/Services/PricingService.php
@@ -52,8 +52,10 @@ class PricingService
     {
         // A negative total means an upstream calculation error — applying a
         // discount on top of it would silently produce a nonsensical result.
+        // Clamp to zero rather than passing it through, to honor this
+        // method's own "never goes below zero" contract.
         if ($total < 0) {
-            return $total;
+            return 0.0;
         }
 
         $normalizedCode = strtoupper(trim($code));

--- a/lien-review-testbed/rust/src/config.rs
+++ b/lien-review-testbed/rust/src/config.rs
@@ -70,9 +70,13 @@ impl Config {
             ));
         }
 
-        if self.max_depth > 100 {
+        // Recursive directory walks past ~50 levels are almost always a
+        // misconfigured input path (or a symlink cycle) rather than a
+        // legitimate project layout; 100 was too permissive to catch that
+        // early.
+        if self.max_depth > 50 {
             return Err(AnalyzerError::ConfigError(
-                "max_depth must not exceed 100".to_string(),
+                "max_depth must not exceed 50".to_string(),
             ));
         }
 


### PR DESCRIPTION
## Summary
- Reject a negative `$total` before applying a discount in `PricingService::applyDiscount` (PHP testbed).
- Lower `Config::validate`'s `max_depth` ceiling from 100 to 50 (Rust testbed) — 100 was too permissive for a legitimate directory-walk depth.

## Why
Both `PricingService` and `Config` are referenced by real dependents (constructor injection / type hints) that never literally call a symbol named after the class itself — exactly the shape issue #994 Phase 5 needs non-JS/TS `blast_radius` fixtures for. This PR gives `packages/review/test/harness/fixtures/blast-radius/` a real, small, hand-verifiable diff to capture via `capture-pr.ts <this-pr-number> ... --sha <this-commit>`, mirroring PR #981's Python fixture.

## Test plan
- [x] This is a testbed-only change (no `packages/*` code touched) — CI's existing testbed-analysis checks apply.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!WARNING]
> **1 issue found** · Low Risk
>
> This PR tightens two testbed fixtures. The PHP PricingService now clamps negative totals to 0.0 before discounting, which correctly honors the existing 'never goes below zero' contract (and also fixes the previously uncovered case of invalid codes with negative totals). The Rust Config lowers the max_depth ceiling from 100 to 50. The Rust threshold shift is intentional but lacks test coverage at the 50/51 boundary.
>
> - PHP applyDiscount clamps negative totals to 0.0
> - Rust Config.validate rejects max_depth > 50

✅ *Trust: **Delivered** — The review ran to completion within budget.*

**Findings (1)**

- 🟡 **logic error** in `validate` — `lien-review-testbed/rust/src/config.rs:77`
  The max_depth ceiling changed from 100 to 50, so max_depth = 51 flips from valid to invalid. No associated test exercises the new boundary value, leaving the threshold shift unverified.
  💡 *Add a test pair: max_depth = 50 must pass validation, and max_depth = 51 must fail with 'max_depth must not exceed 50'.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 7782089. Updates automatically on new commits.</sup>
<!-- /lien-stats -->