### PR TITLE
refactor(review): route dependency-graph edge resolution through parser's guarded primitives

### DIFF
--- a/packages/review/src/blast-radius-render.ts
+++ b/packages/review/src/blast-radius-render.ts
@@ -6,6 +6,7 @@
  */
 
 import type { BlastRadiusReport, BlastRadiusEntry, BlastRadiusDependent } from './blast-radius.js';
+import { isPreciseProvenance } from './dependency-graph.js';
 
 const LEVEL_LABEL: Record<string, string> = {
   low: 'LOW',
@@ -26,7 +27,9 @@ const NON_SUBSTITUTION_NOTE =
   'Tests column = a test file exists for that dependent, NOT that it covers ' +
   "this PR's change; Complexity = a static metric, not a correctness check. " +
   'This table does not substitute for get_files_context / read_file on a ' +
-  'dependent when you need to confirm the change is actually handled there.';
+  'dependent when you need to confirm the change is actually handled there. ' +
+  'Confidence: verified = a real import/call-site edge; inferred = a ' +
+  'name-matched, same-namespace, or text-matched guess — weight it lower.';
 
 /**
  * Render a blast-radius report as markdown wrapped in a `<blast_radius>` XML tag.
@@ -67,8 +70,8 @@ function renderSummary(report: BlastRadiusReport): string {
 
 function renderTable(entries: BlastRadiusEntry[]): string[] {
   const rows: string[] = [];
-  rows.push('| Seed (changed) | Hops | Dependent | Tests | Complexity |');
-  rows.push('|---|---|---|---|---|');
+  rows.push('| Seed (changed) | Hops | Dependent | Tests | Complexity | Confidence |');
+  rows.push('|---|---|---|---|---|---|');
 
   for (const entry of entries) {
     const seedLabel = formatSeed(entry);
@@ -79,12 +82,23 @@ function renderTable(entries: BlastRadiusEntry[]): string[] {
     });
     for (const dep of deps) {
       rows.push(
-        `| \`${seedLabel}\` | ${dep.hops} | ${formatDependent(dep)} | ${dep.hasTestCoverage ? '✓' : '✗'} | ${formatComplexity(dep)} |`,
+        `| \`${seedLabel}\` | ${dep.hops} | ${formatDependent(dep)} | ${dep.hasTestCoverage ? '✓' : '✗'} | ${formatComplexity(dep)} | ${formatConfidence(dep)} |`,
       );
     }
   }
 
   return rows;
+}
+
+/**
+ * `provenance` is absent only for hand-built test fixtures that predate
+ * #994 Phase 5 (see `BlastRadiusDependent.provenance`'s doc comment) —
+ * rendered as "verified" rather than surfacing that gap to the agent, since
+ * every real `computeBlastRadius` output always sets it.
+ */
+function formatConfidence(dep: BlastRadiusDependent): string {
+  if (!dep.provenance || isPreciseProvenance(dep.provenance)) return 'verified';
+  return 'inferred';
 }
 
 function formatSeed(entry: BlastRadiusEntry): string {

--- a/packages/review/src/blast-radius.ts
+++ b/packages/review/src/blast-radius.ts
@@ -8,7 +8,7 @@
 
 import type { CodeChunk, RiskLevel, BlastRadiusRisk } from '@liendev/parser';
 import { findTestAssociationsFromChunks, computeBlastRadiusRisk } from '@liendev/parser';
-import type { DependencyGraph } from './dependency-graph.js';
+import type { DependencyGraph, EdgeProvenance } from './dependency-graph.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -34,6 +34,17 @@ export interface BlastRadiusDependent {
   complexity?: number;
   /** True when a test file imports the dependent's source file. */
   hasTestCoverage: boolean;
+  /**
+   * How this dependent edge was resolved — carried through from
+   * `dependency-graph.ts`'s `CallerEdge.provenance` (#994 Phase 5) so the
+   * reviewing agent can weight a verified import/call-site edge above a
+   * name-matched guess or an inferred, no-import structural signal, instead
+   * of treating every row in `<blast_radius>` as equally solid. See
+   * `EdgeProvenance`'s doc comment for what each tier means. Optional only
+   * so hand-built test fixtures don't all need one; every dependent produced
+   * by `computeBlastRadius` itself always sets it.
+   */
+  provenance?: EdgeProvenance;
 }
 
 export interface BlastRadiusEntry {
@@ -184,6 +195,7 @@ function buildDependent(
     callSiteLine: edge.callSiteLine,
     complexity: complexity && complexity > 0 ? complexity : undefined,
     hasTestCoverage: coveredFiles.has(edge.caller.filepath),
+    provenance: edge.provenance,
   };
 }
 

--- a/packages/review/src/dependency-graph.ts
+++ b/packages/review/src/dependency-graph.ts
@@ -4,15 +4,73 @@
  * Resolves caller/callee relationships using imports, exports, and callSites
  * without any vector DB. Used by the bug-finding plugin to find all callers
  * of changed functions across the full repo.
+ *
+ * Phase 5 of the duplication refactor (issue #994): per-edge resolution now
+ * routes through @liendev/parser's guarded, multi-language path-matching
+ * primitives (`importMatchesTarget` and friends) instead of this module's own
+ * `resolveImportPath` (deleted — it only ever handled relative JS/TS imports
+ * with a hardcoded 6-extension list). The BFS traversal itself
+ * (`bfsTransitiveCallers`, via `walkBounded`) already came from parser and is
+ * untouched: what changed is how a single edge gets resolved, not how hops are
+ * counted. Review's graph stays symbol/call-site-level throughout (a
+ * genuinely different abstraction from parser's file-level `findDependents`)
+ * — see the module doc on `resolveCallSiteEdges` for why the two were not
+ * unified into one call.
  */
 
-import path from 'node:path/posix';
 import type { CodeChunk } from '@liendev/parser';
-import { walkBounded } from '@liendev/parser';
+import {
+  walkBounded,
+  importMatchesTarget,
+  normalizePath,
+  detectLanguage,
+  findCSharpTypeReferenceDependents,
+} from '@liendev/parser';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
+
+/**
+ * How an edge was resolved, ranked precise-to-weakest. Lets a consumer (the
+ * agent reading `<blast_radius>`, or a caller of `get_dependents`) weight a
+ * verified import edge above a name-matched guess instead of treating every
+ * dependent as equally solid — see issue #994 Phase 5.
+ *
+ * - `same-file`: caller and callee are the same file; no import needed.
+ * - `import-verified`: the caller's own import statement resolves to the
+ *   callee's file via `importMatchesTarget` (all of parser's #884/#887/#929
+ *   guards applied) AND a call site names the called symbol directly.
+ * - `import-only`: same verified import as above, but no call site in the
+ *   importing file names the symbol — e.g. a PHP `new Order()` construction,
+ *   a type hint, or a static/property access that never surfaces as a
+ *   `callSite`. Without this tier the dependent would silently vanish (see
+ *   the module doc on `resolveImportOnlyEdges`); the caller identity attached
+ *   is the file's best-effort representative chunk, not a verified call site.
+ * - `symbol-name-match`: the caller imports a same-named symbol from some
+ *   non-relative (package) path, but the specific source file was never
+ *   confirmed — a real edge only if the name isn't coincidentally reused
+ *   elsewhere in the corpus.
+ * - `oop-method-import`: the caller imports the class (verified) and calls a
+ *   method whose name matches one declared on it; the class import is solid,
+ *   the specific method attribution is inferred.
+ * - `namespace-inferred`: no import at all — resolved via a same-namespace/
+ *   same-directory convention (PHP/Python/Rust) or, for C#, the #930/#971
+ *   type-reference-matching fallback (`findCSharpTypeReferenceDependents`).
+ *   The weakest tier: a real structural signal, never an import edge.
+ */
+export type EdgeProvenance =
+  | 'same-file'
+  | 'import-verified'
+  | 'import-only'
+  | 'symbol-name-match'
+  | 'oop-method-import'
+  | 'namespace-inferred';
+
+/** True for the two tiers backed by a verified import statement (same-file counts as trivially verified). */
+export function isPreciseProvenance(provenance: EdgeProvenance): boolean {
+  return provenance === 'same-file' || provenance === 'import-verified';
+}
 
 export interface SymbolNode {
   filepath: string;
@@ -23,6 +81,8 @@ export interface SymbolNode {
 export interface CallerEdge {
   caller: SymbolNode;
   callSiteLine: number;
+  /** How this edge was resolved — see `EdgeProvenance`'s doc comment. */
+  provenance: EdgeProvenance;
 }
 
 export interface TransitiveCallerEdge extends CallerEdge {
@@ -63,53 +123,27 @@ export interface DependencyGraph {
 }
 
 // ---------------------------------------------------------------------------
-// Import path resolution
+// Path normalization
 // ---------------------------------------------------------------------------
 
-const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mts', '.mjs'];
-const INDEX_FILES = EXTENSIONS.map(ext => `index${ext}`);
-
 /**
- * Resolve a relative import path to a filepath in the known file set.
- * Handles bare paths, extensions, and index files.
+ * A cached wrapper around parser's `normalizePath`, scoped to one
+ * `buildDependencyGraph` call. Review's chunk file paths are already
+ * repo-relative (never prefixed with `workspaceRoot`), so the only thing this
+ * buys over the raw path is `normalizePath`'s cross-language extension strip
+ * (needed for `importMatchesTarget` to compare e.g. a `.js`-suffixed
+ * TypeScript import against a `.ts` file, or a PHP/Python/Rust specifier with
+ * no extension at all against a real file path that has one).
  */
-export function resolveImportPath(
-  importPath: string,
-  importerFile: string,
-  fileSet: Set<string>,
-): string | null {
-  // Skip non-relative imports (node_modules, aliases)
-  if (!importPath.startsWith('.')) return null;
-
-  const importerDir = path.dirname(importerFile);
-  const resolved = path.join(importerDir, importPath);
-
-  // Exact match
-  if (fileSet.has(resolved)) return resolved;
-
-  // Try adding extensions
-  for (const ext of EXTENSIONS) {
-    const withExt = resolved + ext;
-    if (fileSet.has(withExt)) return withExt;
-  }
-
-  // Strip existing extension and re-try (e.g., './foo.js' -> './foo.ts')
-  const parsed = path.parse(resolved);
-  if (parsed.ext) {
-    const withoutExt = path.join(parsed.dir, parsed.name);
-    for (const ext of EXTENSIONS) {
-      const remapped = withoutExt + ext;
-      if (fileSet.has(remapped)) return remapped;
-    }
-  }
-
-  // Try as directory with index file
-  for (const indexFile of INDEX_FILES) {
-    const asDir = path.join(resolved, indexFile);
-    if (fileSet.has(asDir)) return asDir;
-  }
-
-  return null;
+function createNormalizer(workspaceRoot: string): (p: string) => string {
+  const cache = new Map<string, string>();
+  return (p: string): string => {
+    const cached = cache.get(p);
+    if (cached !== undefined) return cached;
+    const normalized = normalizePath(p, workspaceRoot);
+    cache.set(p, normalized);
+    return normalized;
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -119,18 +153,40 @@ export function resolveImportPath(
 /**
  * Build an in-memory dependency graph from CodeChunk[].
  *
- * Three-pass algorithm:
- * 1. Build export index: which files export which symbols
- * 2. Resolve imports: for each chunk, map imported symbols to their source files
- * 3. Build caller edges: for each call site, link it to the exported symbol's definition
+ * `workspaceRoot` only feeds `normalizePath`'s extension-stripping (see
+ * `createNormalizer`) — pass the same value blast-radius.ts already threads
+ * through as `ComputeBlastRadiusOptions.workspaceRoot` (`context.repoRootDir`
+ * in production); omitting it is safe when chunk paths are already relative.
+ *
+ * Four-pass algorithm:
+ * 1. Build export index: which files export/declare which symbols.
+ * 2. Resolve imports: for each chunk, verify which of its import specifiers
+ *    resolve to a real exporting file (via parser's guarded matching).
+ * 3. Build caller edges: for each call site, link it to the exported
+ *    symbol's definition, trying precise-to-weakest strategies in order.
+ * 4. Build the import-only fallback index (#994 Phase 5): files that
+ *    verifiably import a symbol but never literally "call" it (e.g. a PHP
+ *    `new Order()`), so a class/type-shaped seed doesn't silently resolve to
+ *    zero dependents just because nothing invokes it by name.
  */
-export function buildDependencyGraph(chunks: CodeChunk[]): DependencyGraph {
-  const { fileSet, exportIndex } = buildExportIndex(chunks);
-  const chunkImportMaps = resolveChunkImports(chunks, fileSet);
+export function buildDependencyGraph(chunks: CodeChunk[], workspaceRoot = ''): DependencyGraph {
+  const normalize = createNormalizer(workspaceRoot);
+  const { exportIndex, chunksByFile } = buildExportIndex(chunks);
+  const chunkImportMaps = resolveChunkImports(chunks, exportIndex, normalize);
   const callerEdges = buildCallerEdges(chunks, chunkImportMaps, exportIndex);
+  const importOnlyEdges = buildImportOnlyEdges(chunkImportMaps, callerEdges, chunksByFile);
+  const csharpFallbackCache = new Map<string, CallerEdge[] | undefined>();
 
-  const getCallers = (filepath: string, symbolName: string): CallerEdge[] =>
-    callerEdges.get(`${filepath}::${symbolName}`) ?? [];
+  const getCallers = (filepath: string, symbolName: string): CallerEdge[] => {
+    const key = `${filepath}::${symbolName}`;
+    const direct = callerEdges.get(key);
+    if (direct && direct.length > 0) return direct;
+
+    const importOnly = importOnlyEdges.get(key);
+    if (importOnly && importOnly.length > 0) return importOnly;
+
+    return resolveCSharpFallback(filepath, chunks, chunksByFile, csharpFallbackCache) ?? [];
+  };
 
   return {
     getCallers,
@@ -147,6 +203,10 @@ export function buildDependencyGraph(chunks: CodeChunk[]): DependencyGraph {
 // (an exported symbol at a filepath as the node identity) and decorates the
 // raw walk results with the hop/viaSymbol fields callers of this module
 // expect — that decoration happens here, not inside walkBounded.
+//
+// Hop semantics are unchanged by Phase 5: a hop is one call-graph edge
+// (caller-of-caller), never an import-graph edge — see `EdgeProvenance` for
+// how an edge gets resolved, which is orthogonal to how many hops it costs.
 // ---------------------------------------------------------------------------
 
 const DEFAULT_TRANSITIVE_DEPTH = 2;
@@ -187,6 +247,7 @@ function bfsTransitiveCallers(
   const callers: TransitiveCallerEdge[] = results.map(({ edge, fromNode, hops }) => ({
     caller: edge.caller,
     callSiteLine: edge.callSiteLine,
+    provenance: edge.provenance,
     hops,
     viaSymbol: fromNode.symbolName,
   }));
@@ -196,13 +257,16 @@ function bfsTransitiveCallers(
 
 type ExportEntry = { filepath: string; chunk: CodeChunk };
 type ExportIndex = Map<string, ExportEntry[]>;
-type ResolvedImport = { definitionFilepath: string };
-type ChunkImportMap = Map<string, ResolvedImport>;
+/** A chunk's own verified import map: symbol name -> files it verifiably imports that symbol from. */
+type ChunkImportMap = Map<string, ExportEntry[]>;
 
-/** Pass 1: Build file set and export index. */
-function buildExportIndex(chunks: CodeChunk[]): { fileSet: Set<string>; exportIndex: ExportIndex } {
-  const fileSet = new Set<string>();
+/** Pass 1: Build the file->chunks grouping and the export index. */
+function buildExportIndex(chunks: CodeChunk[]): {
+  exportIndex: ExportIndex;
+  chunksByFile: Map<string, CodeChunk[]>;
+} {
   const exportIndex: ExportIndex = new Map();
+  const chunksByFile = new Map<string, CodeChunk[]>();
 
   const addToIndex = (symbol: string, file: string, chunk: CodeChunk) => {
     const existing = exportIndex.get(symbol) ?? [];
@@ -214,7 +278,9 @@ function buildExportIndex(chunks: CodeChunk[]): { fileSet: Set<string>; exportIn
 
   for (const chunk of chunks) {
     const file = chunk.metadata.file;
-    fileSet.add(file);
+    const fileChunks = chunksByFile.get(file) ?? [];
+    fileChunks.push(chunk);
+    chunksByFile.set(file, fileChunks);
 
     // Index explicit exports (classes, functions, interfaces)
     if (chunk.metadata.exports) {
@@ -233,32 +299,86 @@ function buildExportIndex(chunks: CodeChunk[]): { fileSet: Set<string>; exportIn
     }
   }
 
-  return { fileSet, exportIndex };
+  return { exportIndex, chunksByFile };
 }
 
-/** Pass 2: Resolve imported symbols to their source filepaths. */
+/**
+ * Pass 2: For each chunk's `importedSymbols`, verify which named symbols
+ * resolve to a real exporting file — via parser's `importMatchesTarget`,
+ * which applies the #884 whole-module, #887 single-file-vs-package, and #929
+ * Python-bare-module guards, and covers every AST-supported language's
+ * extension/namespace conventions (not just JS/TS's 6 hardcoded extensions).
+ *
+ * Replaces the old `resolveImportPath` + per-chunk fileSet lookup entirely:
+ * rather than resolving a specifier to *some* file in a corpus-wide file set
+ * (expensive, and blind to non-JS/TS syntax), this checks each imported
+ * symbol's specifier against the SMALL set of files that already declare a
+ * symbol of that name (`exportIndex`) — cheap, and the check itself is
+ * language-agnostic.
+ *
+ * Deliberately keyed by symbol name (not raw specifier): a chunk's own
+ * `resolveCallSiteEdges` only ever needs "does this chunk verifiably import
+ * symbol S", so there is nothing to gain from also keeping the specifier
+ * once this pass is done.
+ */
 function resolveChunkImports(
   chunks: CodeChunk[],
-  fileSet: Set<string>,
+  exportIndex: ExportIndex,
+  normalize: (p: string) => string,
 ): Map<CodeChunk, ChunkImportMap> {
   const result = new Map<CodeChunk, ChunkImportMap>();
 
   for (const chunk of chunks) {
-    if (!chunk.metadata.importedSymbols) continue;
+    const importedSymbols = chunk.metadata.importedSymbols;
+    if (!importedSymbols) continue;
 
-    const importMap: ChunkImportMap = new Map();
-    for (const [importPath, symbols] of Object.entries(chunk.metadata.importedSymbols)) {
-      const resolvedPath = resolveImportPath(importPath, chunk.metadata.file, fileSet);
-      if (!resolvedPath) continue;
-      for (const sym of symbols) {
-        importMap.set(sym, { definitionFilepath: resolvedPath });
-      }
-    }
-
+    const importMap = resolveOneChunkImports(chunk, importedSymbols, exportIndex, normalize);
     if (importMap.size > 0) result.set(chunk, importMap);
   }
 
   return result;
+}
+
+/** Verify one chunk's imported symbols against `exportIndex` — see `resolveChunkImports`. */
+function resolveOneChunkImports(
+  chunk: CodeChunk,
+  importedSymbols: Record<string, string[]>,
+  exportIndex: ExportIndex,
+  normalize: (p: string) => string,
+): ChunkImportMap {
+  const importMap: ChunkImportMap = new Map();
+
+  for (const [spec, symbols] of Object.entries(importedSymbols)) {
+    for (const sym of symbols) {
+      const verified = verifiedExportLocations(
+        spec,
+        chunk.metadata.file,
+        sym,
+        exportIndex,
+        normalize,
+      );
+      if (verified.length === 0) continue;
+      const existing = importMap.get(sym) ?? [];
+      importMap.set(sym, [...existing, ...verified]);
+    }
+  }
+
+  return importMap;
+}
+
+/** Which of `sym`'s known export locations does `spec` (as imported by `importerFile`) verifiably resolve to? */
+function verifiedExportLocations(
+  spec: string,
+  importerFile: string,
+  sym: string,
+  exportIndex: ExportIndex,
+  normalize: (p: string) => string,
+): ExportEntry[] {
+  const candidates = exportIndex.get(sym);
+  if (!candidates || candidates.length === 0) return [];
+  return candidates.filter(candidate =>
+    importMatchesTarget(spec, importerFile, normalize(candidate.filepath), normalize),
+  );
 }
 
 /**
@@ -325,6 +445,18 @@ interface EdgeResolutionContext {
   exportFileMap: Map<string, Set<string>>;
 }
 
+/**
+ * Languages with NO implicit-namespace/enclosing-access convention this
+ * module can approximate — TS/JS always require an explicit import, and C#
+ * has a REAL namespace/enclosing-access model (`findCSharpTypeReferenceDependents`,
+ * #930/#971) that the crude same-directory heuristic below must not run
+ * instead of. Fixes the C# gating bug flagged in issue #994 Phase 5: the old
+ * denylist (`!['typescript','javascript'].includes(lang)`) let C# fall
+ * through to same-directory matching despite the comment naming only
+ * PHP/Python/Rust as the intended targets.
+ */
+const NO_DIRECTORY_NAMESPACE_LANGS = new Set(['typescript', 'javascript', 'csharp']);
+
 /** Directory portion of a posix path, including the trailing slash ('' at the root). */
 function dirOf(filepath: string): string {
   return filepath.substring(0, filepath.lastIndexOf('/') + 1);
@@ -361,8 +493,23 @@ function buildCallerEdges(
 /**
  * Resolve and record caller edges for one call site, trying each strategy in
  * priority order and stopping at the first that applies:
- *   1. relative import       2. same-file export      3a. cross-package symbol match
- *   3b. OOP method (caller imports the class)          3c. same-namespace (implicit imports)
+ *   1. same-file export                    2. verified import (any language)
+ *   3a. cross-package symbol match          3b. OOP method (caller imports the class)
+ *   3c. same-namespace (implicit imports)
+ *
+ * Deliberately NOT delegated to parser's `findDependents`: that function is
+ * file-level (its unit of "dependent" is a file that imports a symbol, with
+ * per-call-site `usages` as an optional enrichment), while this graph is
+ * symbol/call-site-level throughout (its unit is a specific caller symbol at
+ * a specific line, feeding a call-graph BFS that hops caller-to-caller — see
+ * `bfsTransitiveCallers`). Measured (see issue #994 Phase 5 PR body): calling
+ * `findDependents` once per BFS-frontier node re-scans the ENTIRE chunk set
+ * every time (~25ms/call on a 9.9k-chunk corpus, no memoization possible
+ * since each node is a different file+symbol) — a real cost that scales
+ * with corpus size and would also land on the live `get_dependents` agent
+ * tool's per-call latency. Routing only the per-edge GUARDS through parser
+ * (`importMatchesTarget` below) keeps this pass's O(n)-once/O(1)-query
+ * architecture intact while still sharing every language guard.
  */
 function resolveCallSiteEdges(
   chunk: CodeChunk,
@@ -374,24 +521,36 @@ function resolveCallSiteEdges(
   const calledSymbol = callSite.symbol;
   const callerFile = chunk.metadata.file;
 
-  // 1. Relative import resolves straight to the definition file.
-  const resolved = importMap?.get(calledSymbol);
-  if (resolved) {
-    addEdge(ctx.edges, `${resolved.definitionFilepath}::${calledSymbol}`, chunk, callSite.line);
-    return;
-  }
-
   const exportLocations = ctx.exportIndex.get(calledSymbol);
   if (!exportLocations) return;
 
-  // 2. The same file both calls and exports the symbol.
+  // 1. The same file both calls and exports the symbol.
   if (exportLocations.some(e => e.filepath === callerFile)) {
-    addEdge(ctx.edges, `${callerFile}::${calledSymbol}`, chunk, callSite.line);
+    addEdge(ctx.edges, `${callerFile}::${calledSymbol}`, chunk, callSite.line, 'same-file');
     return;
   }
 
-  // 3a. Cross-package direct symbol match. Works across languages (TS @liendev/review,
-  //     Python `from package import ...`, Rust `use crate::...`) incl. barrel re-exports.
+  // 2. A verified import (any language, all #884/#887/#929 guards applied) —
+  //    unifies the old "relative import" and "cross-package" precise cases
+  //    into one guarded check against the symbol's actual export locations.
+  const verified = importMap?.get(calledSymbol);
+  if (verified && verified.length > 0) {
+    for (const loc of verified) {
+      addEdge(
+        ctx.edges,
+        `${loc.filepath}::${calledSymbol}`,
+        chunk,
+        callSite.line,
+        'import-verified',
+      );
+    }
+    return;
+  }
+
+  // 3a. Cross-package symbol-name match, unverified against a specific file.
+  //     Works across languages incl. barrel re-exports the verified check
+  //     above can't see through (the specifier names the barrel, not the
+  //     ultimate declaring file).
   if (pkgSymbols?.has(calledSymbol)) {
     addCrossPackageEdges(chunk, callSite, exportLocations, ctx);
     return;
@@ -414,7 +573,13 @@ function addCrossPackageEdges(
   const callerFile = chunk.metadata.file;
   for (const loc of exportLocations) {
     if (loc.filepath === callerFile) continue;
-    addEdge(ctx.edges, `${loc.filepath}::${callSite.symbol}`, chunk, callSite.line);
+    addEdge(
+      ctx.edges,
+      `${loc.filepath}::${callSite.symbol}`,
+      chunk,
+      callSite.line,
+      'symbol-name-match',
+    );
   }
 }
 
@@ -436,7 +601,13 @@ function addOopMethodEdges(
   for (const loc of exportLocations) {
     if (loc.filepath === callerFile) continue;
     if (chunkImportsFromFile(chunk, loc.filepath, pkgSymbols, ctx.exportFileMap)) {
-      addEdge(ctx.edges, `${loc.filepath}::${callSite.symbol}`, chunk, callSite.line);
+      addEdge(
+        ctx.edges,
+        `${loc.filepath}::${callSite.symbol}`,
+        chunk,
+        callSite.line,
+        'oop-method-import',
+      );
       matched = true;
     }
   }
@@ -446,8 +617,9 @@ function addOopMethodEdges(
 /**
  * 3c. Same-namespace fallback: in PHP/Python/Rust, classes in the same namespace
  * reference each other without explicit imports. If the method is defined in a file
- * in the same directory as the caller, create the edge. Skipped for TS/JS, which
- * always require explicit imports.
+ * in the same directory as the caller, create the edge. Skipped for TS/JS (always
+ * require explicit imports) and C# (has a REAL namespace model — see
+ * `NO_DIRECTORY_NAMESPACE_LANGS` and `resolveCSharpFallback` instead).
  */
 function addSameNamespaceEdges(
   chunk: CodeChunk,
@@ -456,7 +628,7 @@ function addSameNamespaceEdges(
   ctx: EdgeResolutionContext,
 ): void {
   const lang = chunk.metadata.language;
-  const supportsImplicitNamespace = lang && !['typescript', 'javascript'].includes(lang);
+  const supportsImplicitNamespace = !!lang && !NO_DIRECTORY_NAMESPACE_LANGS.has(lang);
   if (!supportsImplicitNamespace) return;
 
   const callerFile = chunk.metadata.file;
@@ -464,7 +636,13 @@ function addSameNamespaceEdges(
   for (const loc of exportLocations) {
     if (loc.filepath === callerFile) continue;
     if (dirOf(loc.filepath) === callerDir) {
-      addEdge(ctx.edges, `${loc.filepath}::${callSite.symbol}`, chunk, callSite.line);
+      addEdge(
+        ctx.edges,
+        `${loc.filepath}::${callSite.symbol}`,
+        chunk,
+        callSite.line,
+        'namespace-inferred',
+      );
     }
   }
 }
@@ -474,6 +652,7 @@ function addEdge(
   key: string,
   callerChunk: CodeChunk,
   callSiteLine: number,
+  provenance: EdgeProvenance,
 ): void {
   const existing = edges.get(key) ?? [];
   existing.push({
@@ -483,6 +662,155 @@ function addEdge(
       chunk: callerChunk,
     },
     callSiteLine,
+    provenance,
   });
   edges.set(key, existing);
+}
+
+// ---------------------------------------------------------------------------
+// Import-only fallback (#994 Phase 5) — covers a symbol that is genuinely
+// imported/referenced but never appears as a `callSite`: a class used only
+// via `new Order()`, a type hint, or a static/property access. Without this,
+// `getCallers` on a class-shaped seed silently returns zero even though real
+// dependents exist (confirmed empirically: PHP class exports resolved 0/152
+// via call-site-only matching, vs. 45%+ once import-only counts too).
+// ---------------------------------------------------------------------------
+
+/**
+ * Pick one representative chunk from a file to stand in for "the caller" of
+ * an import-only edge — prefers a top-level class, then a top-level
+ * function, then any chunk with a symbolName. `importedSymbols` is
+ * deliberately duplicated onto every chunk in a file (see `chunker.ts`'s own
+ * doc comment on `createChunk`), so without picking exactly one
+ * representative per file, an import-only edge would fire once per chunk in
+ * the importing file — a 20-method class would fabricate 20 "dependents"
+ * for what is really one file-level relationship.
+ */
+function pickRepresentativeChunk(fileChunks: CodeChunk[]): CodeChunk | undefined {
+  return (
+    fileChunks.find(c => c.metadata.symbolType === 'class' && !c.metadata.parentClass) ??
+    fileChunks.find(c => c.metadata.symbolType === 'function' && !c.metadata.parentClass) ??
+    fileChunks.find(c => !!c.metadata.symbolName)
+  );
+}
+
+/** Sentinel caller identity when a file's chunks carry no usable symbolName at all. */
+const NO_REPRESENTATIVE_SYMBOL = '(module-level)';
+
+/**
+ * Build one fallback `CallerEdge` for `file`, standing in for a caller whose
+ * exact symbol/call-site can't be pinned down (import-only or C#
+ * type-reference recovery) — see `pickRepresentativeChunk`'s doc comment.
+ * Shared by `buildImportOnlyEdges` and `resolveCSharpFallback` so the two
+ * fallback tiers build their edges identically.
+ */
+function buildRepresentativeEdge(
+  file: string,
+  chunksByFile: Map<string, CodeChunk[]>,
+  provenance: EdgeProvenance,
+): CallerEdge {
+  const fileChunks = chunksByFile.get(file) ?? [];
+  const representative = pickRepresentativeChunk(fileChunks);
+  return {
+    caller: {
+      filepath: file,
+      symbolName: representative?.metadata.symbolName ?? NO_REPRESENTATIVE_SYMBOL,
+      chunk: representative ?? (fileChunks[0] as CodeChunk),
+    },
+    callSiteLine: representative?.metadata.startLine ?? 0,
+    provenance,
+  };
+}
+
+/**
+ * Collect, per `file::symbol` key not already covered by a real call-site
+ * edge, the set of files that verifiably import that symbol — deduped per
+ * file (the SAME chunk's `importedSymbols` is duplicated across every chunk
+ * in its file, see `pickRepresentativeChunk`'s doc comment, so without
+ * dedup a 20-method class would produce 20 candidate "files").
+ */
+function collectImportOnlyFileKeys(
+  chunkImportMaps: Map<CodeChunk, ChunkImportMap>,
+  callerEdges: Map<string, CallerEdge[]>,
+): Map<string, Set<string>> {
+  const filesByKey = new Map<string, Set<string>>();
+
+  for (const [chunk, importMap] of chunkImportMaps) {
+    const callerFile = chunk.metadata.file;
+    for (const [sym, locations] of importMap) {
+      for (const loc of locations) {
+        if (loc.filepath === callerFile) continue;
+        const key = `${loc.filepath}::${sym}`;
+        if (callerEdges.has(key)) continue; // a real call-site edge already covers this key
+        const files = filesByKey.get(key) ?? new Set<string>();
+        files.add(callerFile);
+        filesByKey.set(key, files);
+      }
+    }
+  }
+
+  return filesByKey;
+}
+
+/**
+ * Build the file::symbol -> import-only CallerEdge[] fallback index, keyed
+ * identically to `callerEdges` so `getCallers` can look either up with the
+ * same key. Only ever consulted when `callerEdges` came back empty for that
+ * key (see `buildDependencyGraph`'s `getCallers`), so a key already covered
+ * by a real call-site edge never needs a redundant entry here.
+ */
+function buildImportOnlyEdges(
+  chunkImportMaps: Map<CodeChunk, ChunkImportMap>,
+  callerEdges: Map<string, CallerEdge[]>,
+  chunksByFile: Map<string, CodeChunk[]>,
+): Map<string, CallerEdge[]> {
+  const filesByKey = collectImportOnlyFileKeys(chunkImportMaps, callerEdges);
+
+  const result = new Map<string, CallerEdge[]>();
+  for (const [key, files] of filesByKey) {
+    const edges = [...files].map(file =>
+      buildRepresentativeEdge(file, chunksByFile, 'import-only'),
+    );
+    result.set(key, edges);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// C# namespace-scoped fallback (#994 Phase 5) — reuses parser's #930/#971
+// type-reference-matching recovery (`findCSharpTypeReferenceDependents`)
+// instead of the same-directory heuristic `addSameNamespaceEdges` no longer
+// applies to C# (see `NO_DIRECTORY_NAMESPACE_LANGS`). File-level only (the
+// parser primitive has no per-call-site detail), memoized per target file
+// since a review pass can query the same C# file's declared type more than
+// once (e.g. multiple seeds in the same file, or repeated BFS visits).
+// ---------------------------------------------------------------------------
+
+function resolveCSharpFallback(
+  filepath: string,
+  allChunks: CodeChunk[],
+  chunksByFile: Map<string, CodeChunk[]>,
+  cache: Map<string, CallerEdge[] | undefined>,
+): CallerEdge[] | undefined {
+  if (cache.has(filepath)) return cache.get(filepath);
+
+  const fileChunks = chunksByFile.get(filepath);
+  const language = fileChunks?.[0]?.metadata.language;
+  if (language !== 'csharp' || detectLanguage(filepath) !== 'csharp') {
+    cache.set(filepath, undefined);
+    return undefined;
+  }
+
+  const dependentFiles = findCSharpTypeReferenceDependents(filepath, allChunks);
+  if (dependentFiles.length === 0) {
+    cache.set(filepath, undefined);
+    return undefined;
+  }
+
+  const edges: CallerEdge[] = dependentFiles.map(file =>
+    buildRepresentativeEdge(file, chunksByFile, 'namespace-inferred'),
+  );
+
+  cache.set(filepath, edges);
+  return edges;
 }

--- a/packages/review/src/dependency-graph.ts
+++ b/packages/review/src/dependency-graph.ts
@@ -45,7 +45,7 @@ import {
  *   importing file names the symbol — e.g. a PHP `new Order()` construction,
  *   a type hint, or a static/property access that never surfaces as a
  *   `callSite`. Without this tier the dependent would silently vanish (see
- *   the module doc on `resolveImportOnlyEdges`); the caller identity attached
+ *   the module doc on `buildImportOnlyEdges`); the caller identity attached
  *   is the file's best-effort representative chunk, not a verified call site.
  * - `symbol-name-match`: the caller imports a same-named symbol from some
  *   non-relative (package) path, but the specific source file was never

--- a/packages/review/src/index.ts
+++ b/packages/review/src/index.ts
@@ -69,9 +69,11 @@ export {
 // Dependency graph
 export {
   buildDependencyGraph,
+  isPreciseProvenance,
   type DependencyGraph,
   type SymbolNode,
   type CallerEdge,
+  type EdgeProvenance,
 } from './dependency-graph.js';
 
 // Output adapters

--- a/packages/review/src/plugins/agent/agent-tools.ts
+++ b/packages/review/src/plugins/agent/agent-tools.ts
@@ -21,6 +21,7 @@ import {
 } from '@liendev/parser';
 
 import type { AgentToolContext } from './types.js';
+import type { CallerEdge } from '../../dependency-graph.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -190,6 +191,7 @@ export function getDependents(input: Record<string, unknown>, ctx: AgentToolCont
           filepath: c.caller.filepath,
           symbolName: c.caller.symbolName,
           callSiteLine: c.callSiteLine,
+          provenance: c.provenance,
         })),
       });
     }
@@ -210,6 +212,7 @@ export function getDependents(input: Record<string, unknown>, ctx: AgentToolCont
       filepath: string;
       symbolName: string;
       callSiteLine: number;
+      provenance: CallerEdge['provenance'];
     }> = [];
 
     for (const sym of exportedSymbols) {
@@ -220,6 +223,7 @@ export function getDependents(input: Record<string, unknown>, ctx: AgentToolCont
           filepath: c.caller.filepath,
           symbolName: c.caller.symbolName,
           callSiteLine: c.callSiteLine,
+          provenance: c.provenance,
         });
       }
     }

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -215,7 +215,7 @@ export class AgentReviewPlugin implements ReviewPlugin {
     }
 
     // Build dependency graph from in-memory chunks (no embeddings needed)
-    const graph = buildDependencyGraph(context.repoChunks!);
+    const graph = buildDependencyGraph(context.repoChunks!, context.repoRootDir ?? '');
 
     const toolExecutor = (name: string, input: Record<string, unknown>) =>
       dispatchTool(name, input, {
@@ -359,7 +359,7 @@ export class AgentReviewPlugin implements ReviewPlugin {
     provider: string,
     logger: Logger,
   ): Promise<ReviewFinding[]> {
-    const graph = buildDependencyGraph(context.repoChunks ?? []);
+    const graph = buildDependencyGraph(context.repoChunks ?? [], context.repoRootDir ?? '');
     const toolExecutor = (name: string, input: Record<string, unknown>) =>
       dispatchTool(name, input, {
         repoChunks: context.repoChunks ?? [],

--- a/packages/review/test/dependency-graph.test.ts
+++ b/packages/review/test/dependency-graph.test.ts
@@ -1,59 +1,16 @@
 import { describe, it, expect } from 'vitest';
-import { buildDependencyGraph, resolveImportPath } from '../src/dependency-graph.js';
+import { buildDependencyGraph } from '../src/dependency-graph.js';
 import { createTestChunk } from '../src/test-helpers.js';
 
 // ---------------------------------------------------------------------------
-// resolveImportPath
-// ---------------------------------------------------------------------------
-
-describe('resolveImportPath', () => {
-  const fileSet = new Set([
-    'src/utils/validate.ts',
-    'src/utils/format.ts',
-    'src/services/auth.ts',
-    'src/lib/index.ts',
-    'src/helpers.js',
-  ]);
-
-  it('resolves relative import with extension match', () => {
-    expect(resolveImportPath('./validate', 'src/utils/format.ts', fileSet)).toBe(
-      'src/utils/validate.ts',
-    );
-  });
-
-  it('resolves relative import with .js -> .ts remap', () => {
-    expect(resolveImportPath('./validate.js', 'src/utils/format.ts', fileSet)).toBe(
-      'src/utils/validate.ts',
-    );
-  });
-
-  it('resolves parent directory import', () => {
-    expect(resolveImportPath('../services/auth', 'src/utils/format.ts', fileSet)).toBe(
-      'src/services/auth.ts',
-    );
-  });
-
-  it('resolves directory with index file', () => {
-    expect(resolveImportPath('../lib', 'src/utils/format.ts', fileSet)).toBe('src/lib/index.ts');
-  });
-
-  it('returns null for non-relative (bare) imports', () => {
-    expect(resolveImportPath('lodash', 'src/utils/format.ts', fileSet)).toBeNull();
-  });
-
-  it('returns null for unresolvable import', () => {
-    expect(resolveImportPath('./nonexistent', 'src/utils/format.ts', fileSet)).toBeNull();
-  });
-
-  it('resolves exact match (file already has extension)', () => {
-    expect(resolveImportPath('../helpers.js', 'src/services/auth.ts', fileSet)).toBe(
-      'src/helpers.js',
-    );
-  });
-});
-
-// ---------------------------------------------------------------------------
 // buildDependencyGraph
+//
+// Import resolution itself (formerly this module's own `resolveImportPath`,
+// JS/TS-only with a hardcoded 6-extension list) is now @liendev/parser's
+// `importMatchesTarget` — see `packages/parser/src/utils/path-matching.test.ts`
+// for that primitive's own coverage (133 cases across every AST-supported
+// language). The tests below stay at `buildDependencyGraph`'s level: do the
+// caller-graph edges come out right end-to-end, not the path-matching detail.
 // ---------------------------------------------------------------------------
 
 describe('buildDependencyGraph', () => {
@@ -96,6 +53,7 @@ describe('buildDependencyGraph', () => {
     expect(callers[0].caller.filepath).toBe('src/services/auth.ts');
     expect(callers[0].caller.symbolName).toBe('register');
     expect(callers[0].callSiteLine).toBe(8);
+    expect(callers[0].provenance).toBe('import-verified');
   });
 
   it('finds same-file callers (no import needed)', () => {
@@ -131,6 +89,7 @@ describe('buildDependencyGraph', () => {
     expect(callers).toHaveLength(1);
     expect(callers[0].caller.symbolName).toBe('main');
     expect(callers[0].callSiteLine).toBe(9);
+    expect(callers[0].provenance).toBe('same-file');
   });
 
   it('finds multiple callers from different files', () => {
@@ -454,8 +413,12 @@ describe('buildDependencyGraph — cross-package fallback', () => {
     });
 
     const graph = buildDependencyGraph([def1, def2, caller]);
-    expect(graph.getCallers('src/utils/format.ts', 'format')).toHaveLength(1);
-    expect(graph.getCallers('src/helpers/format.ts', 'format')).toHaveLength(1);
+    const utilsCallers = graph.getCallers('src/utils/format.ts', 'format');
+    const helpersCallers = graph.getCallers('src/helpers/format.ts', 'format');
+    expect(utilsCallers).toHaveLength(1);
+    expect(helpersCallers).toHaveLength(1);
+    expect(utilsCallers[0].provenance).toBe('symbol-name-match');
+    expect(helpersCallers[0].provenance).toBe('symbol-name-match');
   });
 
   it('resolves OOP method call through class import (step 3b)', () => {
@@ -493,6 +456,7 @@ describe('buildDependencyGraph — cross-package fallback', () => {
     expect(callers[0].caller.filepath).toBe('app/Repositories/OrderRepository.php');
     expect(callers[0].caller.symbolName).toBe('findOrder');
     expect(callers[0].callSiteLine).toBe(5);
+    expect(callers[0].provenance).toBe('oop-method-import');
   });
 
   it('resolves same-namespace method call for PHP (step 3c)', () => {
@@ -528,6 +492,7 @@ describe('buildDependencyGraph — cross-package fallback', () => {
     expect(callers).toHaveLength(1);
     expect(callers[0].caller.filepath).toBe('app/Services/OrderService.php');
     expect(callers[0].caller.symbolName).toBe('processOrder');
+    expect(callers[0].provenance).toBe('namespace-inferred');
   });
 
   it('does NOT apply same-namespace fallback for TypeScript (step 3c)', () => {
@@ -822,5 +787,245 @@ describe('getCallersTransitive', () => {
     const result = graph.getCallersTransitive('nonexistent.ts', 'noSuchSymbol', { depth: 2 });
     expect(result.callers).toEqual([]);
     expect(result.truncated).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Import-only fallback (#994 Phase 5) — a class-shaped seed with real,
+// verified dependents that never literally call it by name (e.g. a
+// constructor-injected property, never `new PricingService()` or any other
+// call site named `PricingService`). Mirrors the real PHP `PricingService`
+// case measured in `pr1003-php-pricingservice-guard.blast-radius.ts`.
+// ---------------------------------------------------------------------------
+
+describe('buildDependencyGraph — import-only fallback', () => {
+  it('recovers a dependent whose import is verified but no call site names the class', () => {
+    const classChunk = createTestChunk({
+      metadata: {
+        file: 'app/Services/PricingService.php',
+        startLine: 1,
+        endLine: 50,
+        type: 'class',
+        symbolName: 'PricingService',
+        symbolType: 'class',
+        language: 'php',
+        exports: ['PricingService'],
+      },
+    });
+
+    // Constructor-injected property — genuinely depends on PricingService,
+    // but only ever calls its METHODS, never a call site literally named
+    // 'PricingService'.
+    const callerChunk = createTestChunk({
+      content:
+        'function formatTotal($total) { return $this->pricingService->formatPrice($total); }',
+      metadata: {
+        file: 'app/Http/Controllers/ProductController.php',
+        startLine: 1,
+        endLine: 30,
+        type: 'class',
+        symbolName: 'ProductController',
+        symbolType: 'class',
+        language: 'php',
+        exports: ['ProductController'],
+        importedSymbols: { 'App\\Services\\PricingService': ['PricingService'] },
+        callSites: [{ symbol: 'formatPrice', line: 10 }],
+      },
+    });
+
+    const graph = buildDependencyGraph([classChunk, callerChunk]);
+    const callers = graph.getCallers('app/Services/PricingService.php', 'PricingService');
+
+    expect(callers).toHaveLength(1);
+    expect(callers[0].caller.filepath).toBe('app/Http/Controllers/ProductController.php');
+    expect(callers[0].caller.symbolName).toBe('ProductController');
+    expect(callers[0].provenance).toBe('import-only');
+  });
+
+  it('does not fabricate an edge when no chunk in the file verifiably imports the class', () => {
+    const classChunk = createTestChunk({
+      metadata: {
+        file: 'app/Services/PricingService.php',
+        startLine: 1,
+        endLine: 50,
+        type: 'class',
+        symbolName: 'PricingService',
+        symbolType: 'class',
+        language: 'php',
+        exports: ['PricingService'],
+      },
+    });
+
+    const unrelatedChunk = createTestChunk({
+      metadata: {
+        file: 'app/Http/Controllers/UnrelatedController.php',
+        startLine: 1,
+        endLine: 10,
+        type: 'class',
+        symbolName: 'UnrelatedController',
+        symbolType: 'class',
+        language: 'php',
+        exports: ['UnrelatedController'],
+      },
+    });
+
+    const graph = buildDependencyGraph([classChunk, unrelatedChunk]);
+    expect(graph.getCallers('app/Services/PricingService.php', 'PricingService')).toHaveLength(0);
+  });
+
+  it('deduplicates to one edge per importing FILE, not one per chunk', () => {
+    // importedSymbols is deliberately duplicated onto every chunk in a file
+    // (see chunker.ts's own doc comment on createChunk) — a multi-method
+    // class must still produce exactly one import-only dependent per file.
+    const classChunk = createTestChunk({
+      metadata: {
+        file: 'app/Services/PricingService.php',
+        startLine: 1,
+        endLine: 50,
+        type: 'class',
+        symbolName: 'PricingService',
+        symbolType: 'class',
+        language: 'php',
+        exports: ['PricingService'],
+      },
+    });
+
+    const sharedImport = { 'App\\Services\\PricingService': ['PricingService'] };
+    const callerClassChunk = createTestChunk({
+      metadata: {
+        file: 'app/Http/Controllers/ProductController.php',
+        startLine: 1,
+        endLine: 40,
+        type: 'class',
+        symbolName: 'ProductController',
+        symbolType: 'class',
+        language: 'php',
+        exports: ['ProductController'],
+        importedSymbols: sharedImport,
+      },
+    });
+    const method1 = createTestChunk({
+      content: 'function show() { return $this->pricingService->formatPrice(1); }',
+      metadata: {
+        file: 'app/Http/Controllers/ProductController.php',
+        startLine: 10,
+        endLine: 15,
+        type: 'function',
+        symbolName: 'show',
+        symbolType: 'method',
+        parentClass: 'ProductController',
+        language: 'php',
+        importedSymbols: sharedImport,
+        callSites: [{ symbol: 'formatPrice', line: 12 }],
+      },
+    });
+    const method2 = createTestChunk({
+      content: 'function index() { return $this->pricingService->calculateOrderTotal([]); }',
+      metadata: {
+        file: 'app/Http/Controllers/ProductController.php',
+        startLine: 20,
+        endLine: 25,
+        type: 'function',
+        symbolName: 'index',
+        symbolType: 'method',
+        parentClass: 'ProductController',
+        language: 'php',
+        importedSymbols: sharedImport,
+        callSites: [{ symbol: 'calculateOrderTotal', line: 22 }],
+      },
+    });
+
+    const graph = buildDependencyGraph([classChunk, callerClassChunk, method1, method2]);
+    const callers = graph.getCallers('app/Services/PricingService.php', 'PricingService');
+
+    expect(callers).toHaveLength(1);
+    expect(callers[0].caller.filepath).toBe('app/Http/Controllers/ProductController.php');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C# same-namespace gating fix (#994 Phase 5) — `addSameNamespaceEdges`'s
+// crude same-directory heuristic must NOT apply to C#, which has a REAL
+// namespace/enclosing-access model (`findCSharpTypeReferenceDependents`).
+// The old denylist (`!['typescript','javascript'].includes(lang)`) let C#
+// fall through to same-directory matching despite the comment naming only
+// PHP/Python/Rust as the intended targets.
+// ---------------------------------------------------------------------------
+
+describe('buildDependencyGraph — C# namespace gating fix', () => {
+  it('does NOT apply the same-directory fallback for C# (unlike PHP)', () => {
+    const methodChunk = createTestChunk({
+      metadata: {
+        file: 'App/Services/PaymentService.cs',
+        startLine: 1,
+        endLine: 10,
+        type: 'function',
+        symbolName: 'Charge',
+        symbolType: 'method',
+        language: 'csharp',
+        exports: ['PaymentService'],
+      },
+    });
+
+    // Same directory as PaymentService.cs, calls a method with the same
+    // name, but with NO verified import — the pre-Phase-5 behavior would
+    // have matched this via the same-directory heuristic.
+    const callerChunk = createTestChunk({
+      content: 'void ProcessOrder() { paymentService.Charge(); }',
+      metadata: {
+        file: 'App/Services/OrderService.cs',
+        startLine: 1,
+        endLine: 10,
+        type: 'function',
+        symbolName: 'ProcessOrder',
+        language: 'csharp',
+        callSites: [{ symbol: 'Charge', line: 10 }],
+      },
+    });
+
+    const graph = buildDependencyGraph([methodChunk, callerChunk]);
+    const callers = graph.getCallers('App/Services/PaymentService.cs', 'Charge');
+
+    expect(callers).toHaveLength(0);
+  });
+
+  it('recovers a C# dependent via the #930/#971 type-reference fallback instead', () => {
+    // A globally-unique type name with NO import and NO call site at all —
+    // only recoverable via findCSharpTypeReferenceDependents's word-boundary
+    // text match (see that module's own test suite for its full behavior;
+    // this test only checks that dependency-graph.ts wires it in correctly).
+    const declChunk = createTestChunk({
+      content: 'namespace App.Services;\n\npublic class PricingService { }',
+      metadata: {
+        file: 'App/Services/PricingService.cs',
+        startLine: 1,
+        endLine: 3,
+        type: 'class',
+        symbolName: 'PricingService',
+        symbolType: 'class',
+        language: 'csharp',
+        exports: ['PricingService'],
+      },
+    });
+
+    const usageChunk = createTestChunk({
+      content: 'namespace App.Services;\n\nPricingService.Apply(order);',
+      metadata: {
+        file: 'App/Services/OrderService.cs',
+        startLine: 1,
+        endLine: 3,
+        type: 'function',
+        symbolName: 'Process',
+        symbolType: 'method',
+        language: 'csharp',
+      },
+    });
+
+    const graph = buildDependencyGraph([declChunk, usageChunk]);
+    const callers = graph.getCallers('App/Services/PricingService.cs', 'PricingService');
+
+    expect(callers).toHaveLength(1);
+    expect(callers[0].caller.filepath).toBe('App/Services/OrderService.cs');
+    expect(callers[0].provenance).toBe('namespace-inferred');
   });
 });

--- a/packages/review/test/harness/fixtures/blast-radius/pr1003-php-pricingservice-guard.blast-radius.ts
+++ b/packages/review/test/harness/fixtures/blast-radius/pr1003-php-pricingservice-guard.blast-radius.ts
@@ -1,0 +1,169 @@
+#!/usr/bin/env tsx
+/**
+ * Deterministic `computeBlastRadius` baseline for a PHP fixture — PR #1003
+ * (a small guard added to `lien-review-testbed/php/app/Services/PricingService.php`).
+ *
+ * Unlike the `.assertions.ts` corpus (which asserts on an agent's LLM output
+ * via `run.ts`/`--calibrate`, real money per call), this checks a purely
+ * deterministic, pre-computed signal: `computeBlastRadius` runs BEFORE the
+ * agent is ever invoked (see `plugins/agent/index.ts`), so it can be
+ * verified directly against the captured fixture with zero LLM spend and no
+ * `OPENROUTER_API_KEY`. Deliberately named `.blast-radius.ts`, not
+ * `.assertions.ts` (see `pr981-python-check-required-fields.blast-radius.ts`
+ * for the full rationale) — `run.ts` never sweeps this into a paid
+ * `--calibrate` run.
+ *
+ * WHY THIS FIXTURE EXISTS (issue #994 Phase 5): `PricingService`'s diff
+ * touches its class-level chunk (see `chunk.metadata.exports` for a PHP
+ * class chunk lists the CLASS name, not its methods), so blast-radius seeds
+ * on `{filepath: PricingService.php, symbolName: 'PricingService'}` —
+ * `isSeedCandidate` (blast-radius.ts) excludes method chunks whenever their
+ * class is the thing that's actually exported, which is ALWAYS the case for
+ * PHP methods, so a changed PHP class is *structurally* the only kind of PHP
+ * seed blast-radius ever produces, never one of its methods. Every real
+ * consumer of `PricingService` references it via constructor-injected
+ * property (`private readonly PricingService $pricingService`), never a
+ * literal `new PricingService(...)` or any other call site literally named
+ * `PricingService` — so BEFORE #994 Phase 5, `getCallers` found zero
+ * call-site matches and blast-radius reported `risk: low, dependents: []` on
+ * a symbol with real, verified dependents. Confirmed empirically against
+ * this exact fixture on main@099c1d78 (pre-Phase-5): zero dependents, risk
+ * "low", reasoning `[]`.
+ *
+ * Ground truth (verified by hand, `grep -rln "PricingService"
+ * lien-review-testbed/php`): 4 other files reference `PricingService`.
+ * Exactly 2 do so via an explicit `use App\Services\PricingService;` import
+ * (`ProductController.php`, `OrderController.php`) — these are recovered by
+ * the new import-only fallback (`dependency-graph.ts`'s
+ * `buildImportOnlyEdges`), tagged `provenance: 'import-only'`. The other 2
+ * (`OrderService.php`, `CheckoutService.php`) are in the SAME NAMESPACE
+ * (`App\Services`) as `PricingService` and reference it with NO explicit
+ * import at all (PHP same-namespace implicit resolution) — `getCallers` has
+ * no verified import to key off for those two, so they remain a KNOWN,
+ * documented gap (not recovered by this phase; would need a call-site- and
+ * import-free "same-namespace, no evidence" fallback, which was deliberately
+ * NOT added — see `dependency-graph.ts`'s module doc on why extending
+ * `addSameNamespaceEdges` to run without any call-site match at all was
+ * rejected as too weak a signal on its own).
+ *
+ * Regenerate the fixture:
+ *   npx tsx packages/review/test/harness/capture-pr.ts 1003 \
+ *     packages/review/test/harness/fixtures/blast-radius/pr1003-php-pricingservice-guard.fixture.json \
+ *     --sha 77820895632948747e1a95e2388549c8f5555616
+ *
+ * Usage: tsx pr1003-php-pricingservice-guard.blast-radius.ts
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { buildDependencyGraph } from '../../../../src/dependency-graph.js';
+import { computeBlastRadius } from '../../../../src/blast-radius.js';
+import type { BlastRadiusEntry, BlastRadiusReport } from '../../../../src/blast-radius.js';
+import type { ReviewContext } from '../../../../src/plugin-types.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = join(HERE, 'pr1003-php-pricingservice-guard.fixture.json');
+
+const SEED_FILEPATH = 'lien-review-testbed/php/app/Services/PricingService.php';
+const SEED_SYMBOL = 'PricingService';
+
+interface DependentPin {
+  filepath: string;
+  symbolName: string;
+  provenance: string;
+}
+
+/** The 2 real (hand-verified) direct dependents recoverable via import-only edges. */
+const EXPECTED_DIRECT_DEPENDENTS: DependentPin[] = [
+  {
+    filepath: 'lien-review-testbed/php/app/Http/Controllers/ProductController.php',
+    symbolName: 'ProductController',
+    provenance: 'import-only',
+  },
+  {
+    filepath: 'lien-review-testbed/php/app/Http/Controllers/OrderController.php',
+    symbolName: 'OrderController',
+    provenance: 'import-only',
+  },
+];
+
+const EXPECTED_RISK_LEVEL = 'medium';
+
+function keyOf(d: { filepath: string; symbolName: string }): string {
+  return `${d.filepath}::${d.symbolName}`;
+}
+
+function loadReport(): BlastRadiusReport {
+  const ctx = JSON.parse(readFileSync(FIXTURE_PATH, 'utf8')) as ReviewContext;
+  const graph = buildDependencyGraph(ctx.repoChunks!, ctx.repoRootDir);
+  return computeBlastRadius(ctx.chunks, graph, ctx.repoChunks!, { workspaceRoot: ctx.repoRootDir });
+}
+
+function findSeedEntry(report: BlastRadiusReport): BlastRadiusEntry | undefined {
+  return report.entries.find(
+    e => e.seed.filepath === SEED_FILEPATH && e.seed.symbolName === SEED_SYMBOL,
+  );
+}
+
+/** Set-difference the actual hop=1 dependents against the pinned baseline, including provenance. Returns failure messages (empty = pass). */
+function checkDirectDependents(entry: BlastRadiusEntry): string[] {
+  const actualDirect = entry.dependents.filter(d => d.hops === 1);
+  const actualKeys = new Set(actualDirect.map(keyOf));
+  const expectedKeys = new Set(EXPECTED_DIRECT_DEPENDENTS.map(keyOf));
+
+  const missing = EXPECTED_DIRECT_DEPENDENTS.filter(d => !actualKeys.has(keyOf(d)));
+  const extra = actualDirect.filter(d => !expectedKeys.has(keyOf(d)));
+
+  const failures: string[] = [];
+  if (missing.length > 0) {
+    failures.push(`missing expected direct dependent(s): ${missing.map(keyOf).join(', ')}`);
+  }
+  if (extra.length > 0) {
+    failures.push(`unexpected extra direct dependent(s): ${extra.map(d => keyOf(d)).join(', ')}`);
+  }
+
+  for (const expected of EXPECTED_DIRECT_DEPENDENTS) {
+    const actual = actualDirect.find(d => keyOf(d) === keyOf(expected));
+    if (actual && actual.provenance !== expected.provenance) {
+      failures.push(
+        `${keyOf(expected)}: expected provenance '${expected.provenance}', got '${actual.provenance}'`,
+      );
+    }
+  }
+
+  return failures;
+}
+
+function checkRisk(entry: BlastRadiusEntry): string[] {
+  if (entry.risk.level !== EXPECTED_RISK_LEVEL) {
+    return [
+      `risk level drifted — expected '${EXPECTED_RISK_LEVEL}', got '${entry.risk.level}' (${entry.risk.reasoning.join('; ')})`,
+    ];
+  }
+  return [];
+}
+
+function main(): void {
+  const entry = findSeedEntry(loadReport());
+  if (!entry) {
+    console.error(`FAIL: no blast-radius entry for seed ${SEED_SYMBOL}@${SEED_FILEPATH}.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const failures = [...checkDirectDependents(entry), ...checkRisk(entry)];
+  if (failures.length > 0) {
+    console.error(`FAIL:\n  - ${failures.join('\n  - ')}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `OK — ${SEED_SYMBOL}@${SEED_FILEPATH}: ${entry.dependents.length} direct dependents ` +
+      `(all import-only, PRE-#994-Phase-5 this was 0), risk=${entry.risk.level}.`,
+  );
+}
+
+main();

--- a/packages/review/test/harness/fixtures/blast-radius/pr1003-rust-config-guard.blast-radius.ts
+++ b/packages/review/test/harness/fixtures/blast-radius/pr1003-rust-config-guard.blast-radius.ts
@@ -1,0 +1,139 @@
+#!/usr/bin/env tsx
+/**
+ * Deterministic `computeBlastRadius` baseline for a Rust fixture — PR #1003
+ * (a tightened `max_depth` bound in `lien-review-testbed/rust/src/config.rs`).
+ *
+ * See `pr981-python-check-required-fields.blast-radius.ts` for why this file
+ * exists and why it's named `.blast-radius.ts` (not `.assertions.ts` — never
+ * swept into a paid `--calibrate` run).
+ *
+ * THIS FIXTURE PINS A KNOWN GAP, NOT A FIX — read before "improving" it.
+ *
+ * `Config` (the struct) is blast-radius's seed here for the same structural
+ * reason as the PHP `PricingService` fixture: `config.rs`'s diff touches the
+ * struct+impl's own chunk, `isSeedCandidate` excludes its methods (`load`,
+ * `get`, `validate`, `default_config` aren't top-level exports), so `Config`
+ * is the only seed this diff can produce. `cache.rs`, `analyzer.rs`,
+ * `parser.rs`, `reporter.rs`, and `main.rs` all genuinely reference `Config`
+ * (`use crate::config::Config;` + either a type-hinted parameter or a
+ * `Config::load(...)`/`Config::default_config()` call) — real, verified
+ * dependents by any reasonable definition.
+ *
+ * Measured BOTH before and after #994 Phase 5 on this exact fixture: ZERO
+ * dependents, `risk: low, reasoning: []`, in both cases — Phase 5's
+ * import-only fallback (which fixed the equivalent PHP case, see
+ * `pr1003-php-pricingservice-guard.blast-radius.ts`) does NOT recover this
+ * one. Root cause, confirmed directly against `@liendev/parser`'s
+ * `importMatchesTarget` (NOT this package's code):
+ * `lien-review-testbed/rust/` nests each language's sample crate 2
+ * directories below the repo root, so a bare Rust module specifier like
+ * `config` (from `use crate::config::Config;`, recorded as
+ * `importedSymbols: { config: ['Config'] }`) needs to match against
+ * `lien-review-testbed/rust/src/config` — 3 leading path segments before the
+ * bare name. `matchesAtBoundaryPrecise`'s `maxLeadingSegments: 1` cap (the
+ * deliberate #868/#883 boundary for a bare specifier resolving via a single
+ * `src/`-style prefix) rejects that as too deep, so `chunkImportMaps` (this
+ * package's own verified-import index, `dependency-graph.ts`) never
+ * populates an entry for ANY cross-file Rust reference in this testbed at
+ * all — confirmed identically reproducible by calling parser's own
+ * `findDependents(chunks, 'lien-review-testbed/rust/src/config.rs', ...,
+ * 'Config', 1)` directly: same zero-dependent result, so this is a
+ * pre-existing, ALREADY-shared parser-level limitation, not something Phase
+ * 5 introduced or could fix by routing through parser more thoroughly — it's
+ * the shared primitive itself that's capped for this depth. Almost certainly
+ * a testbed-structure artifact rather than a real-world Rust concern (a
+ * typical crate's `src/` sits 0-1 directories from its own repo root, not
+ * 2+), but this fixture's job is to pin the measured truth, not the
+ * probable-in-practice case.
+ *
+ * Do NOT "fix" this fixture by loosening `maxLeadingSegments` to make it
+ * pass — that primitive is shared by every other language's import
+ * resolution and was deliberately capped at 1 to avoid false hubs (see its
+ * own doc comment in `path-matching.ts`). If this gap is worth closing,
+ * it's a parser-level follow-up (loosen the cap for `crate::`-style bare
+ * specifiers specifically, or thread the actual crate root depth through),
+ * not a review-package workaround.
+ *
+ * Regenerate the fixture:
+ *   npx tsx packages/review/test/harness/capture-pr.ts 1003 \
+ *     packages/review/test/harness/fixtures/blast-radius/pr1003-rust-config-guard.fixture.json \
+ *     --sha 77820895632948747e1a95e2388549c8f5555616
+ *
+ * Usage: tsx pr1003-rust-config-guard.blast-radius.ts
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { buildDependencyGraph } from '../../../../src/dependency-graph.js';
+import { computeBlastRadius } from '../../../../src/blast-radius.js';
+import type { BlastRadiusEntry, BlastRadiusReport } from '../../../../src/blast-radius.js';
+import type { ReviewContext } from '../../../../src/plugin-types.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = join(HERE, 'pr1003-rust-config-guard.fixture.json');
+
+const SEED_FILEPATH = 'lien-review-testbed/rust/src/config.rs';
+const SEED_SYMBOL = 'Config';
+
+const EXPECTED_DEPENDENT_COUNT = 0;
+const EXPECTED_RISK_LEVEL = 'low';
+
+function loadReport(): BlastRadiusReport {
+  const ctx = JSON.parse(readFileSync(FIXTURE_PATH, 'utf8')) as ReviewContext;
+  const graph = buildDependencyGraph(ctx.repoChunks!, ctx.repoRootDir);
+  return computeBlastRadius(ctx.chunks, graph, ctx.repoChunks!, { workspaceRoot: ctx.repoRootDir });
+}
+
+function findSeedEntry(report: BlastRadiusReport): BlastRadiusEntry | undefined {
+  return report.entries.find(
+    e => e.seed.filepath === SEED_FILEPATH && e.seed.symbolName === SEED_SYMBOL,
+  );
+}
+
+function main(): void {
+  const report = loadReport();
+  const entry = findSeedEntry(report);
+
+  // No entry at all is ALSO consistent with the pinned "zero dependents"
+  // baseline: computeBlastRadius only emits an entry once its seed has been
+  // through getCallersTransitive, but an empty result for every seed can
+  // leave `entries` empty entirely depending on how seeds got ranked. Handle
+  // both shapes rather than asserting an entry must exist.
+  if (!entry) {
+    console.log(
+      `OK — no blast-radius entry for ${SEED_SYMBOL}@${SEED_FILEPATH} ` +
+        `(consistent with the pinned ${EXPECTED_DEPENDENT_COUNT}-dependent baseline).`,
+    );
+    return;
+  }
+
+  const failures: string[] = [];
+  if (entry.dependents.length !== EXPECTED_DEPENDENT_COUNT) {
+    failures.push(
+      `dependent count drifted — expected ${EXPECTED_DEPENDENT_COUNT}, got ${entry.dependents.length} ` +
+        `(${entry.dependents.map(d => `${d.filepath}::${d.symbolName} [${d.provenance}]`).join(', ')}). ` +
+        `If this is a GENUINE improvement (the parser-level path-depth cap described in this file's ` +
+        `module doc got fixed), update this fixture's expectations — don't just silence the failure.`,
+    );
+  }
+  if (entry.risk.level !== EXPECTED_RISK_LEVEL) {
+    failures.push(
+      `risk level drifted — expected '${EXPECTED_RISK_LEVEL}', got '${entry.risk.level}' (${entry.risk.reasoning.join('; ')})`,
+    );
+  }
+
+  if (failures.length > 0) {
+    console.error(`FAIL:\n  - ${failures.join('\n  - ')}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `OK — ${SEED_SYMBOL}@${SEED_FILEPATH}: ${entry.dependents.length} dependents, risk=${entry.risk.level} ` +
+      `(pinned known-gap baseline — see module doc for the parser-level path-depth cap this is blocked on).`,
+  );
+}
+
+main();


### PR DESCRIPTION
## Summary

Issue #994, Phase 5. `packages/review/src/dependency-graph.ts` had its own `resolveImportPath` — relative-only, JS/TS-only, a hardcoded 6-extension list — sharing zero path-matching with `@liendev/parser`'s guarded, 12-language `importMatchesTarget`/`matchesFile`. Every guard fix parser gained (#884, #886, #887, #929, #934, #953, #955) never reached review's `blast_radius` signal.

- **Deleted `resolveImportPath`.** Replaced with `importMatchesTarget`-based resolution, verified against the symbol's known export locations (`exportIndex`) instead of a corpus-wide file scan — same O(n)-once/O(1)-query architecture, now multi-language.
- **Kept review's own BFS untouched.** `bfsTransitiveCallers` (via parser's `walkBounded`) is unchanged — hop semantics stay call-graph hops throughout. Only per-edge resolution changed.
- **C# gating bug fixed.** `addSameNamespaceEdges`'s same-directory heuristic ran for `csharp` (`!['typescript','javascript'].includes(lang)`) despite its own comment naming only PHP/Python/Rust. C# now routes through `findCSharpTypeReferenceDependents` (#930/#971) instead.
- **New import-only fallback** (`buildImportOnlyEdges`) for a real gap a mid-task measurement surfaced (see "Course correction" below): a class/type-shaped seed referenced only via constructor injection — never a literal call to the class's own name — resolved to **zero** callers under the old call-site-only model, even with real, verified dependents.
- **Provenance tag added** (`EdgeProvenance`: `same-file` / `import-verified` / `import-only` / `symbol-name-match` / `oop-method-import` / `namespace-inferred`) on every `CallerEdge`/`BlastRadiusDependent`, surfaced as a new **Confidence** column in `<blast_radius>` and in `get_dependents`'s JSON output — so the agent can weight a verified edge above a name-matched guess.

## Course correction mid-task

The original brief recommended calling parser's `findDependents` directly per BFS node. I measured this instead of implementing it as specified:

```
single findDependents call (symbol, depth1): 39.16 ms
240x findDependents calls total: 6131.74 ms, avg: 25.55 ms/call
```
(9,864-chunk corpus — this repo at the PR #981 capture point.) `findDependents` rebuilds its whole import index every call with no way to memoize across different (file, symbol) queries, so this cost scales with corpus size and would also land on the **live** `get_dependents` agent tool's per-call latency (called synchronously, mid-investigation, possibly many times per review). I pushed back on the literal recommendation and instead routed only the **per-edge guards** (`importMatchesTarget` et al., all already exported from parser) through review's existing one-time index build, preserving O(n)-once/O(1)-query performance while still sharing every language guard. This also sidesteps the "both call it `hops` but count different graphs" ambiguity entirely — review's BFS never touches `findDependents`'s own hop/depth machinery.

Separately, the coordinator ran an independent measurement mid-task and found `getCallers` resolves via `exports`-listed symbols at 0% for PHP (0/152) vs 45-98% via a chunk's own `symbolName` — root-caused to PHP classes being called via their *methods*, never their own class name as a literal call site. I reproduced this independently (see below) before building on it, and it changes the fix's shape: `provenance` alone isn't enough if a real dependent still returns zero. That's what `buildImportOnlyEdges` is for — recovering the case that call-site-only matching structurally cannot see.

## Reproduced the coordinator's finding independently

Captured a real PR fixture (#1003, this branch's own testbed edits — see below) and ran `findDependents` directly against parser, no review code involved:

```js
findDependents(chunks, 'lien-review-testbed/rust/src/config.rs', ..., 'Config', 1) → 0 dependents
```
Confirmed the analogous PHP case pre-Phase-5 (`buildDependencyGraph` on `main`): `getCallers('PricingService.php', 'PricingService')` → **0** callers, `risk: low`, despite 4 real files depending on it. Matches the coordinator's report; not repeated here as a re-measurement, just independently confirmed before building the fix on top of it.

## Measurement (before/after, zero LLM cost)

Deterministic `computeBlastRadius` checkers — no `OPENROUTER_API_KEY`, never swept into `--calibrate` (named `.blast-radius.ts`, not `.assertions.ts`):

| Fixture | Seed | Before (main@099c1d78) | After |
|---|---|---|---|
| PR #981 (Python, pre-existing) | `check_required_fields` | 3 direct / 12 total, risk=high | **unchanged** — 3 direct / 12 total, risk=high |
| PR #1003 (PHP, new) | `PricingService` (class) | **0 dependents**, risk=low | **2 direct dependents** (both `import-only`), risk=medium |
| PR #1003 (Rust, new) | `Config` (struct) | 0 dependents, risk=low | **unchanged** — 0 dependents, risk=low (see below) |

```
$ npx tsx packages/review/test/harness/fixtures/blast-radius/pr981-python-check-required-fields.blast-radius.ts
OK — check_required_fields@lien-review-testbed/python/pipeline/validator.py: 3 direct dependents match baseline, 12 total, risk=high.

$ npx tsx packages/review/test/harness/fixtures/blast-radius/pr1003-php-pricingservice-guard.blast-radius.ts
OK — PricingService@lien-review-testbed/php/app/Services/PricingService.php: 2 direct dependents (all import-only, PRE-#994-Phase-5 this was 0), risk=medium.

$ npx tsx packages/review/test/harness/fixtures/blast-radius/pr1003-rust-config-guard.blast-radius.ts
OK — Config@lien-review-testbed/rust/src/config.rs: 0 dependents, risk=low (pinned known-gap baseline — see module doc for the parser-level path-depth cap this is blocked on).
```

**Rust is an honest non-improvement, not a bug in this PR.** `Config`'s real dependents (`cache.rs`, `analyzer.rs`, `main.rs`, ...) all reference it via a bare `use crate::config::Config;` → `importedSymbols: { config: ['Config'] }`. `lien-review-testbed/rust/` nests each language's sample crate 2 directories below the repo root, so matching `config` against `lien-review-testbed/rust/src/config` needs 3 leading path segments — over parser's `matchesAtBoundaryPrecise`'s deliberate `maxLeadingSegments: 1` cap (#868/#883, meant for a single `src/`-style prefix). Confirmed this is a **pre-existing, already-shared parser limitation**, not something this PR introduced or could fix by routing through parser more thoroughly:
```js
importMatchesTarget('config', 'lien-review-testbed/rust/src/analyzer.rs', normalize('lien-review-testbed/rust/src/config.rs'), normalize) // false
importMatchesTarget('config', 'src/analyzer.rs', normalize('src/config.rs'), normalize) // true — same shape, 1 level deep
findDependents(chunks, 'lien-review-testbed/rust/src/config.rs', ..., 'Config', 1) // 0 dependents — parser's OWN get_dependents engine, same corpus
```
Filed as a follow-up rather than patched around in review — loosening the shared cap locally would reintroduce exactly the kind of review-side path-matching divergence this phase exists to eliminate. Almost certainly a testbed-nesting artifact (a real crate's `src/` is usually 0-1 directories from its repo root), not a general Rust concern — but the fixture pins the measured truth, not the probable case, and documents this thoroughly (see its module doc).

## PHP testbed fixture PR (merged separately)

lien-review-testbed had no PHP/Rust PR history to `capture-pr.ts --sha` against (only direct "scenario/*" commits, never opened as PRs — confirmed via `gh api .../commits/<sha>/pulls` → `[]`). Opened and merged #1003 (`test(review-testbed): tighten PricingService and Config guards`) specifically to create one, mirroring #981's precedent. Lien Review itself caught a real bug in my first draft (returning a negative total unchanged violated `applyDiscount`'s own "never goes below zero" doc contract) — fixed before merge, re-captured against the corrected SHA (`77820895`).

## Gates

```
npm run format:check   ✓
npm run lint           ✓ 0 errors (37 pre-existing warnings, none in touched files)
npm run typecheck      ✓
npm run build          ✓
npm test                ✓ all test files pass (parser/core/cli/review/action — 226 files)
lien delta              ✓ exit 0 (no NEW-over-threshold or crossed function; see below)
```

`lien delta` shows several `worsened`/`new` entries but nothing crosses a threshold — the biggest new function (`collectImportOnlyFileKeys`, cognitive 14) was refactored down from an initial 17 specifically to stay clear of the 15 threshold. `resolveImportPath` (cognitive 14) is fully removed; `resolveChunkImports` improved 13→5.

Added 5 new unit tests to `dependency-graph.test.ts` (import-only recovery, no-fabrication guard, per-file dedup, C# same-directory exclusion, C# type-reference-fallback wiring) plus `provenance` assertions on 5 existing tests covering each tier. 28/28 pass.

## Harness evidence (byte-identical census, no `--calibrate`)

`build-prompts.ts` always passes `blastRadius: null` — prompt assembly deliberately does not include blast-radius output, so it cannot exercise this PR's change surface. Ran it anyway, before/after, on the 3 tracked (non-gitignored) fixtures to confirm **zero unintended effect on prompt assembly**:

```
sha256 before == after, all 3:
0c94b54734e4c37fdeea386d023948476e9e7273cc44631dcf176f63a40fee65  doc-truth/accurate-doc.fixture.json
5cf9d29cf625b0cd8b0303e0ac9d4a3d414a83c3368ceb588f9db39dd202d781  doc-truth/renamed-stale-claim.fixture.json
17c007762d9fea46bfa404206bcbfabebe8c2fd4139794361f66b19f688d2191  boundary-change/placeholder.fixture.json
```
byte-identical, 3/3 — via `npm run test:harness:build-prompts -w @liendev/review`. The real evidence for the actual change (blast-radius computation) is the deterministic `.blast-radius.ts` checkers above, which directly exercise `computeBlastRadius`/`buildDependencyGraph` with zero LLM spend.

## Design decisions / pushback

- **Did not literally call `findDependents` per BFS node** — measured 25ms/call cost, would scale with corpus size and hit the live tool. Routed the guards through instead (see "Course correction").
- **Did not extend the same-namespace fallback to be call-site-free.** PHP's `OrderService`/`CheckoutService` reference `PricingService` implicitly (same namespace, no `use` statement, no matching call site) and remain an unrecovered, documented gap — see the PHP fixture's module doc. A same-directory match with zero call-site OR import evidence at all would be a materially weaker signal than the import-only fallback (which requires a *verified* import statement); adding it risked reintroducing a false-hub class of bug this whole phase exists to remove. Flagged as a known limitation, not silently claimed as fixed.
- **`review`/`action` are private/unpublished** — no changeset (no `packages/parser`/`core`/`cli` changes in this PR).

Reference: issue #994, Phase 5.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 7 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 1 high-risk file(s) with 1 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 7 | +10 |


> [!NOTE]
> **Low Risk**
>
> This PR refactors review's dependency-graph edge resolution to route through @liendev/parser's guarded `importMatchesTarget` primitives, deletes the old JS/TS-only `resolveImportPath`, adds a provenance tag to every `CallerEdge`/`BlastRadiusDependent`, and introduces import-only and C# type-reference fallbacks. The changes are well-scoped and internally consistent: the new `provenance` field threads correctly through `blast-radius.ts`, `blast-radius-render.ts`, and the `get_dependents` agent tool; `buildDependencyGraph`'s new optional `workspaceRoot` parameter is supplied by both production call sites; and the fallback ordering (direct call-site edges → import-only edges → C# fallback → empty) is sound. The only surviving references to the removed `resolveImportPath` are historical comments in test files, not live code usages, so there is no breaking change.
>
> - Replaced review's hardcoded relative-import resolver with parser's multi-language `importMatchesTarget` guards.
> - Added `EdgeProvenance` tiers and surfaced them as a Confidence column in blast-radius output and `get_dependents` JSON.
> - Added import-only fallback to recover class/type seeds with verified imports but no literal call sites.
> - Fixed C# same-directory gating bug and wired in parser's `findCSharpTypeReferenceDependents` fallback.

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 3457830. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 674K/805K tokens
<!-- /lien:attestation -->