### PR TITLE
fix(parser): route import index's remaining match-side paths through importMatchesTarget (#994 Phase 3)

### DIFF
--- a/.changeset/import-index-raw-specifier.md
+++ b/.changeset/import-index-raw-specifier.md
@@ -1,0 +1,37 @@
+---
+"@liendev/parser": minor
+"@liendev/lien": patch
+---
+
+Collapse the import index's remaining unguarded match paths onto
+`importMatchesTarget` (#994 Phase 3). `dependency-analyzer.ts`'s import index
+used to store bare chunks (`Map<string, CodeChunk[]>`), discarding both the
+raw (pre-normalization) import specifier and per-importer identity once a
+bucket key was computed. That forced `findDependentChunks`'s fuzzy loop to
+reconstruct the #887 (Ruby/Go single-file-vs-package) and #929 (Python
+bare-module) guards itself, per chunk, via two extra `matchesFile` calls
+instead of calling the single guarded primitive directly — the same three
+guards expressed in two different shapes, with nothing forcing them to
+agree (the root cause behind #934 and #955 shipping the same guard gap
+twice).
+
+Each index entry now carries `{ chunk, rawSpecifier }` (`ImportIndexEntry`,
+newly exported), so `findDependentChunks`'s fuzzy loop and both of the
+index's own builders (`buildImportIndex` for `analyzeDependencies`,
+`indexImportEntry`/`addChunkToImportIndex` for `findDependents`) route
+through `importMatchesTarget` uniformly. `addFuzzyMatchChunks`'s signature
+changed accordingly (bucket entries + a normalizer, instead of a normalized
+specifier + bare chunk list) — it and `findDependentChunks` are both public
+exports of `@liendev/parser`, hence the minor bump.
+
+`buildReExportGraph`'s one remaining raw `matchesFile` call is unchanged: it
+is a same-normalizer file-identity check (skip the target file itself when
+scanning re-exporter candidates), not an import-vs-file match, so there was
+never a specifier for `importMatchesTarget` to guard there in the first
+place — see `path-matching.ts`'s updated design comment.
+
+Pure consolidation, not a behavior change: verified byte-identical
+`lien annotate` output before and after on this repo and on tracked
+multi-language fixtures (`lien-review-testbed`'s Python and Rust files).
+`lien delta` (gate 6) reports 2 improved functions (`analyzeDependencies`,
+`addFuzzyMatchChunks`), 0 regressions.

--- a/packages/parser/src/dependency-analyzer.test.ts
+++ b/packages/parser/src/dependency-analyzer.test.ts
@@ -616,6 +616,171 @@ describe('analyzeDependencies', () => {
       expect(result.dependents.map(d => d.filepath)).toContain('app/consumer.py');
     });
   });
