### PR TITLE
fix(parser): stop autoload-dev overwriting autoload for a shared PSR-4 prefix

### DIFF
--- a/.changeset/psr4-autoload-dev-collision.md
+++ b/.changeset/psr4-autoload-dev-collision.md
@@ -1,0 +1,41 @@
+---
+"@liendev/parser": patch
+"@liendev/lien": patch
+---
+
+Fix `get_dependents` reporting `0` (with no caveat) for every file in a PHP
+project whose `composer.json` declares the same PSR-4 namespace prefix in
+both `autoload` and `autoload-dev` — the standard library layout, where a
+package's tests share its own namespace (#1002). `resolvePsr4Map`
+(`php-psr4.ts`) used to build a flat `Map<prefix, string>`, and
+`autoload-dev` was processed second, so it silently overwrote `autoload`'s
+directory for the shared prefix. On Monolog's real `composer.json`
+(`"Monolog\\"` declared as both `src/Monolog` and `tests/Monolog`), every
+`use Monolog\Logger;` in `src/` resolved to the nonexistent
+`tests/Monolog/Logger`, and `get_dependents` reported `0` dependents for
+all 232 of Monolog's files with `attributionCaveat: null` — indistinguishable
+from "nothing depends on this file."
+
+Both directories are simultaneously correct (`Monolog\Logger` really lives
+under `src/Monolog`, `Monolog\LoggerTest` really lives under
+`tests/Monolog`), so a flat `Map<prefix, string>` can't represent the data —
+reordering to prefer `autoload` would just invert the bug and break PHP test
+association (#867), the reason this module exists. The map now stores
+`Map<prefix, string[]>`, appending rather than overwriting (this also
+resolves, for free, the previously-ignored case of a PSR-4 prefix mapping to
+an array of Composer fallback directories — only the first entry used to be
+kept). `resolvePsr4Import` tries each candidate directory in declaration
+order (`autoload` before `autoload-dev`) and prefers whichever resolves to a
+real `.php` file on disk, falling back to the first-registered candidate
+when neither exists (matching prior behavior for the single-candidate case).
+
+Verified end to end against a real `Seldaek/monolog` clone: before this fix,
+`0 edges / 232 orphans (100.0%)`; after, `src/Monolog/Logger.php` correctly
+reports all 13 of its real production importers as dependents. Confirmed no
+over-correction (no production file's import resolves to a `tests/`
+candidate that doesn't apply to it). Swept the sibling manifest resolvers
+this module says it "mirrors" (`workspace-packages.ts`, `rust-crate-map.ts`)
+for the same last-write-wins shape — both are clean, because npm/Cargo
+package names are uniqueness-enforced by their respective package managers,
+unlike Composer's PSR-4, which explicitly permits the same prefix in two
+sections.

--- a/packages/parser/src/ast/chunker.ts
+++ b/packages/parser/src/ast/chunker.ts
@@ -127,7 +127,10 @@ function buildManifestRoots(
 
   if (language === 'php') {
     const psr4Map = resolvePsr4Map(workspaceRoot);
-    return psr4Map.size > 0 ? { psr4Map } : undefined;
+    // `workspaceRoot` is threaded through so `resolvePsr4Import` can pick
+    // between multiple candidate directories for the same prefix (#1002) by
+    // checking which one exists on disk.
+    return psr4Map.size > 0 ? { psr4Map, workspaceRoot } : undefined;
   }
 
   if (language === 'go') {

--- a/packages/parser/src/ast/symbols.ts
+++ b/packages/parser/src/ast/symbols.ts
@@ -23,8 +23,13 @@ import { resolveJsDirectoryIndex } from '../js-directory-index.js';
  * without a manifest reader.
  */
 export interface ManifestRoots {
-  /** PHP Composer PSR-4 namespace-prefix -> source-directory map. */
-  psr4Map?: ReadonlyMap<string, string>;
+  /**
+   * PHP Composer PSR-4 namespace-prefix -> candidate source-directories map.
+   * A prefix can have more than one candidate (#1002 — declared in both
+   * `autoload` and `autoload-dev`, or a fallback-dir array); disambiguated in
+   * `resolveManifestRoot` using `workspaceRoot` below.
+   */
+  psr4Map?: ReadonlyMap<string, string[]>;
   /** Go module's declared import-path prefix (`go.mod`'s `module` line). */
   goModulePrefix?: string;
   /** Python src-layout root directory (`src`), when detected on disk. */
@@ -157,7 +162,9 @@ function resolveDirectoryIndexIfRelative(
 /** Apply step 3 (manifest-root resolution) of `resolveImportSpecifier`. */
 function resolveManifestRoot(specifier: string, manifestRoots: ManifestRoots | undefined): string {
   if (!manifestRoots) return specifier;
-  if (manifestRoots.psr4Map) return resolvePsr4Import(specifier, manifestRoots.psr4Map);
+  if (manifestRoots.psr4Map) {
+    return resolvePsr4Import(specifier, manifestRoots.psr4Map, manifestRoots.workspaceRoot);
+  }
   if (manifestRoots.goModulePrefix) {
     return resolveGoModuleImport(specifier, manifestRoots.goModulePrefix);
   }

--- a/packages/parser/src/php-psr4.test.ts
+++ b/packages/parser/src/php-psr4.test.ts
@@ -41,7 +41,7 @@ describe('resolvePsr4Map', () => {
 
     const map = resolvePsr4Map(testDir);
 
-    expect(map.get('GuzzleHttp\\')).toBe('src/');
+    expect(map.get('GuzzleHttp\\')).toEqual(['src/']);
   });
 
   it('normalizes a namespace prefix missing its trailing backslash and a dir missing its trailing slash', async () => {
@@ -51,10 +51,10 @@ describe('resolvePsr4Map', () => {
 
     const map = resolvePsr4Map(testDir);
 
-    expect(map.get('GuzzleHttp\\')).toBe('src/');
+    expect(map.get('GuzzleHttp\\')).toEqual(['src/']);
   });
 
-  it('merges autoload and autoload-dev sections', async () => {
+  it('merges autoload and autoload-dev sections for DIFFERENT prefixes', async () => {
     await writeJson('composer.json', {
       autoload: { 'psr-4': { 'GuzzleHttp\\': 'src/' } },
       'autoload-dev': { 'psr-4': { 'GuzzleHttp\\Tests\\': 'tests/' } },
@@ -62,18 +62,36 @@ describe('resolvePsr4Map', () => {
 
     const map = resolvePsr4Map(testDir);
 
-    expect(map.get('GuzzleHttp\\')).toBe('src/');
-    expect(map.get('GuzzleHttp\\Tests\\')).toBe('tests/');
+    expect(map.get('GuzzleHttp\\')).toEqual(['src/']);
+    expect(map.get('GuzzleHttp\\Tests\\')).toEqual(['tests/']);
   });
 
-  it('takes the first directory when a PSR-4 prefix maps to a fallback-dir array', async () => {
+  it('APPENDS (not overwrites) when autoload and autoload-dev declare the SAME prefix (Monolog shape, #1002)', async () => {
+    // Monolog's real composer.json: the library's own namespace is declared
+    // in BOTH sections, because its tests share the library's namespace.
+    // Before #1002's fix, `autoload-dev` was processed second and silently
+    // discarded `autoload`'s entry, so every `use Monolog\Logger;` under
+    // `src/Monolog` resolved to the nonexistent `tests/Monolog/Logger`.
+    await writeJson('composer.json', {
+      autoload: { 'psr-4': { 'Monolog\\': 'src/Monolog' } },
+      'autoload-dev': { 'psr-4': { 'Monolog\\': 'tests/Monolog' } },
+    });
+
+    const map = resolvePsr4Map(testDir);
+
+    // Both directories must be present, `autoload`'s first (see
+    // `resolvePsr4Import`'s tie-break, which depends on this order).
+    expect(map.get('Monolog\\')).toEqual(['src/Monolog/', 'tests/Monolog/']);
+  });
+
+  it('keeps every directory when a PSR-4 prefix maps to a fallback-dir array (#1002)', async () => {
     await writeJson('composer.json', {
       autoload: { 'psr-4': { 'App\\': ['src/', 'lib/'] } },
     });
 
     const map = resolvePsr4Map(testDir);
 
-    expect(map.get('App\\')).toBe('src/');
+    expect(map.get('App\\')).toEqual(['src/', 'lib/']);
   });
 
   it('maps an empty-string PSR-4 dir onto the project root (symfony/console shape, #925)', async () => {
@@ -83,7 +101,7 @@ describe('resolvePsr4Map', () => {
 
     const map = resolvePsr4Map(testDir);
 
-    expect(map.get('Symfony\\Component\\Console\\')).toBe('');
+    expect(map.get('Symfony\\Component\\Console\\')).toEqual(['']);
   });
 
   it('caches the map per workspace root', async () => {
@@ -97,25 +115,25 @@ describe('resolvePsr4Map', () => {
     const second = resolvePsr4Map(testDir);
 
     expect(second).toBe(first);
-    expect(second.get('GuzzleHttp\\')).toBe('src/');
+    expect(second.get('GuzzleHttp\\')).toEqual(['src/']);
   });
 });
 
 describe('resolvePsr4Import', () => {
   it('is a no-op for an empty map', () => {
-    const map = new Map<string, string>();
+    const map = new Map<string, string[]>();
     expect(resolvePsr4Import('GuzzleHttp\\Cookie\\SetCookie', map)).toBe(
       'GuzzleHttp\\Cookie\\SetCookie',
     );
   });
 
   it('resolves a namespaced specifier to its real source path (guzzle repro from #867)', () => {
-    const map = new Map([['GuzzleHttp\\', 'src/']]);
+    const map = new Map([['GuzzleHttp\\', ['src/']]]);
     expect(resolvePsr4Import('GuzzleHttp\\Cookie\\SetCookie', map)).toBe('src/Cookie/SetCookie');
   });
 
   it('leaves a specifier unchanged when no registered prefix matches', () => {
-    const map = new Map([['GuzzleHttp\\', 'src/']]);
+    const map = new Map([['GuzzleHttp\\', ['src/']]]);
     expect(resolvePsr4Import('PHPUnit\\Framework\\TestCase', map)).toBe(
       'PHPUnit\\Framework\\TestCase',
     );
@@ -123,8 +141,8 @@ describe('resolvePsr4Import', () => {
 
   it('matches the longest registered prefix when multiple are registered', () => {
     const map = new Map([
-      ['GuzzleHttp\\', 'src/'],
-      ['GuzzleHttp\\Tests\\', 'tests/'],
+      ['GuzzleHttp\\', ['src/']],
+      ['GuzzleHttp\\Tests\\', ['tests/']],
     ]);
 
     expect(resolvePsr4Import('GuzzleHttp\\Tests\\Cookie\\SetCookieTest', map)).toBe(
@@ -134,14 +152,70 @@ describe('resolvePsr4Import', () => {
   });
 
   it('resolves a bare-prefix specifier with no remaining path segment', () => {
-    const map = new Map([['App\\', 'src/']]);
+    const map = new Map([['App\\', ['src/']]]);
     expect(resolvePsr4Import('App\\Kernel', map)).toBe('src/Kernel');
   });
 
   it('resolves a root-mapped namespace (empty-string dir) with no leading slash (symfony/console repro, #925)', () => {
-    const map = new Map([['Symfony\\Component\\Console\\', '']]);
+    const map = new Map([['Symfony\\Component\\Console\\', ['']]]);
     expect(resolvePsr4Import('Symfony\\Component\\Console\\Command\\Command', map)).toBe(
       'Command/Command',
     );
+  });
+
+  describe('multiple candidate directories for the same prefix (#1002)', () => {
+    let testDir: string;
+
+    beforeEach(async () => {
+      testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-php-psr4-import-'));
+    });
+
+    afterEach(async () => {
+      await fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+    });
+
+    async function touch(relPath: string): Promise<void> {
+      const abs = path.join(testDir, relPath);
+      await fs.mkdir(path.dirname(abs), { recursive: true });
+      await fs.writeFile(abs, '<?php\n');
+    }
+
+    it('prefers the candidate that exists on disk under the PRODUCTION (autoload) root (Monolog repro, #1002)', async () => {
+      await touch('src/Monolog/Logger.php');
+      const map = new Map([['Monolog\\', ['src/Monolog/', 'tests/Monolog/']]]);
+
+      expect(resolvePsr4Import('Monolog\\Logger', map, testDir)).toBe('src/Monolog/Logger');
+    });
+
+    it('prefers the candidate that exists on disk under the DEV (autoload-dev) root when only that one is real', async () => {
+      await touch('tests/Monolog/LoggerTest.php');
+      const map = new Map([['Monolog\\', ['src/Monolog/', 'tests/Monolog/']]]);
+
+      expect(resolvePsr4Import('Monolog\\LoggerTest', map, testDir)).toBe(
+        'tests/Monolog/LoggerTest',
+      );
+    });
+
+    it('does NOT attribute a production-shaped specifier to a test file that happens to share the resolved path', async () => {
+      // Regression guard for the #928 fabrication shape: only touch the
+      // production candidate, and confirm the dev candidate is never chosen
+      // even though it's listed second.
+      await touch('src/Monolog/Handler/AbstractHandler.php');
+      const map = new Map([['Monolog\\', ['src/Monolog/', 'tests/Monolog/']]]);
+
+      expect(resolvePsr4Import('Monolog\\Handler\\AbstractHandler', map, testDir)).toBe(
+        'src/Monolog/Handler/AbstractHandler',
+      );
+    });
+
+    it('falls back to the first-registered (autoload) candidate when neither exists on disk', async () => {
+      const map = new Map([['Monolog\\', ['src/Monolog/', 'tests/Monolog/']]]);
+      expect(resolvePsr4Import('Monolog\\Missing', map, testDir)).toBe('src/Monolog/Missing');
+    });
+
+    it('falls back to the first-registered candidate when no workspaceRoot is given', () => {
+      const map = new Map([['Monolog\\', ['src/Monolog/', 'tests/Monolog/']]]);
+      expect(resolvePsr4Import('Monolog\\Logger', map)).toBe('src/Monolog/Logger');
+    });
   });
 });

--- a/packages/parser/src/php-psr4.ts
+++ b/packages/parser/src/php-psr4.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 /**
  * Resolves PHP Composer PSR-4 autoload mappings (`composer.json`'s
- * `autoload.psr-4` / `autoload-dev.psr-4`) to a `Map<namespacePrefix, dir>`,
+ * `autoload.psr-4` / `autoload-dev.psr-4`) to a `Map<namespacePrefix, dir[]>`,
  * and resolves a raw PHP import specifier against that map.
  *
  * This closes the PHP test-association blind spot (#867): the PHP import
@@ -13,14 +13,35 @@ import path from 'path';
  * (`"GuzzleHttp\\": "src/"`) — the namespace root essentially never equals a
  * literal directory name, so `matchesPHPNamespace`'s directory-alignment
  * guess in `path-matching.ts` fails for the standard, non-Laravel PSR-4
- * layout. Mirrors `workspace-packages.ts`'s pattern exactly: parse the
- * manifest once per workspace root, cache the result, and treat "no manifest"
- * / "no match" as a no-op so every non-PHP or non-Composer project sees zero
- * behavior change.
+ * layout. Mirrors `workspace-packages.ts`'s pattern: parse the manifest once
+ * per workspace root, cache the result, and treat "no manifest" / "no match"
+ * as a no-op so every non-PHP or non-Composer project sees zero behavior
+ * change.
  *
  * v1 scope (deliberately KISS/YAGNI, per #867's plan): only `autoload.psr-4`
  * and `autoload-dev.psr-4` are read. `classmap`/`files` autoloading, and
  * PSR-0, are out of scope — add if/when a real repo needs them.
+ *
+ * A namespace prefix can map to MORE THAN ONE directory, and both #1002 and
+ * Composer's own docs confirm this isn't an edge case:
+ * - The same prefix commonly appears in BOTH `autoload` and `autoload-dev`
+ *   (Monolog's own `composer.json` declares `"Monolog\\": "src/Monolog"` in
+ *   `autoload` AND `"Monolog\\": "tests/Monolog"` in `autoload-dev` — the
+ *   standard PHP library convention of a library's tests sharing its own
+ *   namespace). Both directories are simultaneously correct: `Monolog\Logger`
+ *   really does live under `src/Monolog`, and `Monolog\LoggerTest` really
+ *   does live under `tests/Monolog`.
+ * - Composer also lets a single section map one prefix to an ARRAY of
+ *   fallback directories, searched in order.
+ * A flat `Map<prefix, string>` can hold only one answer, so the second write
+ * silently discarded the first (#1002: `autoload-dev` is processed after
+ * `autoload`, so it always won, and every `use Monolog\Logger;` in
+ * `src/Monolog` resolved to the nonexistent `tests/Monolog/Logger`). The map
+ * therefore stores `string[]` per prefix — every directory from every
+ * section, in declaration order (`autoload` entries first, `autoload-dev`
+ * appended after) — and `resolvePsr4Import` tries each candidate in turn,
+ * preferring one that exists on disk. See its own doc comment for the
+ * candidate-selection order.
  */
 
 /** A minimal shape for the fields of composer.json this module reads. */
@@ -30,7 +51,7 @@ interface ComposerJsonShape {
 }
 
 /** Per-workspace-root cache so repeated calls during a single index run are O(1) map lookups. */
-const psr4MapCache = new Map<string, Map<string, string>>();
+const psr4MapCache = new Map<string, Map<string, string[]>>();
 
 /** Clears the cached PSR-4 maps. Exported for test isolation. */
 export function clearPsr4Cache(): void {
@@ -68,45 +89,61 @@ function normalizeSourceDir(dir: string): string {
 }
 
 /**
- * Merge one `autoload`/`autoload-dev` PSR-4 section into `map`. Composer
- * allows a prefix to map to either a single directory string or an array of
- * fallback directories — the first entry is the common case and the only one
- * handled here (a fallback dir is, by definition, a secondary location).
+ * Merge one `autoload`/`autoload-dev` PSR-4 section into `map`, APPENDING
+ * each prefix's directories rather than overwriting (#1002). Composer allows
+ * a prefix to map to either a single directory string or an array of
+ * fallback directories, searched in order — both shapes are normalized to
+ * (one or more) entries appended onto that prefix's candidate list, so a
+ * prefix declared in both `autoload` and `autoload-dev` (the standard
+ * library convention: a package's tests share its own namespace) keeps BOTH
+ * directories, and a fallback-directory array keeps every entry, not just
+ * the first.
  */
-function collectPsr4Entries(section: unknown, map: Map<string, string>): void {
+function collectPsr4Entries(section: unknown, map: Map<string, string[]>): void {
   if (!section || typeof section !== 'object') return;
 
   for (const [prefix, value] of Object.entries(section as Record<string, unknown>)) {
-    const dir = Array.isArray(value)
-      ? value.find((v): v is string => typeof v === 'string')
-      : value;
+    const rawDirs = Array.isArray(value) ? value : [value];
     // An empty string is a VALID Composer PSR-4 mapping -- "map this
     // namespace prefix directly onto the project root", used by libraries
     // with no `src/` subdirectory (e.g. symfony/console's own
     // `"Symfony\\Component\\Console\\": ""`, #925). Only a genuinely
     // non-string value (missing/malformed entry) should be skipped.
-    if (typeof dir !== 'string') continue;
-    map.set(normalizeNamespacePrefix(prefix), normalizeSourceDir(dir));
+    const dirs = rawDirs.filter((v): v is string => typeof v === 'string').map(normalizeSourceDir);
+    if (dirs.length === 0) continue;
+
+    const key = normalizeNamespacePrefix(prefix);
+    const existing = map.get(key);
+    if (existing) {
+      existing.push(...dirs);
+    } else {
+      map.set(key, dirs);
+    }
   }
 }
 
 /**
- * Build (or retrieve from cache) the PSR-4 namespace-prefix -> source-dir map
- * for a workspace root.
+ * Build (or retrieve from cache) the PSR-4 namespace-prefix -> source-dir[]
+ * map for a workspace root.
  *
  * Returns an empty map when there is no `composer.json`, or it declares no
  * `autoload.psr-4`/`autoload-dev.psr-4` map — callers can pass the result
  * straight through with zero behavior change.
  *
+ * `autoload` is collected before `autoload-dev`, so when a prefix is declared
+ * in both, its candidate array always has the `autoload` (production)
+ * directory first — see `resolvePsr4Import`'s tie-break, which relies on
+ * this ordering.
+ *
  * @param workspaceRoot - Absolute path to the project root.
  */
-export function resolvePsr4Map(workspaceRoot: string): Map<string, string> {
+export function resolvePsr4Map(workspaceRoot: string): Map<string, string[]> {
   const normalizedRoot = workspaceRoot.replace(/\\/g, '/').replace(/\/$/, '');
 
   const cached = psr4MapCache.get(normalizedRoot);
   if (cached) return cached;
 
-  const map = new Map<string, string>();
+  const map = new Map<string, string[]>();
   const composerJson = readComposerJson(path.join(normalizedRoot, 'composer.json'));
   if (composerJson) {
     collectPsr4Entries(composerJson.autoload?.['psr-4'], map);
@@ -115,6 +152,11 @@ export function resolvePsr4Map(workspaceRoot: string): Map<string, string> {
 
   psr4MapCache.set(normalizedRoot, map);
   return map;
+}
+
+/** True when `<workspaceRoot>/<candidate>.php` exists on disk. */
+function existsAsPhpFile(workspaceRoot: string, candidate: string): boolean {
+  return fs.existsSync(path.join(workspaceRoot, `${candidate}.php`));
 }
 
 /**
@@ -131,18 +173,46 @@ export function resolvePsr4Map(workspaceRoot: string): Map<string, string> {
  *
  * Matches the LONGEST registered namespace prefix (a project can declare
  * several via `autoload` + `autoload-dev`, and a more specific prefix like
- * `Foo\Bar\` must win over a broader `Foo\` if both are registered), replaces
- * it with the mapped directory, and converts the remaining namespace
- * separators to `/`.
+ * `Foo\Bar\` must win over a broader `Foo\` if both are registered), then
+ * builds one candidate resolved path per directory registered for that
+ * prefix (#1002 — a prefix can have more than one, see `resolvePsr4Map`'s doc
+ * comment) and picks among them:
+ * 1. If `workspaceRoot` is given, the first candidate that exists on disk as
+ *    a real `.php` file wins. PSR-4's own contract (the file's basename must
+ *    equal the class name) makes this a precise existence check, not a
+ *    heuristic — and because `resolvePsr4Map` puts `autoload`'s directory
+ *    before `autoload-dev`'s, iterating in order already prefers the
+ *    production root on a tie (both candidates happen to exist).
+ * 2. Otherwise (no `workspaceRoot`, or no candidate exists on disk — e.g. the
+ *    specifier is genuinely unresolvable), fall back to the first-registered
+ *    candidate: `autoload`'s directory when the prefix is declared there,
+ *    same as before #1002 for the single-candidate case.
+ *
+ * This deliberately keeps a single best-guess `string` return (not
+ * `string[]`) rather than pushing candidate selection onto callers: its only
+ * caller, `resolveImportSpecifier` (`ast/symbols.ts`), folds the result into
+ * both a flat `imports: string[]` array AND a `Record<importPath,
+ * symbols[]>` map keyed by this return value — plumbing multiple candidates
+ * through both shapes would ripple well past this module for a case the
+ * existence check above already resolves correctly in the overwhelming
+ * common case (a real file exists under exactly one of the candidate roots).
  *
  * No-op (returns `specifier` unchanged) when the map is empty or no prefix
  * matches — non-PSR-4 specifiers and non-Composer projects see zero behavior
  * change.
  *
  * @param specifier - The raw (pre-`normalizePath`) PHP import specifier.
- * @param psr4Map - Map of namespace prefix (trailing `\`) -> source dir (trailing `/`).
+ * @param psr4Map - Map of namespace prefix (trailing `\`) -> candidate source dirs (each trailing `/`).
+ * @param workspaceRoot - Absolute project root, used to disambiguate multiple
+ *   candidates by checking which resolves to a real file. Omit (e.g. in unit
+ *   tests exercising the map directly) to always get the first-registered
+ *   candidate.
  */
-export function resolvePsr4Import(specifier: string, psr4Map: ReadonlyMap<string, string>): string {
+export function resolvePsr4Import(
+  specifier: string,
+  psr4Map: ReadonlyMap<string, string[]>,
+  workspaceRoot?: string,
+): string {
   if (psr4Map.size === 0) return specifier;
 
   let bestPrefix: string | undefined;
@@ -153,7 +223,14 @@ export function resolvePsr4Import(specifier: string, psr4Map: ReadonlyMap<string
   }
   if (!bestPrefix) return specifier;
 
-  const dir = psr4Map.get(bestPrefix) as string;
+  const dirs = psr4Map.get(bestPrefix) as string[];
   const rest = specifier.slice(bestPrefix.length).replace(/\\/g, '/');
-  return `${dir}${rest}`;
+  const candidates = dirs.map(dir => `${dir}${rest}`);
+  if (candidates.length === 1) return candidates[0];
+
+  if (workspaceRoot) {
+    const existing = candidates.find(candidate => existsAsPhpFile(workspaceRoot, candidate));
+    if (existing) return existing;
+  }
+  return candidates[0];
 }


### PR DESCRIPTION
## Summary

Fixes #1002. `resolvePsr4Map` (`packages/parser/src/php-psr4.ts`) built a flat `Map<prefix, string>`, and `collectPsr4Entries` wrote with an unconditional `map.set()`. A project declaring the same PSR-4 namespace prefix in both `composer.json`'s `autoload` and `autoload-dev` sections — the standard PHP library convention, where a package's tests share its own namespace — had `autoload-dev` (processed second) silently overwrite `autoload`'s directory for that prefix.

On a real project (Monolog), this meant `"Monolog\\"` resolved only to `tests/Monolog/`, `src/Monolog` was gone from the map, and every `use Monolog\Logger;` in `src/` resolved to the nonexistent `tests/Monolog/Logger`. `get_dependents` reported `0` dependents for all 232 of Monolog's files, with `attributionCaveat: null` — indistinguishable from "nothing depends on this file."

**Not fixed by reordering.** Both directories are simultaneously correct — `Monolog\Logger` really lives under `src/Monolog`, `Monolog\LoggerTest` really lives under `tests/Monolog` — so preferring `autoload` unconditionally would just invert the bug and break PHP test association (#867, the reason this module exists).

## Fix

`resolvePsr4Map` now builds `Map<prefix, string[]>`, appending each `autoload`/`autoload-dev` section's directories instead of overwriting (`autoload` is always collected first, so a prefix's candidate array always has the production directory first). This also fixes, for free, the previously-ignored case of a PSR-4 prefix mapping to an ARRAY of Composer fallback directories — `collectPsr4Entries` used to take only the first entry (`value.find(...)`); it now keeps all of them.

`resolvePsr4Import` builds one candidate resolved path per directory registered for the matched prefix, and picks among them:
1. If `workspaceRoot` is available, the first candidate that exists on disk as a real `.php` file wins (PSR-4's own contract — the file's basename must equal the class name — makes this a precise check, not a heuristic). Because `autoload`'s directory is always first in the array, this also naturally prefers the production root on a tie (both candidates happen to exist).
2. Otherwise, falls back to the first-registered candidate (matching prior single-candidate behavior).

`ast/chunker.ts`'s `buildManifestRoots` now threads `workspaceRoot` into PHP's `ManifestRoots` (previously only `psr4Map` was returned) so `resolveManifestRoot` (`ast/symbols.ts`) can pass it through to `resolvePsr4Import`.

### Return-shape decision: kept `resolvePsr4Import` returning a single `string`, not `string[]`

Checked its callers in `ast/symbols.ts` before deciding, per the issue's instruction. `resolveImportSpecifier` has **three** call sites:
- `extractImportPaths` — pushes the result into a flat `imports: string[]` array.
- `appendReferencedFQCNs` — same, deduped via a `Set`.
- `extractSymbolsWithExtractor` — uses the result as a **single key** in a `Record<importPath, symbols[]>` map.

The third call site in particular doesn't have an obvious "correct" multi-key shape without a larger change to `extractImportedSymbols`'s return type, which ripples into every caller of that function. Since the existence-check approach (using `workspaceRoot`, the same pattern already used by `resolveJsDirectoryIndex` and `resolvePythonSrcLayoutImport`) resolves the common case correctly — a real file exists under exactly one of the candidate roots — I kept the single-`string` return and did not plumb multi-candidate arrays through the rest of the pipeline. This is the "single best-candidate return with existence checking" option the issue flagged as the possible KISS answer.

### Importer-location tiebreak: not implemented, on purpose

The issue asked me to consider whether the *importer's own location* should break a tie (a test file importing from its own root more likely means the dev candidate). I did not add this: `resolveManifestRoot`/`resolvePsr4Import` don't currently receive the importer's filepath (only `resolveImportSpecifier`, one level up, has it), so this would require new plumbing through `resolveManifestRoot`. The existence check already resolves every case in this issue's evidence (Monolog) and the common real-world case (test importing a class that only exists in `src/`, or vice versa) — the importer-location tiebreak would only matter in the genuinely rare case where **both** candidates resolve to real files with the same relative path under both roots, which is an edge case on top of an edge case. Per the issue's own instruction not to invent new plumbing for a marginal gain, I left this out.

## Verification (before/after, real Monolog clone)

Shallow-cloned `Seldaek/monolog` and ran `performChunkOnlyIndex` + `findDependents` from `@liendev/parser`'s built output, exactly as the issue specifies.

**BEFORE** (reverted `php-psr4.ts`/`symbols.ts`/`chunker.ts` back to `origin/main`'s version locally, rebuilt, re-ran):
```
files= 232
edges= 0
orphans= 232 (100.0%)
```
Matches the issue's reported numbers exactly.

**AFTER** (this fix):
```
files= 232
edges= 405
orphans= 197 (84.9%)
```

`src/Monolog/Logger.php` dependents after the fix (15 total): all **13** ground-truth production importers (verified via `grep -rl 'use Monolog\\Logger;' src/`) are present —
`Processor/MercurialProcessor.php`, `Processor/IntrospectionProcessor.php`, `Processor/GitProcessor.php`, `Handler/TestHandler.php`, `Handler/PushoverHandler.php`, `Handler/NullHandler.php`, `Handler/FingersCrossedHandler.php`, `Handler/FilterHandler.php`, `Handler/DeduplicationHandler.php`, `Handler/AbstractHandler.php`, `Handler/FingersCrossed/ErrorLevelActivationStrategy.php`, `Handler/FingersCrossed/ChannelLevelActivationStrategy.php`, `Test/MonologTestCase.php` — plus two legitimate test-file dependents (`tests/Monolog/Handler/SymfonyMailerHandlerTest.php`, `tests/Monolog/Handler/PHPConsoleHandlerTest.php`), both confirmed via `grep` to contain a real `use Monolog\Logger;` statement.

**Over-correction guard** (per the issue's warning about the #928 fabrication shape): checked every `src/` file's OWN `imports` metadata for any entry resolving into a `tests/` path — **0 found**. No production file's import is ever misattributed to the dev root; the existence check always finds the real `src/` file first when it exists.

## Sibling sweep (mandatory, per the issue)

`php-psr4.ts`'s doc comment claimed to mirror `workspace-packages.ts` "exactly" (now softened, since it no longer is one). Checked both siblings named in the issue for the same last-write-wins shape:

- **`workspace-packages.ts`** (npm workspaces) — clean. Its map is keyed by `package.json`'s `name` field, one write per matched workspace member directory. Unlike Composer's PSR-4 (which explicitly sanctions declaring the *same* prefix in two different sections), npm enforces globally-unique package names within a workspace — `npm install` itself fails on a duplicate. There is no legitimate scenario where the same key gets two different, both-correct values.
- **`rust-crate-map.ts`** (Cargo, cf. closed #903) — clean, same reasoning. Cargo enforces unique package names within a workspace; a "collision" here would mean an already-broken `Cargo.toml` that wouldn't build, not two independently-valid entries.

Both are genuinely fine as-is — no follow-up needed. (Also glanced at `go-module.ts`: not map-based at all, single prefix string, not applicable.)

## Tests

- `php-psr4.test.ts`: added the same-prefix collision repro (Monolog shape) to `resolvePsr4Map`'s suite — confirmed it **fails on current `main`** (`'tests/Monolog/'` vs expected `['src/Monolog/', 'tests/Monolog/']`) by temporarily reverting `php-psr4.ts` to `origin/main`'s version and re-running just that test.
- Added a fallback-dir-array test asserting all entries are kept, not just the first.
- Added a `resolvePsr4Import` sub-suite covering the existence-check tie-break: prefers the production candidate when it exists, prefers the dev candidate when only that one exists, does not misattribute a production import to a test file, and falls back correctly with no `workspaceRoot`/neither candidate existing.
- Updated all pre-existing tests for the new `Map<prefix, string[]>` shape.
- 20/20 tests pass in `php-psr4.test.ts`.

## Gates

All run locally in a fresh worktree (rebased onto `origin/main` mid-session after two concurrent PRs — #994 Phase 3 `#1006` and Phase 4 `#1001` — merged ahead of this branch; final diff against `origin/main` is exactly the 4 touched files + changeset):

- `npm run format:check` — pass
- `npm run lint` — 0 errors (37 pre-existing warnings, untouched files)
- `npm run typecheck` — pass (all packages)
- `npm run build` — pass (all packages)
- `npm test` — pass: parser 1613/1613, core 406/406, review 1723/1723, cli 1525/1525 (excl. e2e), action 41/41, parser-native 27/27
- `npm run test:e2e:php -w packages/cli` — pass (14/14, 140 skipped for other languages), ran against a fresh Monolog clone
- `packages/parser/src/test-associations.test.ts` (PHP FQCN-association tests, #878/#867) — 20/20 pass, no regression
- `node packages/cli/dist/index.js delta --base origin/main` — **exit 0**. Only pre-existing-function "worsened" warnings (`collectPsr4Entries` cognitive 7→10, `resolvePsr4Import` cognitive 7→12, `resolvePsr4Map`/`buildManifestRoots`/`resolveManifestRoot` time +1m each) from the added candidate-array/tie-break logic — no new threshold crossings.

This PR does not touch `packages/review/src/plugins/agent/`, so the Harness Attestation Gate auto-passes (no evidence required per its own path-diff check).

## Changeset

Added `.changeset/psr4-autoload-dev-collision.md` — `patch` for both `@liendev/parser` and `@liendev/lien`, matching the precedent for prior PHP PSR-4 false-zero fixes (#925/#926).

## Conflict-scope note

Per the task brief, avoided all files owned by concurrent agents (`dependency-analyzer.ts`, `path-matching.ts`, `chunk-complexity.ts`, `complexity-analyzer.ts`, `review/*`, `rust.ts`). Touched `ast/symbols.ts` for the `resolveManifestRoot`/`ManifestRoots` change (unowned, kept minimal — one new field, one call-site update) as pre-authorized in the brief.

Found dogfooding for #994.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Medium Risk**
>
> This PR fixes a real PHP PSR-4 bug where `autoload-dev` silently overwrote `autoload` for a shared namespace prefix, causing `get_dependents` to report zero edges. The fix changes `psr4Map` from `Map<prefix, string>` to `Map<prefix, string[]>`, appends candidates in declaration order, and disambiguates via an on-disk `.php` existence check using the newly threaded `workspaceRoot`. The change is well-scoped, thoroughly tested (including the Monolog reproduction and fallback-dir-array cases), and the author verified end-to-end against a real Monolog clone with no over-correction. No concrete bugs or breaking runtime behaviors were found.
>
> - PSR-4 map now stores multiple candidate directories per prefix instead of last-write-wins
> - Import resolution prefers the candidate whose resolved `.php` file exists on disk, falling back to the first-registered (production) candidate
> - `workspaceRoot` is now threaded through PHP `ManifestRoots` so the existence check can run during import resolution

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 064ecfe. Updates automatically on new commits.</sup>
<!-- /lien-stats -->