### PR TITLE
fix(parser): resolve Rust mod_item declarations to concrete import edges

### DIFF
--- a/.changeset/rust-mod-item-import-edges.md
+++ b/.changeset/rust-mod-item-import-edges.md
@@ -11,17 +11,22 @@ zero import edges. `get_dependents` on the child module returned a
 confident, wrong `[]` (or an undercount when the file also happened to gain
 one edge via an unrelated `use crate::x` elsewhere).
 
-A `mod x;` declaration is resolved to the CONCRETE sibling path it names
-(`x.rs`/`x/mod.rs` relative to the declaring file, honoring the leaf-file
-2018+-edition directory-split convention, inline-mod nesting, and a
-`#[path = "..."]` override) rather than emitted as a bare specifier for
-downstream fuzzy bare-module matching to guess at — the bare-specifier shape
-is exactly what #928/#884's `isUnresolvableWholeModuleImport` guard exists to
-reject, so resolving deterministically up front avoids reintroducing that
-fabrication bug. An inline `mod x { ... }` (has a body, e.g. `#[cfg(test)]
-mod tests { ... }`) is a namespace, not an import, and correctly produces no
-edge for itself; `collectImportNodes` now recurses into such a body so any
-`use`/nested `mod` declared inside it is still discovered.
+A `mod x;` declaration is resolved to a directory-anchored, extensionless
+module path (e.g. `src/reporter` for `src/main.rs`'s `mod reporter;`,
+honoring the leaf-file 2018+-edition directory-split convention, inline-mod
+nesting, and a `#[path = "..."]` override) rather than emitted as an
+unanchored bare specifier for downstream fuzzy bare-module matching to
+guess at. The extractor itself doesn't choose between the `x.rs` and
+`x/mod.rs` on-disk conventions — it leaves the specifier extensionless, and
+downstream matching (which already normalizes every candidate file path by
+stripping extensions) resolves it to whichever one is actually on disk. The
+unanchored-bare-specifier shape is exactly what #928/#884's
+`isUnresolvableWholeModuleImport` guard exists to reject, so resolving to a
+directory-anchored path up front avoids reintroducing that fabrication bug.
+An inline `mod x { ... }` (has a body, e.g. `#[cfg(test)] mod tests { ... }`)
+is a namespace, not an import, and correctly produces no edge for itself;
+`collectImportNodes` now recurses into such a body so any `use`/nested `mod`
+declared inside it is still discovered.
 
 Verified on the tracked `lien-review-testbed/rust` fixture (reporter.rs
 0 -> 1 dependent, formatter.rs and parser.rs each gain the previously-missing

--- a/.changeset/rust-mod-item-import-edges.md
+++ b/.changeset/rust-mod-item-import-edges.md
@@ -1,0 +1,31 @@
+---
+"@liendev/parser": patch
+---
+
+Fix Rust `mod X;` declarations producing no import edge (#1000).
+
+`RustImportExtractor.importNodeTypes` only listed `use_declaration` —
+`mod_item` was absent, so the idiomatic Rust pattern of `mod x;` at the
+crate root plus qualified calls (`x::func()`) with no `use` at all produced
+zero import edges. `get_dependents` on the child module returned a
+confident, wrong `[]` (or an undercount when the file also happened to gain
+one edge via an unrelated `use crate::x` elsewhere).
+
+A `mod x;` declaration is resolved to the CONCRETE sibling path it names
+(`x.rs`/`x/mod.rs` relative to the declaring file, honoring the leaf-file
+2018+-edition directory-split convention, inline-mod nesting, and a
+`#[path = "..."]` override) rather than emitted as a bare specifier for
+downstream fuzzy bare-module matching to guess at — the bare-specifier shape
+is exactly what #928/#884's `isUnresolvableWholeModuleImport` guard exists to
+reject, so resolving deterministically up front avoids reintroducing that
+fabrication bug. An inline `mod x { ... }` (has a body, e.g. `#[cfg(test)]
+mod tests { ... }`) is a namespace, not an import, and correctly produces no
+edge for itself; `collectImportNodes` now recurses into such a body so any
+`use`/nested `mod` declared inside it is still discovered.
+
+Verified on the tracked `lien-review-testbed/rust` fixture (reporter.rs
+0 -> 1 dependent, formatter.rs and parser.rs each gain the previously-missing
+`main.rs` edge, the other 5 files unchanged) and on the real `dtolnay/anyhow`
+crate (all 10 of `lib.rs`'s `mod` declarations now produce edges; the two
+real inline modules in that crate, `context.rs`'s `mod ext` and `fmt.rs`'s
+`mod tests`, correctly produce none).

--- a/packages/parser/src/ast/languages/rust.test.ts
+++ b/packages/parser/src/ast/languages/rust.test.ts
@@ -518,11 +518,11 @@ pub static COUNTER: i32 = 0;`;
     // with no `use` at all is the idiomatic Rust pattern — before this, it
     // produced NO import edge whatsoever (mod_item wasn't in
     // importNodeTypes), so `get_dependents` on the child module returned a
-    // confident, wrong `[]`. The fix resolves `mod` to a concrete sibling
-    // path up front (see `extractModImportPath`'s doc comment) rather than
-    // emitting a bare specifier for downstream fuzzy matching to guess at —
-    // the exact #928/#884 trap this issue explicitly warns against
-    // reintroducing.
+    // confident, wrong `[]`. The fix resolves `mod` to a directory-anchored,
+    // extensionless module path up front (see `extractModImportPath`'s doc
+    // comment) rather than emitting an unanchored bare specifier for
+    // downstream fuzzy matching to guess at — the exact #928/#884 trap this
+    // issue explicitly warns against reintroducing.
     describe('mod_item file-backed import resolution (#1000)', () => {
       it('includes mod_item in importNodeTypes', () => {
         expect(importExtractor.importNodeTypes).toContain('mod_item');

--- a/packages/parser/src/ast/languages/rust.test.ts
+++ b/packages/parser/src/ast/languages/rust.test.ts
@@ -513,6 +513,122 @@ pub static COUNTER: i32 = 0;`;
         expect(importExtractor.extractImportPath(superRoot.namedChild(0)!)).toBe('../utils/helper');
       });
     });