+
+  // #994 Phase 3 characterization: `buildReExportGraph` is one of the four
+  // match-side call paths path-matching.ts:378-388 (pre-fix) documents as not
+  // routed through `importMatchesTarget`. Its own re-export detection
+  // (`fileIsReExporter` -> `findReExportedSymbolsForFile` ->
+  // `collectImportedSymbolsFromSource`) already routes through the guarded
+  // primitive, so the three guards below are exercised here at the
+  // `buildReExportGraph`/`analyzeDependencies` level for the first time --
+  // previously #884 only had unit coverage one layer down
+  // (`findReExportedSymbolsForFile`'s own describe block), and #887/#929 had
+  // none at all in the barrel/re-export path.
+  describe('buildReExportGraph guard coverage (#994 Phase 3 characterization)', () => {
+    it('#884: a Swift whole-module bare import does not make a same-basename file a re-exporter', () => {
+      const chunks: CodeChunk[] = [
+        createChunk('Source/Alamofire.swift', [], undefined, { exports: ['Alamofire'] }),
+        // Bare whole-module import sharing the target's basename (the #884
+        // false-hub shape) that also happens to export the same name --
+        // without the guard this would look like a genuine re-export.
+        createChunk('Source/Core/Session.swift', ['Alamofire'], undefined, {
+          importedSymbols: { Alamofire: ['Alamofire'] },
+          exports: ['Alamofire'],
+        }),
+        createChunk('Tests/SessionTests.swift', ['Source/Core/Session.swift'], undefined, {
+          importedSymbols: { './Session': ['Alamofire'] },
+        }),
+      ];
+
+      const result = analyzeDependencies('Source/Alamofire.swift', chunks, workspaceRoot);
+
+      const dependentPaths = result.dependents.map(d => d.filepath);
+      expect(dependentPaths).not.toContain('Source/Core/Session.swift');
+      expect(dependentPaths).not.toContain('Tests/SessionTests.swift');
+    });
+
+    it('#887 (Ruby): a bare multi-segment require does not make a sibling file a re-exporter of an unrelated target', () => {
+      // Mirrors the #887 findDependentChunks fixture above, for the
+      // re-export path instead: base.rb bare-requires 'rack/protection',
+      // which Ruby's single-file semantics resolve to the umbrella entry
+      // point ONLY, never to a sibling under the same directory. If this
+      // guard were missing here, base.rb would be wrongly credited as a
+      // re-exporter of xss_header.rb (a sibling, not the umbrella), pulling
+      // in its own consumers as fabricated transitive dependents.
+      const chunks: CodeChunk[] = [
+        createChunk('rack-protection/lib/rack/protection/base.rb', ['rack/protection'], undefined, {
+          importedSymbols: { 'rack/protection': ['ProtectionThing'] },
+          exports: ['ProtectionThing'],
+        }),
+        createChunk(
+          'rack-protection/lib/rack/protection/consumer.rb',
+          ['rack/protection/base'],
+          undefined,
+          { importedSymbols: { 'rack/protection/base': ['ProtectionThing'] } },
+        ),
+      ];
+
+      const result = analyzeDependencies(
+        'rack-protection/lib/rack/protection/xss_header.rb',
+        chunks,
+        workspaceRoot,
+      );
+
+      const dependentPaths = result.dependents.map(d => d.filepath);
+      expect(dependentPaths).not.toContain('rack-protection/lib/rack/protection/base.rb');
+      expect(dependentPaths).not.toContain('rack-protection/lib/rack/protection/consumer.rb');
+    });
+
+    it('#929 (Python): a TypeScript resolved bare-directory import does not make its file a re-exporter of an unrelated file under that directory', () => {
+      const chunks: CodeChunk[] = [
+        createChunk('src/middleware/jwt/index.ts', ['src'], undefined, {
+          importedSymbols: { src: ['color'] },
+          exports: ['color'],
+        }),
+        createChunk('src/middleware/jwt/consumer.ts', ['src/middleware/jwt/index.ts'], undefined, {
+          importedSymbols: { './index': ['color'] },
+        }),
+      ];
+
+      const result = analyzeDependencies('src/utils/color.ts', chunks, workspaceRoot);
+
+      const dependentPaths = result.dependents.map(d => d.filepath);
+      expect(dependentPaths).not.toContain('src/middleware/jwt/index.ts');
+      expect(dependentPaths).not.toContain('src/middleware/jwt/consumer.ts');
+    });
+
+    it('still finds a genuine re-exporter through a Go package-directory import (regression guard)', () => {
+      const chunks: CodeChunk[] = [
+        createChunk('internal/fs/fs.go', [], undefined, { exports: ['Open'] }),
+        createChunk('render/html.go', ['internal/fs'], undefined, {
+          importedSymbols: { 'internal/fs': ['Open'] },
+          exports: ['Open'],
+        }),
+        createChunk('app/main.go', ['render/html.go'], undefined, {
+          importedSymbols: { 'render/html': ['Open'] },
+        }),
+      ];
+
+      const result = analyzeDependencies('internal/fs/fs.go', chunks, workspaceRoot);
+
+      const dependentPaths = result.dependents.map(d => d.filepath);
+      expect(dependentPaths).toContain('render/html.go');
+      expect(dependentPaths).toContain('app/main.go');
+    });
+  });
+
+  // #994 Phase 3 characterization: `buildReExportGraph`'s own raw
+  // `matchesFile(filepath, normalizedTarget)` self-skip call (excluding the
+  // target file itself from re-exporter consideration) is orthogonal to the
+  // three guards above -- there is no import specifier in play, only two
+  // already-identically-normalized file paths, so none of #884/#887/#929
+  // apply to it. This pins its current behavior; see the NOTE below for why
+  // it's suspicious.
+  describe('buildReExportGraph self-skip fuzzy-matching (#994 Phase 3, investigated)', () => {
+    it('a two-hop re-export chain through a file whose own path fuzzy-matches the target is still found (masking regression guard)', () => {
+      // Investigation note (not a confirmed bug -- see #994 Phase 3 report):
+      // `fs/fs.go` and `internal/fs/fs.go` are two DIFFERENT real files.
+      // buildReExportGraph's self-skip does `matchesFile(filepath,
+      // normalizedTarget)` -- a fuzzy match, not exact equality, even though
+      // both sides already come from the SAME `normalizePathCached` (so a
+      // plain `===` would be exact and sufficient). `matchesFile('fs/fs.go',
+      // 'internal/fs/fs.go')` returns true via Strategy 2's permissive
+      // (Go-default) multi-segment tail match -- the same boundary rule that
+      // legitimately lets a bare `internal/fs` import credit every file in
+      // that package directory here misfires on a FILE-vs-FILE identity
+      // check instead of an import-vs-file one, so `fs/fs.go` is wrongly
+      // treated as if it WERE the target and excluded from
+      // `reExporterPaths` via `continue`.
+      //
+      // On paper this should silently drop any consumer only reachable
+      // through `fs/fs.go`'s re-export chain. Empirically it does not: ANY
+      // specifier that references `fs/fs.go` by its own path/name (the only
+      // way to build a chain through it) ALSO fuzzy-matches the target
+      // directly, by the same tail-match property that trips the self-skip
+      // in the first place. So `mid/wrapper.go` (which re-exports
+      // `fs/fs.go`'s `Open`) gets independently, directly recognized as a
+      // target re-exporter by `buildReExportGraph`'s own loop over every
+      // file in the corpus -- bypassing the broken chain through `fs/fs.go`
+      // entirely -- and `app/main.go` is still found. Two attempts to
+      // construct a repro where this masking does NOT apply were
+      // unsuccessful; the self-skip's fuzzy-vs-exact mismatch looks like a
+      // code smell (using an import matcher for a file-identity check) but
+      // has no demonstrated observable effect through `analyzeDependencies`/
+      // `findDependents`. Reported as an unconfirmed finding, not fixed here.
+      const chunks: CodeChunk[] = [
+        createChunk('internal/fs/fs.go', [], undefined, { exports: ['Open'] }),
+        createChunk('fs/fs.go', ['internal/fs'], undefined, {
+          importedSymbols: { 'internal/fs': ['Open'] },
+          exports: ['Open'],
+        }),
+        createChunk('mid/wrapper.go', ['fs/fs.go'], undefined, {
+          importedSymbols: { 'fs/fs.go': ['Open'] },
+          exports: ['Open'],
+        }),
+        createChunk('app/main.go', ['mid/wrapper.go'], undefined, {
+          importedSymbols: { 'mid/wrapper.go': ['Open'] },
+        }),
+      ];
+
+      const result = analyzeDependencies('internal/fs/fs.go', chunks, workspaceRoot);
+      const dependentPaths = result.dependents.map(d => d.filepath);
+
+      expect(dependentPaths).toContain('fs/fs.go');
+      expect(dependentPaths).toContain('mid/wrapper.go');
+      expect(dependentPaths).toContain('app/main.go');
+    });
+  });
 });
 
 // Direct unit coverage for the shared re-export intersection algorithm,

--- a/packages/parser/src/dependency-analyzer.ts
+++ b/packages/parser/src/dependency-analyzer.ts
@@ -7,8 +7,6 @@ import {
   isTestFile,
   isUnresolvableWholeModuleImport,
   importMatchesTarget,
-  hasSingleFileImportSemantics,
-  hasPythonModuleSemantics,
 } from './utils/path-matching.js';
 import { RISK_ORDER } from './insights/types.js';
 import { detectLanguage, hasEnclosingNamespaceAccess } from './ast/languages/registry.js';
