### PR TITLE
fix(review): carry traced symbol through barrel so blast-radius BFS doesn't dead-end (#1011 regression)

### DIFF
--- a/packages/review/src/dependency-graph.ts
+++ b/packages/review/src/dependency-graph.ts
@@ -16,6 +16,22 @@
  * genuinely different abstraction from parser's file-level `findDependents`)
  * — see the module doc on `resolveCallSiteEdges` for why the two were not
  * unified into one call.
+ *
+ * Post-#1011 regression fix: a pure re-export barrel (a file with no chunk
+ * of its own carrying a real symbol name — see `NO_REPRESENTATIVE_SYMBOL`)
+ * used to dead-end the BFS. `buildRepresentativeEdge` keyed the barrel's
+ * *display* identity ('(module-level)') as the frontier node too, so
+ * `getCallers(barrel, '(module-level)')` was queried next — a key nothing
+ * is ever indexed under, since no call site literally names that sentinel.
+ * The real dependents reachable only through the barrel (e.g. every
+ * language extractor importing `calculateComplexity` from
+ * `ast/complexity/index.ts` rather than `cyclomatic.ts` directly) silently
+ * vanished at hop 2. Fixed by carrying the *traced* symbol forward as
+ * `CallerEdge.frontierSymbol`, used only to decide the next frontier node —
+ * the barrel's caller identity shown to a consumer stays '(module-level)'
+ * (it is never credited as if it called anything; that false-attribution
+ * shape is exactly what #1011 removed and must not come back), but the walk
+ * now continues via the symbol actually being traced, not the placeholder.
  */
 
 import type { CodeChunk } from '@liendev/parser';
@@ -83,6 +99,19 @@ export interface CallerEdge {
   callSiteLine: number;
   /** How this edge was resolved — see `EdgeProvenance`'s doc comment. */
   provenance: EdgeProvenance;
+  /**
+   * The symbol to use in place of `caller.symbolName` when this edge's
+   * `caller` becomes the next BFS frontier node. Only set by
+   * `buildRepresentativeEdge` when the target file has no chunk of its own
+   * carrying a real symbol name (`caller.symbolName === NO_REPRESENTATIVE_SYMBOL`
+   * — a pure re-export barrel or similar pass-through file). `caller.symbolName`
+   * stays the honest *display* identity ('(module-level)': this file doesn't
+   * call anything); `frontierSymbol` is purely a traversal hint so
+   * `bfsTransitiveCallers` keeps expanding via the symbol actually being
+   * traced through the barrel instead of a placeholder nothing is indexed
+   * under. See the module doc's "Post-#1011 regression fix" note.
+   */
+  frontierSymbol?: string;
 }
 
 export interface TransitiveCallerEdge extends CallerEdge {
@@ -175,7 +204,7 @@ export function buildDependencyGraph(chunks: CodeChunk[], workspaceRoot = ''): D
   const chunkImportMaps = resolveChunkImports(chunks, exportIndex, normalize);
   const callerEdges = buildCallerEdges(chunks, chunkImportMaps, exportIndex);
   const importOnlyEdges = buildImportOnlyEdges(chunkImportMaps, callerEdges, chunksByFile);
-  const csharpFallbackCache = new Map<string, CallerEdge[] | undefined>();
+  const csharpDependentFilesCache = new Map<string, string[] | null>();
 
   const getCallers = (filepath: string, symbolName: string): CallerEdge[] => {
     const key = `${filepath}::${symbolName}`;
@@ -185,7 +214,15 @@ export function buildDependencyGraph(chunks: CodeChunk[], workspaceRoot = ''): D
     const importOnly = importOnlyEdges.get(key);
     if (importOnly && importOnly.length > 0) return importOnly;
 
-    return resolveCSharpFallback(filepath, chunks, chunksByFile, csharpFallbackCache) ?? [];
+    return (
+      resolveCSharpFallback(
+        filepath,
+        symbolName,
+        chunks,
+        chunksByFile,
+        csharpDependentFilesCache,
+      ) ?? []
+    );
   };
 
   return {
@@ -222,8 +259,20 @@ function callerGraphNodeKey(node: CallerGraphNode): string {
   return `${node.filepath}::${node.symbolName}`;
 }
 
+/**
+ * The frontier identity an edge's caller continues the walk as — the traced
+ * symbol for a barrel/representative edge (`frontierSymbol`), otherwise the
+ * caller's own real symbol name. Shared by `callerEdgeKey` and the
+ * `getNextNode` mapper below so both stay in the same key format, per
+ * `walkBounded`'s contract (`getEdgeKey(edge)` must equal
+ * `getNodeKey(getNextNode(edge))`).
+ */
+function callerFrontierSymbol(edge: CallerEdge): string {
+  return edge.frontierSymbol ?? edge.caller.symbolName;
+}
+
 function callerEdgeKey(edge: CallerEdge): string {
-  return `${edge.caller.filepath}::${edge.caller.symbolName}`;
+  return `${edge.caller.filepath}::${callerFrontierSymbol(edge)}`;
 }
 
 function bfsTransitiveCallers(
@@ -238,7 +287,7 @@ function bfsTransitiveCallers(
   const { results, truncated, visitedCount } = walkBounded<CallerGraphNode, CallerEdge>(
     { filepath, symbolName },
     node => getCallers(node.filepath, node.symbolName),
-    edge => ({ filepath: edge.caller.filepath, symbolName: edge.caller.symbolName }),
+    edge => ({ filepath: edge.caller.filepath, symbolName: callerFrontierSymbol(edge) }),
     callerEdgeKey,
     callerGraphNodeKey,
     { depth, maxNodes },
@@ -703,23 +752,41 @@ const NO_REPRESENTATIVE_SYMBOL = '(module-level)';
  * type-reference recovery) — see `pickRepresentativeChunk`'s doc comment.
  * Shared by `buildImportOnlyEdges` and `resolveCSharpFallback` so the two
  * fallback tiers build their edges identically.
+ *
+ * `tracedSymbol` is the symbol whose callers are being looked for (e.g. the
+ * `sym` key in `buildImportOnlyEdges`, or the `symbolName` `getCallers` was
+ * called with, for the C# fallback). When `file` has no representative
+ * chunk of its own — a pure re-export barrel, `NO_REPRESENTATIVE_SYMBOL` —
+ * there is no real "caller symbol" to continue the walk with, so the edge's
+ * `frontierSymbol` carries `tracedSymbol` forward instead, letting
+ * `bfsTransitiveCallers` keep expanding through the barrel. See the module
+ * doc's "Post-#1011 regression fix" note.
  */
 function buildRepresentativeEdge(
   file: string,
   chunksByFile: Map<string, CodeChunk[]>,
   provenance: EdgeProvenance,
+  tracedSymbol: string,
 ): CallerEdge {
   const fileChunks = chunksByFile.get(file) ?? [];
   const representative = pickRepresentativeChunk(fileChunks);
+  const symbolName = representative?.metadata.symbolName ?? NO_REPRESENTATIVE_SYMBOL;
   return {
     caller: {
       filepath: file,
-      symbolName: representative?.metadata.symbolName ?? NO_REPRESENTATIVE_SYMBOL,
+      symbolName,
       chunk: representative ?? (fileChunks[0] as CodeChunk),
     },
     callSiteLine: representative?.metadata.startLine ?? 0,
     provenance,
+    frontierSymbol: symbolName === NO_REPRESENTATIVE_SYMBOL ? tracedSymbol : undefined,
   };
+}
+
+/** One `file::symbol` key's import-only bucket: the traced symbol plus the importing files. */
+interface ImportOnlyBucket {
+  symbol: string;
+  importingFiles: Set<string>;
 }
 
 /**
@@ -727,13 +794,16 @@ function buildRepresentativeEdge(
  * edge, the set of files that verifiably import that symbol — deduped per
  * file (the SAME chunk's `importedSymbols` is duplicated across every chunk
  * in its file, see `pickRepresentativeChunk`'s doc comment, so without
- * dedup a 20-method class would produce 20 candidate "files").
+ * dedup a 20-method class would produce 20 candidate "files"). Keeps `sym`
+ * alongside the files so `buildImportOnlyEdges` can pass it to
+ * `buildRepresentativeEdge` as the traced symbol (needed for the barrel
+ * frontier fix — see the module doc's "Post-#1011 regression fix" note).
  */
 function collectImportOnlyFileKeys(
   chunkImportMaps: Map<CodeChunk, ChunkImportMap>,
   callerEdges: Map<string, CallerEdge[]>,
-): Map<string, Set<string>> {
-  const filesByKey = new Map<string, Set<string>>();
+): Map<string, ImportOnlyBucket> {
+  const buckets = new Map<string, ImportOnlyBucket>();
 
   for (const [chunk, importMap] of chunkImportMaps) {
     const callerFile = chunk.metadata.file;
@@ -742,14 +812,14 @@ function collectImportOnlyFileKeys(
         if (loc.filepath === callerFile) continue;
         const key = `${loc.filepath}::${sym}`;
         if (callerEdges.has(key)) continue; // a real call-site edge already covers this key
-        const files = filesByKey.get(key) ?? new Set<string>();
-        files.add(callerFile);
-        filesByKey.set(key, files);
+        const bucket = buckets.get(key) ?? { symbol: sym, importingFiles: new Set<string>() };
+        bucket.importingFiles.add(callerFile);
+        buckets.set(key, bucket);
       }
     }
   }
 
-  return filesByKey;
+  return buckets;
 }
 
 /**
@@ -764,12 +834,12 @@ function buildImportOnlyEdges(
   callerEdges: Map<string, CallerEdge[]>,
   chunksByFile: Map<string, CodeChunk[]>,
 ): Map<string, CallerEdge[]> {
-  const filesByKey = collectImportOnlyFileKeys(chunkImportMaps, callerEdges);
+  const buckets = collectImportOnlyFileKeys(chunkImportMaps, callerEdges);
 
   const result = new Map<string, CallerEdge[]>();
-  for (const [key, files] of filesByKey) {
-    const edges = [...files].map(file =>
-      buildRepresentativeEdge(file, chunksByFile, 'import-only'),
+  for (const [key, bucket] of buckets) {
+    const edges = [...bucket.importingFiles].map(file =>
+      buildRepresentativeEdge(file, chunksByFile, 'import-only', bucket.symbol),
     );
     result.set(key, edges);
   }
@@ -784,33 +854,52 @@ function buildImportOnlyEdges(
 // parser primitive has no per-call-site detail), memoized per target file
 // since a review pass can query the same C# file's declared type more than
 // once (e.g. multiple seeds in the same file, or repeated BFS visits).
+//
+// The expensive part (`findCSharpTypeReferenceDependents`) is cached purely
+// per `filepath` — it's file-level and ignores `symbolName` — but the
+// `CallerEdge[]` returned to `getCallers` is rebuilt per call (cheap: a
+// `.map()` over an already-small dependent-file list) so `frontierSymbol`
+// can carry whichever `symbolName` THIS query traced, matching the barrel
+// frontier fix in `buildRepresentativeEdge` (see the module doc's
+// "Post-#1011 regression fix" note). Caching the built edges themselves, as
+// before, would freeze `frontierSymbol` to whichever symbol first missed
+// the cache for a given file.
 // ---------------------------------------------------------------------------
 
-function resolveCSharpFallback(
+/** Cached, file-level (`symbolName`-independent) part of the C# fallback — `null` means "not applicable". */
+function getCSharpDependentFiles(
   filepath: string,
   allChunks: CodeChunk[],
   chunksByFile: Map<string, CodeChunk[]>,
-  cache: Map<string, CallerEdge[] | undefined>,
-): CallerEdge[] | undefined {
-  if (cache.has(filepath)) return cache.get(filepath);
+  cache: Map<string, string[] | null>,
+): string[] | null {
+  const cached = cache.get(filepath);
+  if (cached !== undefined) return cached;
 
   const fileChunks = chunksByFile.get(filepath);
   const language = fileChunks?.[0]?.metadata.language;
   if (language !== 'csharp' || detectLanguage(filepath) !== 'csharp') {
-    cache.set(filepath, undefined);
-    return undefined;
+    cache.set(filepath, null);
+    return null;
   }
 
   const dependentFiles = findCSharpTypeReferenceDependents(filepath, allChunks);
-  if (dependentFiles.length === 0) {
-    cache.set(filepath, undefined);
-    return undefined;
-  }
+  const result = dependentFiles.length > 0 ? dependentFiles : null;
+  cache.set(filepath, result);
+  return result;
+}
 
-  const edges: CallerEdge[] = dependentFiles.map(file =>
-    buildRepresentativeEdge(file, chunksByFile, 'namespace-inferred'),
+function resolveCSharpFallback(
+  filepath: string,
+  symbolName: string,
+  allChunks: CodeChunk[],
+  chunksByFile: Map<string, CodeChunk[]>,
+  cache: Map<string, string[] | null>,
+): CallerEdge[] | undefined {
+  const dependentFiles = getCSharpDependentFiles(filepath, allChunks, chunksByFile, cache);
+  if (!dependentFiles) return undefined;
+
+  return dependentFiles.map(file =>
+    buildRepresentativeEdge(file, chunksByFile, 'namespace-inferred', symbolName),
   );
-
-  cache.set(filepath, edges);
-  return edges;
 }

--- a/packages/review/test/dependency-graph.test.ts
+++ b/packages/review/test/dependency-graph.test.ts
@@ -1029,3 +1029,167 @@ describe('buildDependencyGraph — C# namespace gating fix', () => {
     expect(callers[0].provenance).toBe('namespace-inferred');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Barrel transitive-walk regression (post-#1011) — a pure re-export barrel
+// (no chunk of its own carries a real symbol name) used to dead-end
+// `getCallersTransitive`: the frontier re-queried
+// `getCallers(barrel, '(module-level)')`, a key nothing is ever indexed
+// under, so every real consumer reachable only through the barrel silently
+// vanished at hop 2. Fails on the pre-fix `dependency-graph.ts` (confirmed:
+// reverting the `frontierSymbol` plumbing reproduces a truncated 1-caller
+// walk that never reaches `consumerChunk`).
+// ---------------------------------------------------------------------------
+
+describe('buildDependencyGraph — barrel transitive-walk regression (post-#1011)', () => {
+  it('reaches a real consumer through a pure re-export barrel via getCallersTransitive', () => {
+    const implChunk = createTestChunk({
+      metadata: {
+        file: 'src/impl.ts',
+        startLine: 1,
+        endLine: 5,
+        type: 'function',
+        symbolName: 'doWork',
+        symbolType: 'function',
+        language: 'typescript',
+        exports: ['doWork'],
+      },
+    });
+
+    // A pure re-export barrel: no chunk of its own carries a real symbol
+    // name, so `pickRepresentativeChunk` returns undefined and the caller
+    // identity is the `NO_REPRESENTATIVE_SYMBOL` sentinel — exactly the
+    // shape that dead-ended the BFS pre-fix.
+    const barrelChunk = createTestChunk({
+      content: "export { doWork } from './impl.js';",
+      metadata: {
+        file: 'src/index.ts',
+        startLine: 1,
+        endLine: 1,
+        type: 'block',
+        symbolName: undefined,
+        symbolType: undefined,
+        language: 'typescript',
+        exports: ['doWork'],
+        importedSymbols: { './impl.js': ['doWork'] },
+      },
+    });
+
+    const consumerChunk = createTestChunk({
+      content: "import { doWork } from './index.js';\nfunction run() { doWork(); }",
+      metadata: {
+        file: 'src/consumer.ts',
+        startLine: 1,
+        endLine: 5,
+        type: 'function',
+        symbolName: 'run',
+        symbolType: 'function',
+        language: 'typescript',
+        exports: ['run'],
+        importedSymbols: { './index.js': ['doWork'] },
+        callSites: [{ symbol: 'doWork', line: 2 }],
+      },
+    });
+
+    const graph = buildDependencyGraph([implChunk, barrelChunk, consumerChunk]);
+
+    // Direct getCallers on the impl file: only the barrel's import-only
+    // pass-through edge (no one calls impl.ts's doWork directly).
+    const direct = graph.getCallers('src/impl.ts', 'doWork');
+    expect(direct).toHaveLength(1);
+    expect(direct[0].caller.filepath).toBe('src/index.ts');
+    expect(direct[0].caller.symbolName).toBe('(module-level)');
+    expect(direct[0].provenance).toBe('import-only');
+
+    // The transitive walk must continue THROUGH the barrel and reach the
+    // real consumer at hop 2 — this is exactly what #1011 broke: the BFS
+    // frontier re-queried getCallers(barrel, '(module-level)'), a key
+    // nothing is indexed under, and dead-ended instead of continuing via
+    // 'doWork'.
+    const transitive = graph.getCallersTransitive('src/impl.ts', 'doWork', { depth: 2 });
+    expect(transitive.truncated).toBe(false);
+    const consumerEdge = transitive.callers.find(c => c.caller.filepath === 'src/consumer.ts');
+    expect(consumerEdge).toBeDefined();
+    expect(consumerEdge?.hops).toBe(2);
+    expect(consumerEdge?.caller.symbolName).toBe('run');
+    expect(consumerEdge?.provenance).toBe('import-verified');
+
+    // The barrel itself must NOT be credited as if it calls doWork — its
+    // display identity stays the honest '(module-level)' placeholder (the
+    // false-attribution shape #1011 removed must not come back).
+    const barrelEdge = transitive.callers.find(c => c.caller.filepath === 'src/index.ts');
+    expect(barrelEdge?.caller.symbolName).toBe('(module-level)');
+  });
+
+  it('does not infinite-loop when a consumer is reached through a chain of two barrels (cycle-adjacent guard)', () => {
+    const implChunk = createTestChunk({
+      metadata: {
+        file: 'src/real.ts',
+        startLine: 1,
+        endLine: 5,
+        type: 'function',
+        symbolName: 'compute',
+        symbolType: 'function',
+        language: 'typescript',
+        exports: ['compute'],
+      },
+    });
+
+    const barrelBChunk = createTestChunk({
+      content: "export { compute } from './real.js';",
+      metadata: {
+        file: 'src/barrel-b.ts',
+        startLine: 1,
+        endLine: 1,
+        type: 'block',
+        symbolName: undefined,
+        symbolType: undefined,
+        language: 'typescript',
+        exports: ['compute'],
+        importedSymbols: { './real.js': ['compute'] },
+      },
+    });
+
+    const barrelAChunk = createTestChunk({
+      content: "export { compute } from './barrel-b.js';",
+      metadata: {
+        file: 'src/barrel-a.ts',
+        startLine: 1,
+        endLine: 1,
+        type: 'block',
+        symbolName: undefined,
+        symbolType: undefined,
+        language: 'typescript',
+        exports: ['compute'],
+        importedSymbols: { './barrel-b.js': ['compute'] },
+      },
+    });
+
+    const consumerChunk = createTestChunk({
+      content: "import { compute } from './barrel-a.js';\nfunction run() { compute(); }",
+      metadata: {
+        file: 'src/consumer.ts',
+        startLine: 1,
+        endLine: 5,
+        type: 'function',
+        symbolName: 'run',
+        symbolType: 'function',
+        language: 'typescript',
+        exports: ['run'],
+        importedSymbols: { './barrel-a.js': ['compute'] },
+        callSites: [{ symbol: 'compute', line: 2 }],
+      },
+    });
+
+    const graph = buildDependencyGraph([implChunk, barrelBChunk, barrelAChunk, consumerChunk]);
+    const transitive = graph.getCallersTransitive('src/real.ts', 'compute', {
+      depth: 3,
+      maxNodes: 30,
+    });
+
+    expect(transitive.truncated).toBe(false);
+    const consumerEdge = transitive.callers.find(c => c.caller.filepath === 'src/consumer.ts');
+    expect(consumerEdge).toBeDefined();
+    expect(consumerEdge?.hops).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #1011 (issue #994 Phase 5): blast-radius transitive traversal dead-ended at any pure re-export barrel, silently dropping every real dependent reachable only through it.

- **#1011 stays correct** — its false-attribution fix (a barrel no longer wrongly credited as the *caller* of a symbol it merely re-exports) is untouched and re-verified below.
- **This PR fixes the regression it introduced**: the BFS frontier re-queried `getCallers(barrel, '(module-level)')` — a key nothing is ever indexed under — instead of continuing via the symbol actually being traced through the barrel.

## Root cause

`buildRepresentativeEdge` gives a pure re-export barrel (no chunk of its own carries a real symbol name) a synthetic caller identity, the `'(module-level)'` sentinel (`NO_REPRESENTATIVE_SYMBOL`). That's the right *display* identity (the barrel doesn't call anything). But `bfsTransitiveCallers` also used it as the **next frontier query key**, and nothing is ever indexed under `file::(module-level)` — so the walk dead-ended one hop past any barrel, at any depth.

## Fix

Added `CallerEdge.frontierSymbol`: the symbol to use *only* when deciding the BFS's next frontier node, set exclusively when the caller has no real symbol of its own. `caller.symbolName` keeps showing `'(module-level)'` (never credited as if it called anything — the exact shape #1011 removed), but the walk now continues via the traced symbol, reaching real consumers on the far side of the barrel. Applied uniformly to both fallback tiers that build representative edges (`buildImportOnlyEdges` and the C# `findCSharpTypeReferenceDependents` fallback — the latter's cache was narrowed to the file-level dependent list only, so `frontierSymbol` can vary per query instead of freezing to whichever symbol first missed cache for that file).

`bfsTransitiveCallers`/`walkBounded` itself is unchanged (per the module doc's own constraint) — only what the frontier is keyed on changed.

## Verification (dogfooded against this repo's real source, not just unit tests)

**1. The exact reported repro, before/after**, via the real `computeBlastRadius` + `renderBlastRadiusMarkdown` (the same functions `plugins/agent/system-prompt.ts` calls in production) against `packages/parser/src`, seeded on `cyclomatic.ts::calculateComplexity`:

| | Before (main, with #1011) | After (this PR) |
|---|---|---|
| `getCallers(cyclomatic.ts, calculateComplexity)` | 1 edge → `index.ts#(module-level)` [import-only] | unchanged (this call is untouched) |
| `getCallersTransitive(depth=2)` | **1 caller** (dead end) | **17 callers** (barrel row + 16 real, `import-verified`) |
| `computeBlastRadius` | 2 dependents / risk **low-medium-ish** (dead BFS) | **17 dependents / MEDIUM** |

Rendered `<blast_radius>` after the fix:
```
Global risk: MEDIUM — 17 distinct dependents (17 callers, max complexity 3).
| ast/complexity/cyclomatic.ts:calculateComplexity | 1 | ast/complexity/index.ts:(module-level) | ✓ | — | inferred |
| ast/complexity/cyclomatic.ts:calculateComplexity | 2 | ast/languages/csharp.ts:extractMethodInfo | ✓ | 2 | verified |
... (14 more real, import-verified consumers: rust/ruby/python/php/kotlin/javascript/java/go/csharp)
```

**Important nuance on "27/HIGH"**: I checked out the pre-#1011 commit (`056d0cf5~1`) and ran the identical repro. Pre-#1011 reports **26** dependents (not counting the barrel row) at "depth=2" and risk HIGH — but it reaches those 26 *without ever showing the barrel as a hop*, because the same broad "cross-package symbol match" mechanism #1011 correctly removed elsewhere *also* collapsed `cyclomatic.ts` and `index.ts` into one hop by accident (parser normalizes relative specifiers like `'../complexity/index.js'` to a repo-relative form with no leading `.`, which `buildPackageImportedSymbols`'s naive `startsWith('.')` check then treated as a "package" import — the exact imprecision #1011 fixed). That accident let a nominal depth=2 walk reach what is, in the correct topology, **hop 3** (10 dispatcher functions like `extractSymbol` that call the hop-2 extractors) for free.

I confirmed this directly: running this PR's fixed code at **depth=3** reproduces **all 27 nodes** (1 barrel + 16 real hop-2 consumers + 10 hop-3 dispatchers) — an exact match to pre-#1011's 26 real callers, plus the one honest barrel row. So no coverage is lost; the default-depth count (17/MEDIUM) is the *correct* accounting for a 2-hop walk through the real topology, not a shortfall. Reproducing "27/HIGH" at the *default* depth would require reintroducing the exact false-attribution mechanism #1011 removed, which I did not do. Flagging this explicitly per the instruction to say so with evidence rather than silently chasing a number.

**2. Census re-swept** (barrel-only direct edge that should now recover a real dependent via the transitive walk):
- `packages/review/src`: **9/9 recover** — `analysis.ts::runComplexityAnalysis`, `analysis.ts::enrichWithTestAssociations`, `delta.ts::calculateDeltas`, `delta.ts::calculateDeltaSummary`, `github-api.ts::getPRChangedFiles`, `github-api.ts::removePRDescriptionSection`, plus `plugins/agent/index.ts::AgentReviewPlugin`, `plugins/agent/index.ts::hasIncompleteMainPass`, `plugins/complexity.ts::ComplexityPlugin`.
- `packages/parser/src`: **4/4 recover** — `ast/complexity/cyclomatic.ts::calculateComplexity`, `ast/complexity/cognitive.ts::calculateCognitiveComplexity`, `ast/complexity/halstead.ts::calculateHalstead`, `ast/native/compat-node.ts::buildCompatTree`.
- (30 other barrel-only keys in review/src and 16 in parser/src did *not* "recover" — correctly: those symbols genuinely have zero real consumers *within that package's own src/* tree (their only real consumers are in `test/` or other packages), which the transitive walk correctly can't manufacture.)

**3. #1011's resolve-rate gains re-measured, unaffected** — `getCallers` (the one-hop resolution #1011's PHP/Rust/Python numbers are measured against) is untouched by this diff; confirmed by diffing this PR's code against itself with the fix reverted:
- PHP: 8/11 = 72.7% (both before and after this PR — unchanged)
- Rust: 26/27 = 96.3% (unchanged)
- Python: 34/34 = 100% (unchanged)

**4. No false barrel attribution reintroduced** — swept `lien-review-testbed/typescript`'s `src/index.ts` barrel: 0 edges where `index.ts` is credited as caller with anything other than the honest `(module-level)`/`import-only` pass-through shape (10 honest pass-through rows, 0 false rows).

**5. Regression test added**: `packages/review/test/dependency-graph.test.ts` — a minimal barrel fixture (impl + pure re-export barrel + real consumer) asserting `getCallersTransitive` reaches the consumer at hop 2, plus a two-barrel-chain case. Confirmed both **fail on pre-fix `dependency-graph.ts`** (reverted just that file, kept the new tests) and pass after.

## Gates

```
npm run format:check   ✓
npm run lint            ✓ (0 errors; pre-existing warnings only)
npm run typecheck       ✓
npm run build           ✓
npm test                ✓ (parser-native/parser/core/review/cli/action all green, incl. 30/30 in dependency-graph.test.ts)
lien delta               ✓ exit 0 (no new-over-threshold or crossed functions)
```

`packages/review` is private/unpublished — no changeset (no `packages/parser` changes).

Refs #994, #1011.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency analysis through re-export barrel files.
  * Preserved accurate caller identities while continuing transitive dependency traversal.
  * Improved C# dependency discovery and query-specific results.
  * Prevented incomplete traversal and infinite loops across multiple re-export layers.

* **Tests**
  * Added coverage for direct, multi-hop, and multi-barrel dependency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes a regression from #1011 where blast-radius BFS traversal dead-ended at pure re-export barrels. The fix introduces `CallerEdge.frontierSymbol` as a traversal hint while preserving `(module-level)` as the display identity, then threads that hint through `callerEdgeKey`, the BFS next-node mapping, and both fallback edge builders (import-only and C# namespace-inferred). The C# cache was correctly narrowed to file-level dependent lists so `frontierSymbol` can vary per query. The change is additive and backward-compatible, and the new regression tests exercise both a single-barrel and a two-barrel chain.
>
> - Added optional `CallerEdge.frontierSymbol` to carry the traced symbol through barrels without falsely attributing the call to the barrel itself
> - Updated BFS key/next-node logic to use `callerFrontierSymbol`, satisfying `walkBounded`'s edge-key/node-key contract
> - Narrowed the C# fallback cache from built `CallerEdge[]` to raw dependent-file lists so `frontierSymbol` is per-query, not frozen to the first cached symbol
> - Added regression tests covering single-barrel and chained-barrel transitive walks

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit ed4bd17. Updates automatically on new commits.</sup>
<!-- /lien-stats -->