+
+    // #1000: `mod X;` at the crate root plus qualified calls (`X::func()`)
+    // with no `use` at all is the idiomatic Rust pattern — before this, it
+    // produced NO import edge whatsoever (mod_item wasn't in
+    // importNodeTypes), so `get_dependents` on the child module returned a
+    // confident, wrong `[]`. The fix resolves `mod` to a concrete sibling
+    // path up front (see `extractModImportPath`'s doc comment) rather than
+    // emitting a bare specifier for downstream fuzzy matching to guess at —
+    // the exact #928/#884 trap this issue explicitly warns against
+    // reintroducing.
+    describe('mod_item file-backed import resolution (#1000)', () => {
+      it('includes mod_item in importNodeTypes', () => {
+        expect(importExtractor.importNodeTypes).toContain('mod_item');
+      });
+
+      it('resolves `mod x;` at a module-root file (main.rs) to a sibling in the SAME directory', () => {
+        const code = 'mod reporter;';
+        const root = mustParse(code, 'rust');
+        const modNode = root.namedChild(0)!;
+        expect(importExtractor.extractImportPath(modNode, undefined, 'src/main.rs')).toBe(
+          'src/reporter',
+        );
+      });
+
+      it('resolves `pub mod x;` the same way — visibility does not affect whether the sibling file is a real dependency', () => {
+        const code = 'pub mod reporter;';
+        const root = mustParse(code, 'rust');
+        const modNode = root.namedChild(0)!;
+        expect(importExtractor.extractImportPath(modNode, undefined, 'src/main.rs')).toBe(
+          'src/reporter',
+        );
+      });
+
+      it('resolves `mod x;` from a LEAF file to a subdirectory named after that file (2018+-edition split)', () => {
+        const code = 'mod bar;';
+        const root = mustParse(code, 'rust');
+        const modNode = root.namedChild(0)!;
+        expect(importExtractor.extractImportPath(modNode, undefined, 'src/foo.rs')).toBe(
+          'src/foo/bar',
+        );
+      });
+
+      it('resolves a nested inline mod (`mod outer { mod inner; }`) — the outer name becomes a directory segment', () => {
+        const code = 'mod outer {\n  mod inner;\n}';
+        const root = mustParse(code, 'rust');
+        const outerNode = root.namedChild(0)!;
+        const innerNode = outerNode.childForFieldName('body')!.namedChild(0)!;
+        expect(innerNode.type).toBe('mod_item');
+        expect(importExtractor.extractImportPath(innerNode, undefined, 'src/main.rs')).toBe(
+          'src/outer/inner',
+        );
+      });
+
+      it('returns null for an INLINE mod (has a body) — a namespace, not an import, has no separate file', () => {
+        const code = 'mod tests {\n  fn it_works() {}\n}';
+        const root = mustParse(code, 'rust');
+        const modNode = root.namedChild(0)!;
+        expect(importExtractor.extractImportPath(modNode, undefined, 'src/main.rs')).toBeNull();
+      });
+
+      it('returns null without an importerFile — cannot resolve deterministically', () => {
+        const code = 'mod reporter;';
+        const root = mustParse(code, 'rust');
+        const modNode = root.namedChild(0)!;
+        expect(importExtractor.extractImportPath(modNode)).toBeNull();
+      });
+
+      it('honors a #[path = "..."] override, relative to the declaring file\'s own directory', () => {
+        const code = '#[path = "custom_path.rs"]\nmod aliased;';
+        const root = mustParse(code, 'rust');
+        const modNode = root.namedChildren.find(n => n.type === 'mod_item')!;
+        expect(importExtractor.extractImportPath(modNode, undefined, 'src/main.rs')).toBe(
+          'src/custom_path',
+        );
+      });
+
+      it('does not crash on multiple stacked attributes, finding #[path] among them regardless of order', () => {
+        const adjacent = mustParse('#[cfg(test)]\n#[path = "other.rs"]\nmod combo;', 'rust');
+        const adjacentMod = adjacent.namedChildren.find(n => n.type === 'mod_item')!;
+        expect(importExtractor.extractImportPath(adjacentMod, undefined, 'src/main.rs')).toBe(
+          'src/other',
+        );
+
+        const reversed = mustParse('#[path = "other.rs"]\n#[cfg(test)]\nmod combo;', 'rust');
+        const reversedMod = reversed.namedChildren.find(n => n.type === 'mod_item')!;
+        expect(importExtractor.extractImportPath(reversedMod, undefined, 'src/main.rs')).toBe(
+          'src/other',
+        );
+      });
+
+      it('processImportSymbols reports the whole-module wildcard, like a use_wildcard', () => {
+        const code = 'mod reporter;';
+        const root = mustParse(code, 'rust');
+        const modNode = root.namedChild(0)!;
+        const result = importExtractor.processImportSymbols(modNode, undefined, 'src/main.rs');
+        expect(result).not.toBeNull();
+        expect(result!.importPath).toBe('src/reporter');
+        expect(result!.symbols).toEqual(['*']);
+      });
+
+      it('processImportSymbols returns null for an inline mod (no separate file to attribute symbols to)', () => {
+        const code = 'mod tests {\n  fn it_works() {}\n}';
+        const root = mustParse(code, 'rust');
+        const modNode = root.namedChild(0)!;
+        expect(importExtractor.processImportSymbols(modNode, undefined, 'src/main.rs')).toBeNull();
+      });
+
+      it('extractImportPaths wraps the mod_item result the same as use_declaration', () => {
+        const code = 'mod reporter;';
+        const root = mustParse(code, 'rust');
+        const modNode = root.namedChild(0)!;
+        expect(importExtractor.extractImportPaths(modNode, undefined, 'src/main.rs')).toEqual([
+          'src/reporter',
+        ]);
+      });
+    });
   });
 
   describe('Symbol Extraction', () => {
@@ -815,6 +931,47 @@ pub fn authenticate() -> bool {
       expect(funcChunk).toBeDefined();
       expect(funcChunk?.metadata.imports).toBeDefined();
       expect(funcChunk?.metadata.imports?.length).toBeGreaterThan(0);
+    });
+
+    // #1000 end-to-end: main.rs's `mod reporter;` (no `use` at all) must
+    // surface in chunk.metadata.imports exactly like an explicit `use` would
+    // — this is what get_dependents actually reads.
+    it('surfaces a file-backed `mod x;` declaration in chunk.metadata.imports', () => {
+      const content = `mod reporter;
+
+fn main() {
+    reporter::report();
+}`;
+
+      const chunks = chunkByAST('src/main.rs', content);
+      const funcChunk = chunks.find(c => c.metadata.symbolName === 'main');
+      expect(funcChunk).toBeDefined();
+      expect(funcChunk?.metadata.imports).toContain('src/reporter');
+    });
+
+    // An inline `mod tests { ... }` (e.g. `#[cfg(test)] mod tests`) has no
+    // separate file and must NOT fabricate an import edge for itself — but
+    // `collectImportNodes` must still recurse into its body to find further
+    // import nodes nested inside it (here, a real `use crate::...;`), which
+    // was invisible before mod_item was added to the type set at all.
+    it('does not fabricate an edge for an inline `mod tests { ... }`, but still surfaces a nested use_declaration inside it', () => {
+      const content = `#[cfg(test)]
+mod tests {
+    use crate::helper::assert_helper;
+
+    fn it_works() {
+        assert_helper();
+    }
+}`;
+
+      const chunks = chunkByAST('src/lib.rs', content);
+      const testChunk = chunks.find(c => c.metadata.symbolName === 'it_works');
+      expect(testChunk).toBeDefined();
+      // "tests" itself must never appear as an import path (no such file).
+      expect(testChunk?.metadata.imports ?? []).not.toContain('tests');
+      // The nested `use crate::helper::assert_helper;` — invisible before
+      // mod_item was added to collectImportNodes's recursion — must surface.
+      expect(testChunk?.metadata.imports ?? []).toContain('helper/assert_helper');
     });
   });
 });