@@ -105,8 +103,26 @@ function createPathNormalizer(workspaceRoot: string): (path: string) => string {
 }
 
 /**
- * Builds an index mapping normalized import paths to chunks that import them.
- * Enables O(1) lookup instead of O(n*m) iteration.
+ * One (chunk, raw import specifier) pair in an import index bucket. #994
+ * Phase 3: the index used to store bare chunks, discarding both the raw
+ * (pre-normalization) specifier and the fact that a bucket can span multiple
+ * importer files -- so match-time code (`findDependentChunks`'s fuzzy loop)
+ * had nothing to hand `importMatchesTarget` and had to re-derive the #887/
+ * #929 guards per chunk instead. Keeping `rawSpecifier` alongside each chunk
+ * means every entry now carries both of `importMatchesTarget`'s required
+ * inputs (the raw specifier and `chunk.metadata.file`), so match-time code
+ * can call the single guarded primitive directly. See path-matching.ts:378
+ * for the resulting invariant.
+ */
+export interface ImportIndexEntry<T extends CodeChunk> {
+  chunk: T;
+  rawSpecifier: string;
+}
+
+/**
+ * Builds an index mapping normalized import paths to (chunk, raw specifier)
+ * entries for chunks that import them. Enables O(1) lookup instead of
+ * O(n*m) iteration.
  *
  * Skips bare whole-module imports (#884): for a `wholeModuleImports`
  * language (Swift), a bare import can only ever match a target through
@@ -116,29 +132,31 @@ function createPathNormalizer(workspaceRoot: string): (path: string) => string {
  * feeds both `analyzeDependencies` (consumed by `ComplexityAnalyzer` for
  * complexity reports and `get_complexity`) and `findDependents` (consumed by
  * the `get_dependents` MCP tool), so both index builders need the same
- * treatment.
+ * treatment. This is an early-drop optimization, not a match-time guard --
+ * retaining `rawSpecifier` on every entry that DOES get indexed doesn't
+ * require giving it up.
  *
  * @param chunks - All chunks from the vector database
  * @param normalizePathCached - Cached path normalization function
- * @returns Map of normalized import paths to chunks that import them
+ * @returns Map of normalized import paths to matching (chunk, rawSpecifier) entries
  */
 function buildImportIndex(
   chunks: CodeChunk[],
   normalizePathCached: (path: string) => string,
-): Map<string, CodeChunk[]> {
-  const importIndex = new Map<string, CodeChunk[]>();
+): Map<string, ImportIndexEntry<CodeChunk>[]> {
+  const importIndex = new Map<string, ImportIndexEntry<CodeChunk>[]>();
 
   for (const chunk of chunks) {
     const imports = chunk.metadata.imports || [];
     for (const imp of imports) {
       if (isUnresolvableWholeModuleImport(imp, chunk.metadata.file)) continue;
       const normalizedImport = normalizePathCached(imp);
-      let chunkList = importIndex.get(normalizedImport);
-      if (!chunkList) {
-        chunkList = [];
-        importIndex.set(normalizedImport, chunkList);
+      let entries = importIndex.get(normalizedImport);
+      if (!entries) {
+        entries = [];
+        importIndex.set(normalizedImport, entries);
       }
-      chunkList.push(chunk);
+      entries.push({ chunk, rawSpecifier: imp });
     }
   }
 
@@ -146,52 +164,37 @@ function buildImportIndex(
 }
 
 /**
- * Add the chunks keyed by `normalizedImport` to the dependent set via
- * `addChunk`, applying the #887 per-chunk language check when the match is
- * ambiguous.
- *
- * A multi-segment specifier that matches `normalizedTarget` ONLY through the
- * permissive (package-directory) path -- not the strict (single-file) path
- * -- is #887's ambiguous shape: a Go-shaped importer legitimately means it
- * (every file in the package directory is a member); a Ruby-shaped importer
- * doesn't (a sibling file under the same directory is a separate, unrelated
- * module). `matchesFile` can't disambiguate that without both a target and
- * an importer's language in scope at once, and this function's `chunks`
- * bucket can span multiple importer files (and in principle languages)
- * sharing the same normalized import key, so the language check runs per
- * chunk rather than once per key -- see `hasSingleFileImportSemantics`'s doc
- * comment. `importMatchesTarget` (used by every match-side call site that
- * *does* have a single importer file) makes the same derivation once,
- * up front.
- *
- * #953: applies the same per-chunk treatment for `matchesFile`'s Python
- * Strategy 5 (`matchesParentPythonPackage`'s bare-specifier matching) --
- * see that function's own #929 doc comment for the confirmed hono/TypeScript
- * false-hub this guards against: a resolved bare directory specifier (e.g.
- * `src`, left over when no `index.<ext>` entry file exists for
- * `resolveJsDirectoryIndex` to redirect to -- see `./js-directory-index.ts`)
- * fuzzy-matching every file under that directory for a chunk with no Python
- * semantics at all. `pythonOnlyMatch` is true exactly when Strategy 5 was
- * the ONLY reason the top-of-function permissive gate matched; a genuinely
- * Python chunk still passes (its own bare-package match IS the real
- * semantic), same as `hasSingleFileImportSemantics` above.
+ * Add the chunks in an import-index bucket to the dependent set via
+ * `addChunk`, applying all three match-side guards (#884/#887/#929) through
+ * `importMatchesTarget` -- one call per entry, using that entry's own
+ * `rawSpecifier` and `chunk.metadata.file` (#994 Phase 3). Previously this
+ * function received only a normalized specifier with no per-chunk importer
+ * identity, so it had to reconstruct the #887/#929 guards itself via two
+ * extra `matchesFile` calls (`ambiguous`/`pythonOnlyMatch`) instead of
+ * calling the primitive directly -- see git history on this function for
+ * that shape. Because each `ImportIndexEntry` now carries its own raw
+ * specifier, a bucket spanning multiple importer files (and in principle
+ * languages) is handled correctly for free: `importMatchesTarget` derives
+ * each guard from that entry's own importer file, per entry, exactly like
+ * every other match-side call site.
  */
 export function addFuzzyMatchChunks<T extends CodeChunk>(
-  normalizedImport: string,
   normalizedTarget: string,
-  chunks: T[],
+  entries: ImportIndexEntry<T>[],
+  normalizePathCached: (path: string) => string,
   addChunk: (chunk: T) => void,
 ): void {
-  if (!matchesFile(normalizedImport, normalizedTarget)) return;
-
-  const ambiguous =
-    normalizedImport.includes('/') && !matchesFile(normalizedImport, normalizedTarget, true);
-  const pythonOnlyMatch = !matchesFile(normalizedImport, normalizedTarget, false, false);
-
-  for (const chunk of chunks) {
-    if (ambiguous && hasSingleFileImportSemantics(chunk.metadata.file)) continue;
-    if (pythonOnlyMatch && !hasPythonModuleSemantics(chunk.metadata.file)) continue;
-    addChunk(chunk);
+  for (const entry of entries) {
+    if (
+      importMatchesTarget(
+        entry.rawSpecifier,
+        entry.chunk.metadata.file,
+        normalizedTarget,
+        normalizePathCached,
+      )
+    ) {
+      addChunk(entry.chunk);
+    }
   }
 }
 
@@ -199,12 +202,15 @@ export function addFuzzyMatchChunks<T extends CodeChunk>(
  * Finds all chunks that import the target file using index + fuzzy matching.
  *
  * @param normalizedTarget - The normalized path of the target file
- * @param importIndex - Index mapping import paths to chunks
+ * @param importIndex - Index mapping import paths to (chunk, rawSpecifier) entries
+ * @param normalizePathCached - Cached path normalization function, threaded
+ *   through to `importMatchesTarget` for the fuzzy match branch (#994)
  * @returns Array of chunks that import the target file (deduplicated)
  */
 export function findDependentChunks<T extends CodeChunk>(
   normalizedTarget: string,
-  importIndex: Map<string, T[]>,
+  importIndex: Map<string, ImportIndexEntry<T>[]>,
+  normalizePathCached: (path: string) => string,
 ): T[] {
   const dependentChunks: T[] = [];
   const seenChunkIds = new Set<string>();
@@ -217,20 +223,22 @@ export function findDependentChunks<T extends CodeChunk>(
     }
   };
 
-  // Direct index lookup (fastest path)
+  // Direct index lookup (fastest path). Bucket entries were built via the
+  // identical normalizePathCached, and already passed the build-time #884
+  // prune, so no further guard is needed for an exact key match.
   const directMatches = importIndex.get(normalizedTarget);
   if (directMatches) {
-    for (const chunk of directMatches) {
-      addChunk(chunk);
+    for (const entry of directMatches) {
+      addChunk(entry.chunk);
     }
   }
 
   // Fuzzy match for relative imports and path variations
   // Note: This is O(M) where M = unique import paths. For large codebases with many
   // violations, consider caching fuzzy match results at a higher level.
-  for (const [normalizedImport, chunks] of importIndex.entries()) {
+  for (const [normalizedImport, entries] of importIndex.entries()) {
     if (normalizedImport !== normalizedTarget) {
-      addFuzzyMatchChunks(normalizedImport, normalizedTarget, chunks, addChunk);
+      addFuzzyMatchChunks(normalizedTarget, entries, normalizePathCached, addChunk);
     }
   }
 
@@ -634,7 +642,7 @@ function processTransitiveChunk(
  */
 export function findTransitiveDependents(
   reExporterPaths: string[],
-  importIndex: Map<string, CodeChunk[]>,
+  importIndex: Map<string, ImportIndexEntry<CodeChunk>[]>,
   normalizedTarget: string,
   normalizePathCached: (path: string) => string,
   allChunksByFile: Map<string, CodeChunk[]>,
@@ -653,7 +661,7 @@ export function findTransitiveDependents(
 
   while (queue.length > 0) {
     const [reExporterPath, depth] = queue.shift()!;
-    const dependentChunks = findDependentChunks(reExporterPath, importIndex);
+    const dependentChunks = findDependentChunks(reExporterPath, importIndex, normalizePathCached);
 
     for (const chunk of dependentChunks) {
       const result = processTransitiveChunk(
@@ -670,6 +678,45 @@ export function findTransitiveDependents(
   }
 
   return transitiveChunks;
+}
+
+/**
+ * Find transitive dependents through re-export chains (barrel files) and
+ * merge them into `chunksByFile` in place. Extracted out of
+ * `analyzeDependencies` to keep that function's own complexity flat (#994
+ * Phase 3) -- mirrors `resolveTransitiveDependents`/`mergeTransitiveDependents`
+ * further down, the `findDependents` equivalent of this same merge; this
+ * version has no `ScanContext`/`log` callback since `analyzeDependencies`
+ * has no logging contract.
+ */
+function mergeReExportTransitiveDependents(
+  allChunksByFile: Map<string, CodeChunk[]>,
+  normalizedTarget: string,
+  normalizePathCached: (path: string) => string,
+  importIndex: Map<string, ImportIndexEntry<CodeChunk>[]>,
+  workspaceRoot: string,
+  chunksByFile: Map<string, CodeChunk[]>,
+): void {
+  const reExporterPaths = buildReExportGraph(
+    allChunksByFile,
+    normalizedTarget,
+    normalizePathCached,
+  );
+  if (reExporterPaths.length === 0) return;
+
+  const existingFiles = new Set(chunksByFile.keys());
+  const transitiveChunks = findTransitiveDependents(
+    reExporterPaths,
+    importIndex,
+    normalizedTarget,
+    normalizePathCached,
+    allChunksByFile,
+    existingFiles,
+  );
+  if (transitiveChunks.length > 0) {
+    const transitiveByFile = groupChunksByFile(transitiveChunks, workspaceRoot);
+    mergeChunksByFile(chunksByFile, transitiveByFile);
+  }
 }
 
 /**
@@ -693,39 +740,21 @@ export function analyzeDependencies(
 
   // Find all dependent chunks
   const normalizedTarget = normalizePathCached(targetFilepath);
-  const dependentChunks = findDependentChunks(normalizedTarget, importIndex);
+  const dependentChunks = findDependentChunks(normalizedTarget, importIndex, normalizePathCached);
 
   // Group by file for analysis
   const chunksByFile = groupChunksByFile(dependentChunks, workspaceRoot);
 
   // Find transitive dependents through re-export chains (barrel files)
   const allChunksByFile = groupChunksByNormalizedPath(allChunks, normalizePathCached);
-  const reExporterPaths = buildReExportGraph(
+  mergeReExportTransitiveDependents(
     allChunksByFile,
     normalizedTarget,
     normalizePathCached,
+    importIndex,
+    workspaceRoot,
+    chunksByFile,
   );
-  if (reExporterPaths.length > 0) {
-    const existingFiles = new Set(chunksByFile.keys());
-    const transitiveChunks = findTransitiveDependents(
-      reExporterPaths,
-      importIndex,
-      normalizedTarget,
-      normalizePathCached,
-      allChunksByFile,
-      existingFiles,
-    );
-    if (transitiveChunks.length > 0) {
-      const transitiveByFile = groupChunksByFile(transitiveChunks, workspaceRoot);
-      for (const [fp, chunks] of transitiveByFile.entries()) {
-        if (chunksByFile.has(fp)) {
-          chunksByFile.get(fp)!.push(...chunks);
-        } else {
-          chunksByFile.set(fp, chunks);
-        }
-      }
-    }
-  }
 
   // Calculate complexity metrics
   const fileComplexities = calculateFileComplexities(chunksByFile);
@@ -957,19 +986,23 @@ function fileImportsSymbolFromAny<T extends CodeChunk>(
  * dependency — see `isUnresolvableWholeModuleImport`'s doc comment. Indexing
  * it anyway would let it win both the direct-lookup and fuzzy-match branches
  * of `findDependentChunks` purely by coincidence.
+ *
+ * Stores the raw `importPath` alongside the chunk (#994 Phase 3) so
+ * `findDependentChunks`'s fuzzy loop can call `importMatchesTarget` directly
+ * instead of reconstructing the #887/#929 guards from a bare chunk list.
  */
 function indexImportEntry<T extends CodeChunk>(
   importPath: string,
   chunk: T,
   normalizePathCached: (path: string) => string,
-  importIndex: Map<string, T[]>,
+  importIndex: Map<string, ImportIndexEntry<T>[]>,
 ): void {
   if (isUnresolvableWholeModuleImport(importPath, chunk.metadata.file)) return;
   const normalizedImport = normalizePathCached(importPath);
   if (!importIndex.has(normalizedImport)) {
     importIndex.set(normalizedImport, []);
   }
-  importIndex.get(normalizedImport)!.push(chunk);
+  importIndex.get(normalizedImport)!.push({ chunk, rawSpecifier: importPath });
 }
 
 /**
@@ -978,7 +1011,7 @@ function indexImportEntry<T extends CodeChunk>(
 function addChunkToImportIndex<T extends CodeChunk>(
   chunk: T,
   normalizePathCached: (path: string) => string,
-  importIndex: Map<string, T[]>,
+  importIndex: Map<string, ImportIndexEntry<T>[]>,
 ): void {
   const imports = chunk.metadata.imports || [];
   for (const imp of imports) {
@@ -1030,10 +1063,10 @@ function buildScanIndex<T extends CodeChunk>(
   chunks: Iterable<T>,
   normalizePathCached: (path: string) => string,
 ): {
-  importIndex: Map<string, T[]>;
+  importIndex: Map<string, ImportIndexEntry<T>[]>;
   allChunksByFile: Map<string, T[]>;
 } {
-  const importIndex = new Map<string, T[]>();
+  const importIndex = new Map<string, ImportIndexEntry<T>[]>();
   const allChunksByFile = new Map<string, T[]>();
   const seenRanges = new Map<string, Set<string>>();
 
@@ -1209,7 +1242,7 @@ function mergeChunksByFile<T extends CodeChunk>(
  * travel together, so grouping them removes parameter noise from helpers.
  */
 interface ScanContext<T extends CodeChunk> {
-  importIndex: Map<string, T[]>;
+  importIndex: Map<string, ImportIndexEntry<T>[]>;
   allChunksByFile: Map<string, T[]>;
   normalizePathCached: (p: string) => string;
   log: (message: string, level?: 'warning') => void;
@@ -1614,7 +1647,11 @@ function seedDepth1Dependents<T extends CodeChunk>(
   ctx: ScanContext<T>,
   normalizedTarget: string,
 ): { chunksByFile: Map<string, T[]>; reExporterPaths: string[] } {
-  const dependentChunks = findDependentChunks(normalizedTarget, ctx.importIndex);
+  const dependentChunks = findDependentChunks(
+    normalizedTarget,
+    ctx.importIndex,
+    ctx.normalizePathCached,
+  );
   const chunksByFile = groupChunksByFile(dependentChunks, ctx.workspaceRoot);
   const reExporterPaths = resolveTransitiveDependents(ctx, normalizedTarget, chunksByFile);
   return { chunksByFile, reExporterPaths };
@@ -1754,7 +1791,11 @@ function discoverFrontierDependents<T extends CodeChunk>(
   ctx: ScanContext<T>,
   normalizedFrontier: string,
 ): Map<string, T[]> {
-  const dependentChunks = findDependentChunks(normalizedFrontier, ctx.importIndex);
+  const dependentChunks = findDependentChunks(
+    normalizedFrontier,
+    ctx.importIndex,
+    ctx.normalizePathCached,
+  );
   if (dependentChunks.length === 0) return new Map();
   const grouped = groupChunksByFile(dependentChunks, ctx.workspaceRoot);
   resolveTransitiveDependents(ctx, normalizedFrontier, grouped);
@@ -1820,7 +1861,11 @@ function countUncoveredProductionDependents<T extends CodeChunk>(
 }
 
 function hasTestImporter<T extends CodeChunk>(filepath: string, ctx: ScanContext<T>): boolean {
-  const importers = findDependentChunks(ctx.normalizePathCached(filepath), ctx.importIndex);
+  const importers = findDependentChunks(
+    ctx.normalizePathCached(filepath),
+    ctx.importIndex,
+    ctx.normalizePathCached,
+  );
   for (const chunk of importers) {
     if (isTestFile(chunk.metadata.file)) return true;
   }

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -198,6 +198,7 @@ export type {
   ComplexityMetrics,
   DependentInfo,
   SymbolUsage,
+  ImportIndexEntry,
 } from './dependency-analyzer.js';
 
 // =============================================================================

--- a/packages/parser/src/utils/path-matching.ts
+++ b/packages/parser/src/utils/path-matching.ts
@@ -272,8 +272,10 @@ export function isUnresolvableWholeModuleImport(
  * caller passes the default (`true`), preserving this function's pre-#929
  * behavior exactly -- this is deliberately scoped to `importMatchesTarget`'s
  * match-side callers, mirroring #887's precedent, not to `matchesFile`'s
- * direct callers (existing Python fixtures, `findDependentChunks`'s fuzzy
- * loop, `buildReExportGraph`).
+ * remaining direct callers (existing Python fixtures, `buildReExportGraph`'s
+ * self-skip check -- see `importMatchesTarget`'s doc comment for why
+ * `findDependentChunks`'s fuzzy loop no longer belongs on this list as of
+ * #994 Phase 3).
  *
  * @param normalizedImport - Normalized import path
  * @param normalizedTarget - Normalized target file path
@@ -377,14 +379,35 @@ export function matchesFile(
  *
  * Every match-side reverse-dependency call path that used to open-code
  * `!isUnresolvableWholeModuleImport(imp, f) && matchesFile(normalize(imp), t)`
- * now goes through here instead (#886); the two build-side sites that index
- * imports with no target in scope (`buildImportIndex`,
- * `indexImportEntry`/`addChunkToImportIndex`) still call
- * `isUnresolvableWholeModuleImport` directly, and `findDependentChunks`'s
- * fuzzy loop and `buildReExportGraph` stay on raw `matchesFile` -- see #886's
- * design comment for why those four are not routed through this primitive,
- * and `findDependentChunks`'s own doc comment for how it independently
- * derives the #887 distinction per-chunk (it has no single importer file).
+ * now goes through here instead (#886). Three call paths in
+ * `dependency-analyzer.ts` used to be the exception, and are no longer (#994
+ * Phase 3):
+ *
+ * - The two build-side sites that index imports with no target in scope
+ *   (`buildImportIndex`, `indexImportEntry`/`addChunkToImportIndex`) still
+ *   call `isUnresolvableWholeModuleImport` directly at build time (that part
+ *   hasn't changed -- it's an early-drop optimization, and there's still no
+ *   target to compare against yet). What changed is what they store: each
+ *   index entry now keeps the raw (pre-normalization) specifier alongside its
+ *   chunk (`ImportIndexEntry`), instead of discarding it once the bucket key
+ *   is computed.
+ * - `findDependentChunks`'s fuzzy loop (`addFuzzyMatchChunks`) used to have
+ *   nothing but a normalized specifier and a bare chunk list to work with, so
+ *   it reconstructed the #887/#929 guards itself via two extra `matchesFile`
+ *   calls per bucket. With `rawSpecifier` preserved on every entry, it now
+ *   calls `importMatchesTarget` directly, per entry -- the same primitive,
+ *   the same guards, no reconstruction.
+ *
+ * `buildReExportGraph` is unchanged and still not routed through here, for a
+ * different reason than the other three: it never reads the import index at
+ * all. Its own re-export detection (`fileIsReExporter` ->
+ * `findReExportedSymbolsForFile` -> `collectImportedSymbolsFromSource`)
+ * already calls `importMatchesTarget` (that was already true before #994).
+ * The one raw `matchesFile` call left in `buildReExportGraph` itself is a
+ * same-normalizer FILE-vs-FILE identity check (skip the target file when
+ * scanning candidates), not an import-vs-file match -- there is no
+ * `importSpecifier` in that comparison for this primitive to guard, so it
+ * was never a candidate for routing through it in the first place.
  *
  * @param importSpecifier - The raw (pre-normalization) import specifier, or
  *   an `importedSymbols` key (same shape).
@@ -412,8 +435,13 @@ export function importMatchesTarget(
 /**
  * True when `importerFile`'s language sets `LanguageDefinition.singleFileImports`
  * (Ruby today) -- see that flag's doc comment for the Ruby-vs-Go distinction
- * this drives. Shared by `importMatchesTarget` and `findDependentChunks`'s
- * per-chunk #887 check so the two can't compute it differently.
+ * this drives. Until #994 Phase 3, this was also called directly by
+ * `findDependentChunks`'s own per-chunk #887 reconstruction (see git history
+ * on `addFuzzyMatchChunks`), specifically so the two computations couldn't
+ * drift apart. `findDependentChunks` now routes through `importMatchesTarget`
+ * like every other match-side call site, so `importMatchesTarget` is this
+ * function's only caller -- there is no longer a second computation to keep
+ * in sync with.
  */
 export function hasSingleFileImportSemantics(importerFile: string): boolean {
   const language = detectLanguage(importerFile);


### PR DESCRIPTION
## Summary

Phase 3 of the duplication refactor tracked in #994. `path-matching.ts:378-388` documented four match-side call paths deliberately not routed through the `importMatchesTarget` primitive (#886) because the import index (`Map<string, CodeChunk[]>`) discarded the raw import specifier and per-importer identity once a bucket key was computed. This is the root cause behind #934 and #955 shipping the same guard gap twice (44 minutes apart, per the dated commit evidence in #994).

- Each index entry now carries `{ chunk, rawSpecifier }` (`ImportIndexEntry<T>`, exported from `@liendev/parser`).
- `buildImportIndex` (analyzeDependencies's index) and `indexImportEntry`/`addChunkToImportIndex` (findDependents's index) still prune bare whole-module imports (#884) at build time — unchanged, an early-drop optimization that doesn't require giving up the raw specifier on what does get indexed.
- `findDependentChunks`'s fuzzy loop (`addFuzzyMatchChunks`) no longer reconstructs the #887/#929 guards itself via two extra `matchesFile` calls per bucket — it now calls `importMatchesTarget(entry.rawSpecifier, entry.chunk.metadata.file, normalizedTarget, normalize)` directly, per entry, the same primitive every other match-side call site uses.
- `buildReExportGraph` is **deliberately left unrouted** — see "Scope decision" below.
- Extracted `mergeReExportTransitiveDependents` out of `analyzeDependencies` to keep its own complexity flat (the added parameter pushed it over `lien delta`'s threshold — see Gate 6 below) and replaced an inline `Map` merge loop with the existing `mergeChunksByFile` helper.
- Updated `path-matching.ts`'s design comment plus two doc comments (`importMatchesTarget`, `hasSingleFileImportSemantics`) that would have gone stale describing the old four-unrouted-sites shape.

## The 3×4 matrix (guards × call paths)

Guards: **G1** = #884 whole-module, **G2** = #887 single-file-vs-package (Ruby/Go), **G3** = #929 Python bare-module.
Call paths: **P1** = `buildImportIndex`, **P2** = `indexImportEntry`/`addChunkToImportIndex`, **P3** = `findDependentChunks`'s fuzzy loop, **P4** = `buildReExportGraph`.

| | G1 (#884) | G2 (#887) | G3 (#929) |
|---|---|---|---|
| **P1** `buildImportIndex` | Applicable (build-time prune) — **tested** (`analyzeDependencies` "#884" block) | N/A (match-time only) | N/A |
| **P2** `indexImportEntry`/`addChunkToImportIndex` | Applicable — **tested** (CLI `findDependents` "#884" block) | N/A | N/A |
| **P3** `findDependentChunks` fuzzy loop | N/A (already pruned upstream) | Applicable — **tested** (both `analyzeDependencies` and CLI `findDependents` "#887" blocks) | Applicable — **tested** (both suites' "#953" blocks, incl. a depth-2 BFS-pollution test) |
| **P4** `buildReExportGraph` | Applicable (via already-routed `fileIsReExporter`) — **EMPTY** before this PR (only unit-tested one layer below, at `findReExportedSymbolsForFile`) | Applicable — **EMPTY anywhere** | Applicable — **EMPTY anywhere** |

**Empty cells found and fixed:** all three P4 cells. Added characterization tests at the `buildReExportGraph`/`analyzeDependencies` level for all three guards, in `dependency-analyzer.test.ts` (separate commit, before the production fix): `66a704a9`.

## Scope decision: `buildReExportGraph` is not routed through `importMatchesTarget`

While writing the characterization tests I found the "four sites" framing doesn't fit `buildReExportGraph` the same way as the other three. It **never reads the import index at all** — it iterates `allChunksByFile` directly and calls `fileIsReExporter` → `findReExportedSymbolsForFile` → `collectImportedSymbolsFromSource`, which **already** routes through `importMatchesTarget` (that was true before this PR). The one raw `matchesFile` call left in `buildReExportGraph` itself is `matchesFile(filepath, normalizedTarget)` — a same-normalizer **file-identity** check (skip the target file itself among re-exporter candidates), not an import-vs-file match. There's no `importSpecifier` in that comparison for the primitive to guard, so retaining the raw specifier in the index (this PR's actual mechanism) doesn't touch it. I updated `path-matching.ts`'s design comment to say this plainly rather than force-fitting `buildReExportGraph` onto a mechanism that doesn't apply to it.

**Investigated separately:** that self-skip call uses fuzzy `matchesFile` for what is actually an exact-equality question (both sides already come from the same `normalizePathCached`, so `===` would be exact and sufficient). I constructed two scenarios trying to demonstrate an observable bug from this fuzzy-vs-exact mismatch and both failed — any specifier that references a self-skip-triggering file by its own name also happens to fuzzy-match the target directly (the same tail-match property that trips the self-skip), so the affected file gets independently, correctly recognized as a re-exporter through the ordinary corpus-wide scan regardless. This is pinned as a passing regression test (`buildReExportGraph self-skip fuzzy-matching (#994 Phase 3, investigated)`) documenting the investigation rather than a bug fix — reporting it as an unconfirmed code smell, not filing it as a bug, since I could not demonstrate actual harm.

## Sibling sweep

Dispatched a repo-wide search for other `Map<string, ...[]>`-shaped import indexes that discard the raw specifier the same way, and for any other direct (unguarded) `matchesFile` match-side call, outside the three known-excluded cases (`dependent-counts.ts`, `review/src/dependency-graph.ts` — tracked as Phase 5, and `buildReExportGraph`'s self-skip).

**Result: no siblings found.** Codebase-wide, `matchesFile(` has exactly 4 hits outside tests: its own definition, its own doc comment, its call inside `importMatchesTarget` itself, and `buildReExportGraph`'s self-skip (already accounted for above) — nothing else calls it directly. The other import-matching-adjacent indexes in the tree don't share this shape for a structural reason, not an oversight: `test-associations.ts` and `get-files-context.ts`'s test-file matchers call `importMatchesTarget` inline per import (no separate index to discard anything from); `go-same-directory-tests.ts`/`java-same-package-tests.ts` key their index by **directory**, not import specifier (these languages emit no import statement for the association at all); `swift-symbol-usage-signals.ts` and `csharp-type-reference-signals.ts` are call-site/type-name driven, not import-driven. `packages/action/src` has no import-matching code. (One dead end during the sweep: Lien's own MCP search index is stale — pinned at a commit that predates this PR — and initially suggested a bare `Map<string, SearchResult[]>` still existed in `packages/cli/src/mcp/handlers/dependency-analyzer.ts`; the actual file on disk confirmed that engine was already relocated into `packages/parser/src/dependency-analyzer.ts` by #992, where this PR's fix already applies.)

## Gates (all in this worktree)

- `npm run format:check` — pass
- `npm run lint` — 0 errors (pre-existing warnings unrelated to touched files)
- `npm run typecheck` — pass, all packages
- `npm run build` — pass, all packages
- `npm test` — **all green**: parser 1607/1607, core 406/406, cli 1525/1525 (root suite excludes E2E), review 1723/1723, action 41/41. (A direct `vitest run packages/cli` from the monorepo root shows 7 pre-existing failures in `annotate-cmd.test.ts` caused by `process.cwd()` returning this worktree's full nested path instead of a repo-relative one — confirmed pre-existing by reverting my changes via a tagged `git stash` and re-running; the proper `npm test` orchestration (which `cd`s into each workspace) shows 0 failures.)
- `npm run test:e2e:python -w packages/cli` — pass (Requests, 14/14 non-skipped) — required
- `npm run test:e2e:go -w packages/cli` — pass (Chi, 14/14 non-skipped) — the required "one more language," chosen since Go is central to #887's package-directory semantics
- Bonus, not required but directly relevant to the guards touched: `test:e2e:ruby` (Sinatra, #887's other language) and `test:e2e:swift` (SwiftyJSON, #884's whole-module language) — both pass, 14/14 non-skipped
- `lien delta` (gate 6) — **exit 0**. `analyzeDependencies` improved (cognitive 14→3) after the extraction; `addFuzzyMatchChunks` improved (cognitive 9→3); 9 functions show an advisory "worsened" (Halstead `time`, all still comfortably under threshold — the extra `normalizePathCached` parameter threaded through); 0 new crossings.

## Dogfood evidence (mandatory, verbatim)

`lien index --force` on this repo, then `lien annotate` (the CLI's `findDependents`-backed impact command) against 7 real targets, captured **before** the fix (stashed working tree, rebuilt) and **after** (fix restored, rebuilt) — byte-identical `diff` on every target:

```
$ node packages/cli/dist/index.js index --force
✔ Overlay ready: 142 added, 244 modified, 114 deleted, 304 shared with base (386/386)

$ node packages/cli/dist/index.js annotate packages/parser/src/utils/path-matching.ts
Lien impact for packages/parser/src/utils/path-matching.ts:
  • 34 files import this — packages/parser/src/test-associations.ts, packages/parser/src/swift-symbol-usage-signals.ts, packages/parser/src/index.ts, packages/parser/src/dependency-analyzer.ts, +30 more; risk: high (34 callers, 2 untested, max complexity 11).
  • Test coverage: packages/parser/src/utils/path-matching.test.ts, packages/parser/src/ast/symbols.test.ts.

$ node packages/cli/dist/index.js annotate packages/parser/src/dependency-analyzer.ts
Lien impact for packages/parser/src/dependency-analyzer.ts:
  • 28 files import this — packages/parser/src/index.ts, packages/parser/src/insights/chunk-complexity.ts, packages/cli/src/cli/delta-git.ts, packages/core/src/constants.ts, +24 more; risk: high (28 callers, 2 untested, max complexity 11).
  • Test coverage: packages/parser/src/dependency-analyzer.test.ts.

$ node packages/cli/dist/index.js annotate lien-review-testbed/python/pipeline/models.py
Lien impact for lien-review-testbed/python/pipeline/models.py:
  • 8 files import this — lien-review-testbed/python/pipeline/validator.py, lien-review-testbed/python/pipeline/transformer.py, lien-review-testbed/python/pipeline/processor.py, lien-review-testbed/python/pipeline/reporter.py, +4 more; risk: high (8 callers, 8 untested, max complexity 11, untested high-complexity dependent).
  • No test coverage.

$ node packages/cli/dist/index.js annotate lien-review-testbed/python/pipeline/cache.py
Lien impact for lien-review-testbed/python/pipeline/cache.py:
  • 2 files import this — lien-review-testbed/python/pipeline/processor.py, lien-review-testbed/python/pipeline/cli.py; risk: high (2 callers, 2 untested, max complexity 11, untested high-complexity dependent).
  • No test coverage.

$ node packages/cli/dist/index.js annotate lien-review-testbed/rust/src/cache.rs
Lien impact for lien-review-testbed/rust/src/cache.rs:
  • No test coverage.

$ node packages/cli/dist/index.js annotate lien-review-testbed/rust/src/error.rs
Lien impact for lien-review-testbed/rust/src/error.rs:
  • No test coverage.
```

Method: captured the same 7 `annotate` invocations against a `git stash`-reverted tree (tagged `phase3-994-dogfood-before-baseline`, rebuilt `@liendev/parser`/`@liendev/core`/`packages/cli`), then restored the fix (`git stash apply` + drop) and rebuilt again. `diff` between before/after output was empty (exit 0) for all 7 targets — this is a consolidation, dependent sets are identical, as expected for a pure "same guards, one primitive" refactor.

## Reporting

- No AI attribution added to commits per repo convention.
- Two commits: characterization tests first (`66a704a9`), production fix second (`ffa9681b`).
- Nothing pinned as a confirmed bug in this PR — the one adjacent finding (`buildReExportGraph`'s self-skip fuzzy-vs-exact mismatch) is documented above as investigated-but-unconfirmed, with a passing regression test, not filed as a new issue since I could not demonstrate observable harm.

Reference: #994 (Phase 3).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Medium Risk**
>
> This PR consolidates the parser's import-matching guard logic by preserving the raw import specifier in the import index (`ImportIndexEntry`) and routing `findDependentChunks`'s fuzzy loop through the existing `importMatchesTarget` primitive. The implementation appears correct: all internal callers are updated, the direct-index path safely reuses the build-time #884 prune, and the new characterization tests cover the previously empty P4 guard cells. Dogfood evidence shows byte-identical output. Risk is medium purely because of the public API signature changes (`addFuzzyMatchChunks`, `findDependentChunks`, new `ImportIndexEntry` export) and the high transitive blast radius, not because of observed defects.
>
> - Import index entries now carry `{ chunk, rawSpecifier }` instead of bare chunks
> - `addFuzzyMatchChunks`/`findDependentChunks` signatures changed to thread the normalizer and entries
> - Fuzzy matching now delegates to `importMatchesTarget` per entry instead of reconstructing #887/#929 guards
> - Added `buildReExportGraph` guard characterization tests and extracted `mergeReExportTransitiveDependents`

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit ffa9681. Updates automatically on new commits.</sup>
<!-- /lien-stats -->