--- a/packages/parser/src/ast/languages/rust.ts
+++ b/packages/parser/src/ast/languages/rust.ts
@@ -211,6 +211,142 @@ function joinFromDir(dir: string, rest: string): string {
 }
 
 /**
+ * Basename of a forward-slash path with its `.rs` extension removed --
+ * e.g. `src/foo.rs` -> `foo`. Used only for Rust's leaf-file submodule
+ * directory convention (see `rustModOwningDirectory`).
+ */
+function basenameNoExt(p: string): string {
+  const base = p.slice(p.lastIndexOf('/') + 1);
+  return base.replace(/\.rs$/, '');
+}
+
+/**
+ * The directory a FILE-BACKED `mod_item` (`mod x;`, no body) resolves its
+ * sibling file against — Rust's file-to-module convention (#1000):
+ *
+ * - A module-root file (`mod.rs`/`lib.rs`/`main.rs`) owns its OWN directory:
+ *   `src/main.rs`'s `mod reporter;` -> `src/reporter.rs`.
+ * - A "leaf" file (any other name, e.g. `src/foo.rs`) owns a SUBDIRECTORY
+ *   named after itself: `src/foo.rs`'s `mod bar;` -> `src/foo/bar.rs` — the
+ *   same 2018+-edition file-plus-sibling-directory split already documented
+ *   on `resolveRustRelativeModulePath` for `self::`/`super::`, but resolved
+ *   precisely here rather than approximated.
+ * - Each INLINE ancestor `mod` block (`mod outer { mod inner; }` — itself
+ *   not file-backed, see `isInlineModDeclaration`) folds its own name in as
+ *   a further directory segment, since Rust's directory-ownership rule
+ *   treats inline nesting exactly like a subdirectory.
+ */
+function rustModOwningDirectory(importerFile: string, modNode: SyntaxNode): string {
+  const normalizedImporter = importerFile.replace(/\\/g, '/');
+  const fileDir = isRustModuleRootFile(normalizedImporter)
+    ? dirnameOf(normalizedImporter)
+    : joinFromDir(dirnameOf(normalizedImporter), basenameNoExt(normalizedImporter));
+
+  return collectInlineAncestorModNames(modNode).reduce(joinFromDir, fileDir);
+}
+
+/**
+ * Names of every INLINE `mod_item` ancestor (outermost first) enclosing
+ * `node` within the SAME file — i.e. `mod_item`s with a `body`, which
+ * `RustTraverser.shouldTraverseChildren` already treats as pass-through
+ * containers for symbol extraction. A file-backed ancestor (no body) can't
+ * occur here: its content lives in a different file entirely, parsed as its
+ * own chunk, so this never walks across a file boundary.
+ */
+function collectInlineAncestorModNames(node: SyntaxNode): string[] {
+  const names: string[] = [];
+  let current = node.parent;
+  while (current) {
+    if (current.type === 'mod_item') {
+      const nameNode = current.childForFieldName('name');
+      if (nameNode) names.unshift(nameNode.text);
+    }
+    current = current.parent;
+  }
+  return names;
+}
+
+/**
+ * Whether a `mod_item` node declares an inline module body (`mod x { ... }`)
+ * rather than a file-backed declaration (`mod x;`). An inline module is a
+ * namespace, not an import — it has no separate file and must NOT produce a
+ * dependency edge (see `extractModImportPath`'s doc comment, #1000).
+ */
+function isInlineModDeclaration(node: SyntaxNode): boolean {
+  return node.childForFieldName('body') !== null;
+}
+
+/**
+ * `#[path = "..."]` overrides the default sibling-file lookup for a single
+ * `mod_item`. tree-sitter-rust attaches attributes as PRECEDING SIBLINGS of
+ * the item they annotate (not children of it), so this walks backward
+ * through the contiguous run of `attribute_item`s immediately before
+ * `modNode` — there can be more than one (`#[cfg(test)] #[path = "..."]
+ * mod x;`) — looking for one shaped like `path = "<value>"`. Returns null
+ * (falls through to the default sibling-file convention) if none is found;
+ * this is the "at least don't crash on it" floor #1000 asks for, not full
+ * attribute-macro support.
+ */
+function findPathAttributeOverride(modNode: SyntaxNode): string | null {
+  const parent = modNode.parent;
+  if (!parent) return null;
+  const siblings = parent.namedChildren;
+  const index = siblings.indexOf(modNode);
+  if (index === -1) return null;
+
+  for (const sibling of siblings.slice(0, index).reverse()) {
+    if (sibling.type !== 'attribute_item') break;
+    const override = extractPathAttributeValue(sibling);
+    if (override) return override;
+  }
+  return null;
+}
+
+/** The `"<value>"` of a single `attribute_item` shaped like `#[path = "..."]`, or null. */
+function extractPathAttributeValue(attributeItem: SyntaxNode): string | null {
+  const attribute = attributeItem.namedChildren.find(child => child.type === 'attribute');
+  if (!attribute) return null;
+  if (attribute.namedChildren[0]?.text !== 'path') return null;
+
+  const valueNode = attribute.childForFieldName('value');
+  const stringContent = valueNode?.namedChildren.find(child => child.type === 'string_content');
+  return stringContent?.text ?? null;
+}
+
+/**
+ * Resolve a FILE-BACKED `mod_item` (`mod x;`, no body) to the concrete
+ * sibling path it declares.
+ *
+ * The trap this deliberately avoids (#1000, closed against #928/#884): a
+ * bare specifier like `reporter` requires downstream fuzzy bare-module
+ * matching to guess which file it means, which is exactly the
+ * language-blind fabrication #928 was closed to prevent. A Rust `mod x;` is
+ * NOT ambiguous like that — it's a declaration that resolves deterministically
+ * to one specific sibling path relative to the declaring file — so this
+ * resolves the concrete path up front (`rustModOwningDirectory` +
+ * `#[path]` override) and returns it complete, the same way
+ * `resolveRustRelativeModulePath` already resolves `self::`/`super::`
+ * precisely instead of leaving them for the generic bare-word matcher.
+ *
+ * Returns null for an inline module (has a body — no separate file, no
+ * edge) or when there's no `importerFile` to resolve against.
+ */
+function extractModImportPath(node: SyntaxNode, importerFile?: string): string | null {
+  if (isInlineModDeclaration(node) || !importerFile) return null;
+
+  const nameNode = node.childForFieldName('name');
+  if (!nameNode) return null;
+
+  const pathOverride = findPathAttributeOverride(node);
+  if (pathOverride) {
+    const normalizedImporter = importerFile.replace(/\\/g, '/');
+    return joinFromDir(dirnameOf(normalizedImporter), pathOverride.replace(/\.rs$/, ''));
+  }
+
+  return joinFromDir(rustModOwningDirectory(importerFile, node), nameNode.text);
+}
+
+/**
  * Resolve a `self::`/`super::`-relative Rust module path against the
  * importing file's own location (#928).
  *
@@ -417,8 +553,15 @@ function extractUseListSymbols(useList: SyntaxNode): string[] {
 /**
  * Rust import extractor
  *
- * Handles all `use` declarations (not just `pub use`).
- * Every `use` creates a dependency.
+ * Handles all `use` declarations (not just `pub use`) — every `use` creates
+ * a dependency — AND file-backed `mod` declarations (`mod x;`/`pub mod x;`,
+ * #1000): the idiomatic Rust pattern of `mod x;` at the crate root plus
+ * qualified calls (`x::func()`) with no `use` at all otherwise produces no
+ * edge whatsoever. See `extractModImportPath` for how a `mod` declaration is
+ * resolved to a concrete sibling path rather than an ambiguous bare
+ * specifier. An INLINE `mod x { ... }` (has a body) is a namespace, not an
+ * import, and correctly produces no edge for itself — see
+ * `isInlineModDeclaration`.
  *
  * Examples:
  * - `use crate::auth::AuthService;`
@@ -427,15 +570,21 @@ function extractUseListSymbols(useList: SyntaxNode): string[] {
  * - `use crate::models::*;`
  * - `use std::io::Read;` (external - skipped)
  * - `use super::utils::helper;`
+ * - `mod reporter;` -> `<owning dir>/reporter` (#1000)
+ * - `pub mod reporter;` -> same as above; visibility doesn't affect whether
+ *   the sibling file is a real dependency
+ * - `mod tests { ... }` -> no edge (inline, no separate file)
  */
 export class RustImportExtractor implements LanguageImportExtractor {
-  readonly importNodeTypes = ['use_declaration'];
+  readonly importNodeTypes = ['use_declaration', 'mod_item'];
 
   extractImportPath(
     node: SyntaxNode,
     rustCrateMap?: ReadonlyMap<string, string>,
     importerFile?: string,
   ): string | null {
+    if (node.type === 'mod_item') return extractModImportPath(node, importerFile);
+
     const argument = node.childForFieldName('argument');
     if (!argument) return null;
 
@@ -456,6 +605,15 @@ export class RustImportExtractor implements LanguageImportExtractor {
     rustCrateMap?: ReadonlyMap<string, string>,
     importerFile?: string,
   ): { importPath: string; symbols: string[] } | null {
+    if (node.type === 'mod_item') {
+      // A `mod x;` brings the whole module namespace into scope (consumers
+      // then use qualified `x::func()` calls) rather than naming specific
+      // symbols, the same "whole module" shape as `use crate::models::*;` —
+      // see `processUseWildcard` below.
+      const importPath = extractModImportPath(node, importerFile);
+      return importPath ? { importPath, symbols: ['*'] } : null;
+    }
+
     const argument = node.childForFieldName('argument');
     if (!argument) return null;
 

--- a/packages/parser/src/ast/languages/rust.ts
+++ b/packages/parser/src/ast/languages/rust.ts
@@ -221,16 +221,27 @@ function basenameNoExt(p: string): string {
 }
 
 /**
- * The directory a FILE-BACKED `mod_item` (`mod x;`, no body) resolves its
- * sibling file against — Rust's file-to-module convention (#1000):
+ * The (extensionless) directory a FILE-BACKED `mod_item` (`mod x;`, no body)
+ * resolves its sibling module against — Rust's file-to-module convention
+ * (#1000). This returns the directory only; `extractModImportPath` joins
+ * the mod's own name onto it and returns THAT unresolved-extension
+ * specifier as-is — it never appends `.rs`, and it doesn't need to choose
+ * between the `x.rs` and `x/mod.rs` on-disk conventions. Downstream
+ * matching (`matchesFile`) normalizes both the specifier and every
+ * candidate target path by stripping extensions before comparing, so the
+ * extensionless specifier exact-matches whichever convention the sibling
+ * module actually uses on disk:
  *
  * - A module-root file (`mod.rs`/`lib.rs`/`main.rs`) owns its OWN directory:
- *   `src/main.rs`'s `mod reporter;` -> `src/reporter.rs`.
+ *   `src/main.rs`'s `mod reporter;` -> directory `src`, giving the resolved
+ *   specifier `src/reporter` (which normalizes-matches `src/reporter.rs` or
+ *   `src/reporter/mod.rs` on disk).
  * - A "leaf" file (any other name, e.g. `src/foo.rs`) owns a SUBDIRECTORY
- *   named after itself: `src/foo.rs`'s `mod bar;` -> `src/foo/bar.rs` — the
- *   same 2018+-edition file-plus-sibling-directory split already documented
- *   on `resolveRustRelativeModulePath` for `self::`/`super::`, but resolved
- *   precisely here rather than approximated.
+ *   named after itself: `src/foo.rs`'s `mod bar;` -> directory `src/foo`,
+ *   giving `src/foo/bar` — the same 2018+-edition file-plus-sibling-
+ *   directory split already documented on `resolveRustRelativeModulePath`
+ *   for `self::`/`super::`, but resolved precisely here rather than
+ *   approximated.
  * - Each INLINE ancestor `mod` block (`mod outer { mod inner; }` — itself
  *   not file-backed, see `isInlineModDeclaration`) folds its own name in as
  *   a further directory segment, since Rust's directory-ownership rule
@@ -314,17 +325,21 @@ function extractPathAttributeValue(attributeItem: SyntaxNode): string | null {
 }
 
 /**
- * Resolve a FILE-BACKED `mod_item` (`mod x;`, no body) to the concrete
- * sibling path it declares.
+ * Resolve a FILE-BACKED `mod_item` (`mod x;`, no body) to the
+ * directory-anchored, extensionless module path it declares (e.g.
+ * `src/reporter` for `src/main.rs`'s `mod reporter;` — see
+ * `rustModOwningDirectory`'s doc comment for exactly what that specifier
+ * does and doesn't resolve to on disk).
  *
- * The trap this deliberately avoids (#1000, closed against #928/#884): a
- * bare specifier like `reporter` requires downstream fuzzy bare-module
- * matching to guess which file it means, which is exactly the
- * language-blind fabrication #928 was closed to prevent. A Rust `mod x;` is
- * NOT ambiguous like that — it's a declaration that resolves deterministically
- * to one specific sibling path relative to the declaring file — so this
- * resolves the concrete path up front (`rustModOwningDirectory` +
- * `#[path]` override) and returns it complete, the same way
+ * The trap this deliberately avoids (#1000, closed against #928/#884): an
+ * UNANCHORED bare specifier like `reporter` (no directory prefix at all)
+ * requires downstream fuzzy bare-module matching to guess which file it
+ * means, which is exactly the language-blind fabrication #928 was closed to
+ * prevent. A Rust `mod x;` is NOT ambiguous like that — it's a declaration
+ * that resolves deterministically to one specific sibling module relative
+ * to the declaring file — so this anchors it to that module's real
+ * directory up front (`rustModOwningDirectory` + `#[path]` override) and
+ * returns the result directly, the same way
  * `resolveRustRelativeModulePath` already resolves `self::`/`super::`
  * precisely instead of leaving them for the generic bare-word matcher.
  *
@@ -558,8 +573,8 @@ function extractUseListSymbols(useList: SyntaxNode): string[] {
  * #1000): the idiomatic Rust pattern of `mod x;` at the crate root plus
  * qualified calls (`x::func()`) with no `use` at all otherwise produces no
  * edge whatsoever. See `extractModImportPath` for how a `mod` declaration is
- * resolved to a concrete sibling path rather than an ambiguous bare
- * specifier. An INLINE `mod x { ... }` (has a body) is a namespace, not an
+ * resolved to a directory-anchored, extensionless module path rather than
+ * an ambiguous bare specifier. An INLINE `mod x { ... }` (has a body) is a namespace, not an
  * import, and correctly produces no edge for itself — see
  * `isInlineModDeclaration`.
  *

--- a/packages/parser/src/ast/symbols.test.ts
+++ b/packages/parser/src/ast/symbols.test.ts
@@ -1063,6 +1063,53 @@ use crate::auth::{AuthService, AuthError};
 
       expect(imports).toContain('auth');
     });
+
+    // #1000: `mod x;` (no `use` at all) is the idiomatic Rust pattern for
+    // crate-root submodules referenced only via qualified calls (`x::func()`).
+    // Before this, mod_item wasn't in importNodeTypes, so it produced no
+    // import edge whatsoever.
+    describe('mod declarations (#1000)', () => {
+      it('extracts a file-backed mod declaration when rustImporterFile is provided', () => {
+        const content = 'mod reporter;';
+        const parseResult = parseAST(content, 'rust');
+        const imports = extractImports(
+          parseResult.tree!.rootNode,
+          'rust',
+          undefined,
+          undefined,
+          undefined,
+          'src/main.rs',
+        );
+        expect(imports).toContain('src/reporter');
+      });
+
+      it('extracts nothing for a mod declaration without rustImporterFile — cannot resolve deterministically', () => {
+        const content = 'mod reporter;';
+        const parseResult = parseAST(content, 'rust');
+        const imports = extractImports(parseResult.tree!.rootNode, 'rust');
+        expect(imports).toHaveLength(0);
+      });
+
+      it('does not fabricate an edge for an inline mod block, but surfaces a use_declaration nested inside it', () => {
+        const content = `
+#[cfg(test)]
+mod tests {
+    use crate::helper::assert_helper;
+}
+        `.trim();
+        const parseResult = parseAST(content, 'rust');
+        const imports = extractImports(
+          parseResult.tree!.rootNode,
+          'rust',
+          undefined,
+          undefined,
+          undefined,
+          'src/lib.rs',
+        );
+        expect(imports).not.toContain('tests');
+        expect(imports).toContain('helper/assert_helper');
+      });
+    });
   });
 
   describe('extractImportedSymbols - Rust', () => {

--- a/packages/parser/src/ast/symbols.ts
+++ b/packages/parser/src/ast/symbols.ts
@@ -95,12 +95,20 @@ export function extractSymbolInfo(
  * non-matching direct child to find imports nested inside such a container. This
  * is backward compatible: languages whose import nodes are already direct
  * children match in the first branch and are never descended into.
+ *
+ * Rust's `mod_item` (#1000) is the one matched type that can ITSELF contain
+ * further import nodes at arbitrary depth: an inline `mod x { ... }` nests
+ * further `use_declaration`/`mod_item` children inside its own body, unlike
+ * every other matched type here (a leaf import statement with nothing
+ * further inside it worth looking for). So a matched `mod_item` with a body
+ * is also recursed into — every other language's matched nodes are leaves
+ * and this is a no-op for them.
  */
 function collectImportNodes(rootNode: SyntaxNode, nodeTypeSet: Set<string>): SyntaxNode[] {
   const nodes: SyntaxNode[] = [];
   for (const child of rootNode.namedChildren) {
     if (nodeTypeSet.has(child.type)) {
-      nodes.push(child);
+      nodes.push(child, ...collectNestedModImportNodes(child, nodeTypeSet));
     } else {
       for (const grandchild of child.namedChildren) {
         if (nodeTypeSet.has(grandchild.type)) nodes.push(grandchild);
@@ -108,6 +116,18 @@ function collectImportNodes(rootNode: SyntaxNode, nodeTypeSet: Set<string>): Syn
     }
   }
   return nodes;
+}
+
+/**
+ * Rust-only (#1000): further import nodes nested inside a matched
+ * `mod_item`'s own inline body — see `collectImportNodes`'s doc comment. A
+ * no-op for every other matched type, and for a file-backed `mod_item`
+ * (no body).
+ */
+function collectNestedModImportNodes(node: SyntaxNode, nodeTypeSet: Set<string>): SyntaxNode[] {
+  if (node.type !== 'mod_item') return [];
+  const body = node.childForFieldName('body');
+  return body ? collectImportNodes(body, nodeTypeSet) : [];
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #1000. `RustImportExtractor.importNodeTypes` only listed
`use_declaration` — `mod_item` was absent, so `mod x;` at the crate root
plus qualified calls (`x::func()`) with no `use` at all produced **zero**
import edges. `get_dependents` on the child module returned a confident,
wrong `[]` (or an undercount when the file happened to also gain one edge
via an unrelated `use crate::x` elsewhere).

Found while baselining #994 (the Phase 3-5 duplication refactor).

**The trap avoided (#928/#884):** `mod reporter;` yields the bare specifier
`reporter`, exactly the shape `isUnresolvableWholeModuleImport` exists to
reject. A Rust `mod X;` is not ambiguous like that, though — it's a
declaration that resolves **deterministically** to a specific sibling module
relative to the declaring file. So the fix resolves `mod` to a
**directory-anchored, extensionless module path at extraction time** (e.g.
`src/reporter` for `src/main.rs`'s `mod reporter;`, honoring the leaf-file
2018+-edition directory split, inline-mod nesting, and a `#[path = "..."]`
override) instead of emitting an unanchored bare specifier for downstream
fuzzy matching to guess at. The extractor itself never appends `.rs` and
doesn't choose between the `x.rs` / `x/mod.rs` on-disk conventions — the
resolved specifier wins via `matchesFile`'s plain **exact-match** strategy
against whichever one is actually on disk (both get extension-stripped by
the existing normalization), no bare-word leniency involved at all.

An inline `mod x { ... }` (has a body — e.g. `#[cfg(test)] mod tests { ... }`)
is a namespace, not an import: it has no separate file and correctly
produces no edge for itself. `collectImportNodes` (`ast/symbols.ts`) now
recurses into such a body so any `use`/nested `mod` declared inside it is
still discovered (previously invisible, since `mod_item` wasn't in the
matched-type set at all).

## Scope

Confined to `packages/parser/src/ast/languages/rust.ts`,
`packages/parser/src/ast/symbols.ts` (the shared `collectImportNodes`
helper — the recursion added there is gated on `child.type === 'mod_item'`,
a no-op for every other language), and their tests, per the no-touch list
for concurrently running Phase 3-5 duplication-refactor agents
(`dependency-analyzer.ts`, `utils/path-matching.ts`,
`insights/chunk-complexity.ts`, `core/insights/complexity-analyzer.ts`,
`review/dependency-graph.ts`, `review/blast-radius.ts` — none touched).

## Before / after: tracked fixture (`lien-review-testbed/rust`)

Measured via `performChunkOnlyIndex` + `findDependents` from `@liendev/parser`
(the same primitives `get_dependents` uses), before and after the fix on the
identical, byte-for-byte tracked fixture — no capture step needed.

| file | before | after |
|---|---|---|
| `src/reporter.rs` | `[]` | **`["src/main.rs"]`** |
| `src/formatter.rs` | `["src/reporter.rs"]` | **`["src/main.rs","src/reporter.rs"]`** |
| `src/parser.rs` | `["src/analyzer.rs","src/reporter.rs"]` | **`["src/analyzer.rs","src/main.rs","src/reporter.rs"]`** |
| `src/main.rs` | `[]` | `[]` (unchanged — crate root, nothing imports it) |
| `src/analyzer.rs` | `["src/cache.rs","src/formatter.rs","src/main.rs","src/reporter.rs"]` | unchanged |
| `src/cache.rs` | `["src/main.rs","src/reporter.rs"]` | unchanged |
| `src/config.rs` | `["src/analyzer.rs","src/cache.rs","src/main.rs","src/parser.rs","src/reporter.rs"]` | unchanged |
| `src/error.rs` | `["src/analyzer.rs","src/cache.rs","src/config.rs","src/formatter.rs","src/main.rs","src/parser.rs","src/reporter.rs"]` | unchanged |

**Note on `src/parser.rs`:** the issue's own reproduction narrative only
called out `reporter.rs` (zero) and `formatter.rs` (undercount) as evidence,
and its "expected after" table lists `parser.rs` unchanged. That's an
oversight in the issue text, not in this fix — `main.rs` declares `mod
parser;` and makes 6 qualified `parser::*` calls (identical shape to
`reporter`/`formatter`), so `parser.rs` **correctly** gains `src/main.rs`
too. Confirmed directly:
```
$ grep -n "parser::" lien-review-testbed/rust/src/main.rs
210:        let input = parser::parse_input(path, config)?;
212:        parser::validate_input(&input)?;
264:    let input = parser::parse_input(path, config)?;
270:    let metadata = parser::parse_metadata(&input);
272:        let (parsed_key, _) = parser::parse_line(...);
311:                let (name, ext) = parser::parse_line(...);
```
So **3 of 8 rows change** (not 2), and the other **5 are byte-identical**
before/after — verified by reverting the two changed source files to `HEAD`,
re-running the same script, and confirming the "before" output matches the
issue's stated ground truth exactly, then reapplying and re-measuring.

## Real-world validation: `dtolnay/anyhow`

Per the "sweep before you fix" ask, also ran against a real, widely-used
crate (shallow-cloned via the same URL the repo's own Rust E2E fixture
uses), not just the 8-file synthetic testbed:

```
lib.rs declares: mod backtrace; mod chain; mod context; mod ensure; mod error;
mod fmt; mod kind; mod macros; mod nightly; mod ptr; mod wrapper;
```

After the fix, every one of those 11 files gains `src/lib.rs` as a
dependent (previously none did):
```
src/backtrace.rs  deps=["src/error.rs","src/lib.rs"]
src/chain.rs      deps=["src/chain.rs","src/error.rs","src/fmt.rs","src/lib.rs"]
src/context.rs    deps=["src/context.rs","src/lib.rs"]
src/ensure.rs     deps=["src/lib.rs"]
src/error.rs      deps=["src/context.rs","src/ensure.rs","src/error.rs","src/fmt.rs",
                        "src/kind.rs","src/lib.rs","tests/test_autotrait.rs",
                        "tests/test_downcast.rs","tests/test_repr.rs"]
src/fmt.rs        deps=["src/lib.rs"]
src/kind.rs       deps=["src/lib.rs"]
src/macros.rs     deps=["src/lib.rs"]
src/nightly.rs    deps=["src/context.rs","src/error.rs","src/lib.rs","src/wrapper.rs"]
src/ptr.rs        deps=["src/error.rs","src/fmt.rs","src/lib.rs"]
src/wrapper.rs    deps=["src/lib.rs"]
src/lib.rs        deps=[]   (crate root, unchanged)
```

This crate also has two REAL inline modules (not present in the synthetic
testbed) that must NOT produce false edges — confirmed clean:
```
context.rs:9   mod ext { use super::*; ... }        <- inline, no ext.rs file exists
fmt.rs:104     mod tests { use super::*; ... }       <- inline, no tests.rs file exists
```
Neither `"ext"` nor `"tests"` appears anywhere in any chunk's `imports` list.

## Sweep: within Rust

Added targeted unit tests (`rust.test.ts`, `symbols.test.ts`) for every
shape called out in the issue:
- `mod x;` at crate root (module-root file) -> same-directory sibling
- `pub mod x;` -> identical resolution (visibility doesn't gate the edge)
- `mod x;` in a **leaf** file (not `main.rs`/`lib.rs`/`mod.rs`) -> resolves
  into a subdirectory named after that file (the 2018+-edition split)
- **Nested inline modules** (`mod outer { mod inner; }`) -> `outer` folds in
  as a directory segment; verified against real `parser.rs`-shape nesting
- **Inline `mod X { ... }`** (has a body, e.g. `mod tests`) -> no edge for
  itself, but `use`/nested `mod` inside it are still discovered
  (`collectImportNodes` recursion)
- **`#[path = "..."]`** override, including with other attributes stacked
  in either order (`#[cfg(test)] #[path = "..."]` and reversed) — resolves
  to the override path relative to the file's own directory, doesn't crash
- No `importerFile` provided -> returns null (can't resolve deterministically,
  matches the existing `self::`/`super::` no-op precedent)

## Sweep: across languages ("declaration form is the edge")

Checked whether any other supported language (TS, JS, Python, Go, Java, C#,
Ruby, Kotlin, Swift, PHP — C isn't a supported AST language here) has a
declaration-style include missing from `importNodeTypes`, the same shape as
Rust's `mod`:

- **Go blank imports** (`import _ "pkg"`) — **confirmed clean**.
  `GoImportExtractor.extractSpecPath`/`extractImportPaths` don't special-case
  the `_`/dot alias at all; the edge is created regardless of alias. Only
  the *symbol name* fallback (`processImportSymbolsList`) treats blank/dot
  specially, which is correct (there's no meaningful symbol name for a blank
  import).
- **Ruby `require`/`require_relative`/`load`/`autoload`** — **confirmed
  clean**. All four are already in `REQUIRE_METHODS` and handled uniformly
  via the `call` node type. Ruby has no separate declaration-only linking
  keyword the way Rust has `mod` — `require`/`require_relative` *are*
  Ruby's only file-linking mechanism, so there's no declaration/use duality
  to miss.
- **PHP `require`/`include`/`require_once`/`include_once`** — **confirmed
  gap, but a different shape**: `PHPImportExtractor.importNodeTypes` is
  `['namespace_use_declaration']` only; literal `require '../foo.php';`
  statements aren't walked as import nodes at all. This is not the
  declaration-vs-use duality #1000 is about (PHP has no `mod`-like
  declarative keyword) — it's a separate, pre-existing "one whole import
  mechanism isn't implemented for PHP" gap, worth its own follow-up issue.
  Not fixed here (out of scope; not requested by #1000, no existing test
  coverage to regress, real design work needed for path resolution incl.
  dynamic requires).
- **C# `partial` classes / Java & Kotlin same-package implicit access** —
  a *different* shape (no import statement is needed at all for same-
  namespace/package files, not a missed declaration keyword). Already
  tracked/being addressed separately: C# namespace-scoped dependent recovery
  shipped in #971, and Java/Go already have dedicated same-package/directory
  test-pairing logic (`java-same-package-tests.test.ts`,
  `go-same-directory-tests.test.ts`) for this exact concern. Not duplicated
  here.
- **Swift module declarations** — already the `wholeModuleImports: true`
  gated case (#884); architecturally a different, already-solved shape
  (Swift's `import Foundation` never names a specific file at all).
- **C `#include`** — not applicable; C isn't a currently supported AST
  language in this parser.

**Verdict:** Rust's `mod` is the only instance of this specific shape
among currently-supported languages. No cross-language test table was
added since the shape doesn't recur elsewhere yet (per the repo policy,
a table is for asserting a *recurring* cross-language invariant — this one
doesn't recur, so a Rust-scoped fix + Rust-scoped tests is the correct-sized
artifact).

## Gates

```
npm run format:check   -> pass
npm run lint            -> 0 errors (37 pre-existing warnings, unrelated files)
npm run typecheck       -> 0 errors
npm run build           -> success
npm test                -> exit 0, all packages pass (parser 1619/1619,
                             core 406/406, review 1723/1723, cli 1525/1525,
                             action 41/41, parser-native 1/1 — 5315/5315 total)
lien delta               -> exit 0 (3 "worsened"/9 "new" entries, all well under threshold —
                             see below)
```

`lien delta` output (informational only — nothing crossed a threshold):
```
packages/parser/src/ast/languages/rust.ts
  ⚠ worsened  RustImportExtractor.extractImportPath      cognitive 2 → 3
  ⚠ worsened  RustImportExtractor.processImportSymbols   cognitive 1 → 3
  · new       basenameNoExt                    cyclomatic – → 1
  · new       rustModOwningDirectory           cognitive  – → 1
  · new       collectInlineAncestorModNames    cognitive  – → 6
  · new       isInlineModDeclaration           cyclomatic – → 1
  · new       findPathAttributeOverride        cognitive  – → 7
  · new       extractPathAttributeValue        cognitive  – → 2
  · new       extractModImportPath             cognitive  – → 4

packages/parser/src/ast/symbols.ts
  ⚠ worsened  collectImportNodes               time 11m → 13m
  · new       collectNestedModImportNodes      cognitive – → 2
```
(`collectImportNodes` was split into a helper mid-implementation specifically
because the first version pushed its own cognitive complexity 11→18, over
the threshold of 15 — the version shipped here stays under it.)

Also run (dogfooded, real dependency checks — not synthetic):
```
npm run test:e2e:rust -w packages/cli   -> 14 passed, 140 skipped (network-gated), 0 failed
npm run test:e2e:go -w packages/cli     -> 14 passed, 140 skipped (network-gated), 0 failed
```

## Notes

- `parser` is published — changeset added (`patch`, matching this repo's
  precedent for parser-only bugfixes).
- No files from the Phase 3-5/4/5 duplication-refactor no-touch list were
  edited.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR fixes a real bug in Rust import extraction by adding `mod_item` to the matched import-node types and resolving file-backed `mod x;` declarations to directory-anchored, extensionless module paths. The change is additive and confined to the Rust extractor and the shared `collectImportNodes` helper. Callers in `chunker.ts` receive additional, more accurate import edges for Rust modules; no existing caller is broken because the new `mod_item` handling returns `null` safely when `importerFile` is absent and skips inline `mod` bodies. The implementation correctly distinguishes module-root files (`main.rs`/`lib.rs`/`mod.rs`) from leaf files, honors inline-mod nesting and `#[path = "..."]` overrides, and recurses into inline mod bodies without fabricating edges for the inline module itself. Extensive unit and integration tests cover the new behavior, including the boundary cases called out in the issue.
>
> - Added `mod_item` to `RustImportExtractor.importNodeTypes` and implemented deterministic path resolution for file-backed `mod x;` declarations.
> - Added `collectNestedModImportNodes` so `use` and nested `mod` declarations inside inline `mod` blocks are still discovered without creating a false edge for the inline block.
> - Added targeted tests for module-root files, leaf files, inline nesting, `#[path]` overrides, and inline mod blocks.

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 72b046e. Updates automatically on new commits.</sup>
<!-- /lien-stats -->