### PR TITLE
fix(parser): Cargo tests/benches/examples/src-bin are mod crate roots (#1016)

### DIFF
--- a/.changeset/rust-crate-root-mod-self-edge.md
+++ b/.changeset/rust-crate-root-mod-self-edge.md
@@ -1,0 +1,48 @@
+---
+"@liendev/parser": patch
+---
+
+Fix a regression from #1008: Cargo integration-test/bench/example/binary
+files fabricated a `mod` self-edge (#1016).
+
+#1008 taught `mod x;` to resolve to a directory-anchored sibling path, but
+`isRustModuleRootFile` only recognized `mod.rs`/`lib.rs`/`main.rs` as
+"module-root" files that own their own directory. Every other Cargo
+crate-root convention — `tests/*.rs` (each an independent integration-test
+binary), `benches/*.rs`, `examples/*.rs`, and `src/bin/*.rs` — fell through
+to the "leaf file owns a subdirectory named after itself" branch instead.
+So `tests/test_context.rs`'s `mod drop;` resolved to the phantom path
+`tests/test_context/drop`, which then fuzzy-matched back onto
+`tests/test_context.rs` itself at a path boundary, fabricating a
+self-edge — inflating that file's own dependent count and blast-radius
+risk with a dependency on itself.
+
+`isRustModuleRootFile` now also recognizes a `.rs` file directly under a
+top-level `tests/`, `benches/`, or `examples/` directory, and a `.rs` file
+directly under `src/bin/`, as owning its own directory the same way
+`lib.rs`/`main.rs` do. A file nested one level deeper (`tests/foo/bar.rs`)
+is unaffected — it's a module within that directory's own crate root, not
+a fresh crate root itself.
+
+Independently, `extractModImportPath` now rejects a resolved specifier
+that is *exactly* the declaring file's own (extensionless) path — a self-edge,
+which is never a real dependency regardless of which convention produced
+it. This is deliberately exact-equality, not fuzzy path-boundary matching:
+the ordinary leaf-file convention (`src/foo.rs`'s `mod bar;` -> `src/foo/bar`)
+always produces a specifier that is a superstring of the leaf file's own
+path at a boundary, which is correct, not a self-edge — a fuzzy guard would
+misfire on every leaf-file submodule. The guard is scoped to `mod`
+resolution only: a bare `use crate::x` path resolving back onto its own
+file is a distinct, pre-existing issue (fuzzy bare-word matching, not `mod`
+resolution) left untouched here.
+
+Verified on a fresh `dtolnay/anyhow` clone: the 5 fabricated self-edges
+(`tests/test_context.rs`, `tests/test_convert.rs`, `tests/test_downcast.rs`,
+`tests/test_macros.rs`, `tests/test_repr.rs`) are gone, and the real edge
+now appears (`tests/drop/mod.rs` gains `tests/test_context.rs` as a
+dependent, via its now-correctly-resolved `mod drop;`). The 3 pre-existing
+`use crate::`-based self-edges (`src/chain.rs`, `src/context.rs`,
+`src/error.rs`) are unaffected, as expected — they come from a different
+code path. `lib.rs`'s 11 top-level `mod` declarations still all produce
+edges, and `lien-review-testbed/rust`'s `reporter.rs`/`formatter.rs`/
+`parser.rs` dependents (#1008's original fix) are unchanged.

--- a/packages/parser/src/ast/languages/rust.test.ts
+++ b/packages/parser/src/ast/languages/rust.test.ts
@@ -629,6 +629,104 @@ pub static COUNTER: i32 = 0;`;
         ]);
       });
     });
+
+    describe('Cargo crate roots -- tests/benches/examples/src/bin (#1016)', () => {
+      // #1016 regression: tests/*.rs (and benches/*.rs, examples/*.rs,
+      // src/bin/*.rs) are each their OWN Cargo crate root, exactly like
+      // lib.rs/main.rs -- NOT a "leaf" file that owns a subdirectory named
+      // after itself. Before the fix, isRustModuleRootFile only recognized
+      // mod.rs/lib.rs/main.rs, so a mod_item declared inside one of these
+      // files fell through to the leaf rule and resolved into a phantom
+      // subdirectory sharing the file's own basename -- which then
+      // fuzzy-matched back onto the declaring file as a fabricated
+      // self-edge (dtolnay/anyhow's tests/test_context.rs, tests/test_convert.rs,
+      // tests/test_downcast.rs, tests/test_macros.rs, tests/test_repr.rs all
+      // hit this). None of these shapes existed in the pre-#1016 fixture set
+      // (mod.rs/lib.rs/main.rs and one flat leaf file only), so this suite
+      // could not express the bug at all until now.
+      it('resolves `mod x;` from a top-level tests/ file to a SIBLING within tests/, not a subdirectory named after the file', () => {
+        const code = 'mod drop;';
+        const root = mustParse(code, 'rust');
+        const modNode = root.namedChild(0)!;
+        expect(importExtractor.extractImportPath(modNode, undefined, 'tests/test_context.rs')).toBe(
+          'tests/drop',
+        );
+      });
+
+      it("never resolves to the importer's own path -- the exact #1016 self-edge shape", () => {
+        const code = 'mod drop;';
+        const root = mustParse(code, 'rust');
+        const modNode = root.namedChild(0)!;
+        const resolved = importExtractor.extractImportPath(
+          modNode,
+          undefined,
+          'tests/test_context.rs',
+        );
+        expect(resolved).not.toBeNull();
+        expect(resolved).not.toBe('tests/test_context');
+      });
+
+      it('treats a file directly under benches/ as a crate root the same way', () => {
+        const code = 'mod helper;';
+        const root = mustParse(code, 'rust');
+        const modNode = root.namedChild(0)!;
+        expect(importExtractor.extractImportPath(modNode, undefined, 'benches/my_bench.rs')).toBe(
+          'benches/helper',
+        );
+      });
+
+      it('treats a file directly under examples/ as a crate root the same way', () => {
+        const code = 'mod util;';
+        const root = mustParse(code, 'rust');
+        const modNode = root.namedChild(0)!;
+        expect(importExtractor.extractImportPath(modNode, undefined, 'examples/demo.rs')).toBe(
+          'examples/util',
+        );
+      });
+
+      it('treats a file directly under src/bin/ as an additional-binary crate root', () => {
+        const code = 'mod helper;';
+        const root = mustParse(code, 'rust');
+        const modNode = root.namedChild(0)!;
+        expect(importExtractor.extractImportPath(modNode, undefined, 'src/bin/mytool.rs')).toBe(
+          'src/bin/helper',
+        );
+      });
+
+      it('does NOT treat a NESTED file inside tests/ as a crate root -- only the top-level tests/*.rs files are', () => {
+        const code = 'mod baz;';
+        const root = mustParse(code, 'rust');
+        const modNode = root.namedChild(0)!;
+        // tests/foo/bar.rs is a module WITHIN whatever crate root owns
+        // tests/foo.rs (or tests/foo/main.rs), not a fresh crate root
+        // itself -- falls through to the ordinary LEAF rule.
+        expect(importExtractor.extractImportPath(modNode, undefined, 'tests/foo/bar.rs')).toBe(
+          'tests/foo/bar/baz',
+        );
+      });
+
+      it('self-edge guard rejects a #[path] override that points back at the declaring file itself', () => {
+        const code = '#[path = "test_context.rs"]\nmod whatever;';
+        const root = mustParse(code, 'rust');
+        const modNode = root.namedChildren.find(n => n.type === 'mod_item')!;
+        expect(
+          importExtractor.extractImportPath(modNode, undefined, 'tests/test_context.rs'),
+        ).toBeNull();
+      });
+
+      it("does not regress the ordinary leaf-file case: src/foo.rs's own submodule is a real sibling, not a self-edge (guard false-positive check)", () => {
+        const code = 'mod bar;';
+        const root = mustParse(code, 'rust');
+        const modNode = root.namedChild(0)!;
+        // src/foo/bar is a superstring of the importer's own stripped path
+        // (src/foo) at a path boundary -- a fuzzy self-edge guard would
+        // wrongly reject this ubiquitous, correct convention. Exact-path
+        // equality does not.
+        expect(importExtractor.extractImportPath(modNode, undefined, 'src/foo.rs')).toBe(
+          'src/foo/bar',
+        );
+      });
+    });
   });
 
   describe('Symbol Extraction', () => {

--- a/packages/parser/src/ast/languages/rust.ts
+++ b/packages/parser/src/ast/languages/rust.ts
@@ -183,15 +183,73 @@ export class RustExportExtractor implements LanguageExportExtractor {
 // =============================================================================
 
 /**
+ * Cargo directories whose DIRECT (non-nested) `.rs` children are themselves
+ * separate crate roots, exactly like `lib.rs`/`main.rs` — Cargo builds each
+ * `tests/foo.rs` as its own integration-test binary target (ditto
+ * `benches/*.rs` for benchmarks and `examples/*.rs` for examples; see the
+ * Cargo Book's "Package Layout"). A file nested one level deeper
+ * (`tests/foo/bar.rs`) is a module WITHIN that `tests/foo.rs` crate, not a
+ * fresh crate root itself, so this only matches when the file's OWN parent
+ * directory is literally named one of these three — not merely somewhere
+ * inside a `tests/`/`benches/`/`examples/` tree (#1016).
+ */
+const CARGO_TOP_LEVEL_CRATE_ROOT_DIRS = new Set(['tests', 'benches', 'examples']);
+
+/** Last path component (basename) of a directory path; `''` for the repo root. */
+function directoryBasename(dir: string): string {
+  return dir.slice(dir.lastIndexOf('/') + 1);
+}
+
+/**
+ * Whether `importerFile` is a `src/bin/*.rs` additional-binary crate root
+ * (Cargo Book "Package Layout": each file directly under `src/bin/` is its
+ * own binary target). `src/bin/name/main.rs` is a separate, already-covered
+ * shape — it matches the plain `main.rs` check in `isRustModuleRootFile` —
+ * so this only needs to add the single-file form.
+ */
+function isSrcBinCrateRootFile(importerFile: string): boolean {
+  const dir = dirnameOf(importerFile);
+  return directoryBasename(dir) === 'bin' && directoryBasename(dirnameOf(dir)) === 'src';
+}
+
+/**
+ * Whether `importerFile` is a Cargo crate root by virtue of its DIRECTORY
+ * (an integration test, benchmark, or example — see
+ * `CARGO_TOP_LEVEL_CRATE_ROOT_DIRS` — or an additional `src/bin/` binary),
+ * as opposed to `mod.rs`/`lib.rs`/`main.rs`'s basename-based crate-root
+ * shapes.
+ *
+ * Fixes the regression #1008 introduced (#1016): these files were
+ * previously misclassified as "leaf" files by `isRustModuleRootFile`, so a
+ * `mod x;` declared inside one resolved into a phantom subdirectory named
+ * after the file itself (e.g. `tests/test_context.rs`'s `mod drop;` ->
+ * `tests/test_context/drop`), which then fuzzy-matched back onto the
+ * declaring file as a fabricated self-edge instead of resolving to the real
+ * sibling module (`tests/drop.rs` / `tests/drop/mod.rs`).
+ */
+function isCargoDirectoryCrateRootFile(importerFile: string): boolean {
+  const dirName = directoryBasename(dirnameOf(importerFile));
+  return CARGO_TOP_LEVEL_CRATE_ROOT_DIRS.has(dirName) || isSrcBinCrateRootFile(importerFile);
+}
+
+/**
  * Whether `importerFile`'s basename identifies it as a Rust module-root file
- * (`mod.rs`, or the crate-root files `lib.rs`/`main.rs`) rather than a "leaf"
- * file. Rust's file-to-module convention gives these two shapes DIFFERENT
+ * (`mod.rs`, or the crate-root files `lib.rs`/`main.rs`) — or its directory
+ * identifies it as one of Cargo's other crate-root shapes (`tests/*.rs`,
+ * `benches/*.rs`, `examples/*.rs`, `src/bin/*.rs` — see
+ * `isCargoDirectoryCrateRootFile`, #1016) — rather than a "leaf" file. Rust's
+ * file-to-module convention gives these two shapes DIFFERENT
  * containing-directory semantics — see `resolveRustRelativeModulePath`'s doc
  * comment for why that distinction matters for `self::`/`super::`.
  */
 function isRustModuleRootFile(importerFile: string): boolean {
   const base = importerFile.slice(importerFile.lastIndexOf('/') + 1);
-  return base === 'mod.rs' || base === 'lib.rs' || base === 'main.rs';
+  return (
+    base === 'mod.rs' ||
+    base === 'lib.rs' ||
+    base === 'main.rs' ||
+    isCargoDirectoryCrateRootFile(importerFile)
+  );
 }
 
 /**
@@ -352,13 +410,68 @@ function extractModImportPath(node: SyntaxNode, importerFile?: string): string |
   const nameNode = node.childForFieldName('name');
   if (!nameNode) return null;
 
+  const normalizedImporter = importerFile.replace(/\\/g, '/');
   const pathOverride = findPathAttributeOverride(node);
-  if (pathOverride) {
-    const normalizedImporter = importerFile.replace(/\\/g, '/');
-    return joinFromDir(dirnameOf(normalizedImporter), pathOverride.replace(/\.rs$/, ''));
-  }
+  const resolved = pathOverride
+    ? joinFromDir(dirnameOf(normalizedImporter), pathOverride.replace(/\.rs$/, ''))
+    : joinFromDir(rustModOwningDirectory(importerFile, node), nameNode.text);
 
-  return joinFromDir(rustModOwningDirectory(importerFile, node), nameNode.text);
+  return isModSelfEdge(resolved, normalizedImporter) ? null : resolved;
+}
+
+/**
+ * Whether a `mod_item`'s resolved sibling-module specifier is EXACTLY its
+ * own declaring file — a self-edge, which is never a real dependency no
+ * matter which file-to-module convention produced it (#1016). Deliberately
+ * EXACT (extensionless string) equality, not `matchesFile`'s fuzzy boundary
+ * matching: Rust's ordinary "leaf file owns a namesake subdirectory"
+ * convention makes every leaf file's OWN submodule specifier a superstring
+ * of the leaf file's own path by design (`src/foo.rs`'s `mod bar;` ->
+ * `src/foo/bar`, which contains `src/foo` at a path boundary) — that's a
+ * real, different, already-correct sibling file, not a self-edge, so a
+ * fuzzy `matchesFile`-based guard here would misfire on that ubiquitous,
+ * correct case (confirmed by a test regression while building this fix).
+ * Exact equality has no such false positive: it only rejects a specifier
+ * that resolves back to the literal file that declared it, which can only
+ * happen via a `#[path = "..."]` override pointing at the declaring file
+ * itself, or a future regression in `rustModOwningDirectory`/
+ * `isRustModuleRootFile` that (re)introduces this shape — precisely the
+ * "next variant of this bug" this guard exists to catch, independent of the
+ * `isRustModuleRootFile` fix above (which corrects THIS specific #1016
+ * resolution bug; that bug's actual shape — a phantom subdirectory named
+ * after the importer — was never exact-equal to the importer's own path
+ * either, so this guard alone would not have masked #1016 without that
+ * fix, nor does it substitute for it).
+ *
+ * One known, narrow non-catch: a module-root file (`lib.rs`/`main.rs`/
+ * `mod.rs`/a Cargo crate root — see `isRustModuleRootFile`) declaring a
+ * submodule with the SAME basename as itself (e.g. `tests/foo.rs`
+ * containing `mod foo;`, meaning the sibling `tests/foo/mod.rs`) resolves
+ * to a specifier exactly equal to the importer's own stripped path and so
+ * IS suppressed by this guard, even though `tests/foo/mod.rs` can be a
+ * genuinely different, valid file. This is accepted rather than special-
+ * cased: the extensionless matching scheme downstream already collapses
+ * `tests/foo.rs` and `tests/foo/mod.rs` to the same specifier, so that edge
+ * was already ambiguous with a real self-match before this guard: dropping
+ * it errs toward not fabricating a self-edge rather than resolving the
+ * ambiguity in the specifier's favor.
+ *
+ * Deliberately scoped to `mod` resolution only — not `use` imports, and
+ * not other languages:
+ * - A bare `use crate::x` path resolving back onto its own declaring file
+ *   is a distinct, PRE-EXISTING issue (fuzzy bare-word matching in
+ *   `convertRustModulePath`/`matchesFile`, not `mod` resolution — see
+ *   #1016's `src/chain.rs`/`src/context.rs`/`src/error.rs` findings), left
+ *   untouched here rather than silently absorbed by a broader guard.
+ * - Other languages have legitimate same-file specifiers a blanket
+ *   cross-language guard would wrongly suppress — e.g. Node's package
+ *   self-reference feature, where a file inside a package legitimately
+ *   imports that package's own name and resolves back to itself.
+ * A Rust `mod x;` declaring itself has no such legitimate shape: it is
+ * always either a mistake or, as here, a resolution bug.
+ */
+function isModSelfEdge(resolvedSpecifier: string, importerFile: string): boolean {
+  return resolvedSpecifier === importerFile.replace(/\.rs$/, '');
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #1016 — a regression my own earlier PR #1008 introduced. `isRustModuleRootFile` only recognized `mod.rs`/`lib.rs`/`main.rs` as files that own their own directory for `mod x;` resolution. Cargo integration-test files (`tests/*.rs`, each its own crate root) — plus `benches/*.rs`, `examples/*.rs`, and `src/bin/*.rs` by the same convention — fell through to the "leaf file owns a subdirectory named after itself" rule. So `tests/test_context.rs`'s `mod drop;` resolved to the phantom path `tests/test_context/drop`, which then fuzzy-matched back onto `tests/test_context.rs` itself at a path boundary, fabricating a self-edge.

Two independent changes, as requested in the issue:

1. **`isRustModuleRootFile` now also recognizes Cargo's other crate-root shapes** — a `.rs` file directly under a top-level `tests/`, `benches/`, or `examples/` directory, or directly under `src/bin/`. A file nested one level deeper (`tests/foo/bar.rs`) is *not* a crate root — it's a module within whatever crate root owns that directory — so this only matches when the file's own parent directory is literally named one of those.
2. **An independent self-edge guard in `extractModImportPath`**: a `mod` resolution should never produce an edge back to its own declaring file. This is deliberately **exact-path equality**, not `matchesFile`'s fuzzy boundary matching — I initially tried the fuzzy version and it broke an existing, correct test: the ordinary leaf-file convention (`src/foo.rs`'s `mod bar;` → `src/foo/bar`) always makes the resolved specifier a superstring of the leaf file's own path at a boundary, which is *correct*, not a self-edge. Exact equality has no such false positive and still catches the only two ways a real self-edge can arise here: a `#[path = "..."]` override pointing at the declaring file itself, or a future regression in `rustModOwningDirectory`/`isRustModuleRootFile`.

The guard is scoped to `mod` resolution only — not `use` imports, and not other languages. Rationale in the code comment: a bare `use crate::x` path resolving back onto its own file is a distinct, **pre-existing** issue (fuzzy bare-word matching in `convertRustModulePath`/`matchesFile`, not `mod` resolution) — see the `src/chain.rs`/`src/context.rs`/`src/error.rs` findings below, deliberately left untouched. And other languages have legitimate same-file specifiers a blanket cross-language guard would wrongly suppress (e.g. Node's package self-reference feature).

## Verification

### 1. Fresh `dtolnay/anyhow` clone — full before/after dependent table (37 `.rs` files)

```
git clone --depth 1 --branch master https://github.com/dtolnay/anyhow.git
```

PRE = current `main` (post-#1008, has the bug) · POST = this fix, same corpus:

```
file                                PRE self?  POST self?  PRE deps  POST deps
--------------------------------------------------------------------------------
build.rs                            False      False       0         0
src/backtrace.rs                    False      False       2         2
src/chain.rs                        True       True        4         4
src/context.rs                      True       True        2         2
src/ensure.rs                       False      False       1         1
src/error.rs                        True       True        9         9
src/fmt.rs                          False      False       1         1
src/kind.rs                         False      False       1         1
src/lib.rs                          False      False       0         0
src/macros.rs                       False      False       1         1
src/nightly.rs                      False      False       4         4
src/ptr.rs                          False      False       3         3
src/wrapper.rs                      False      False       1         1
tests/common/mod.rs                 False      False       2         2
tests/compiletest.rs                False      False       0         0
tests/crate/test.rs                 False      False       0         0
tests/drop/mod.rs                   False      False       3         4          <-- CHANGED (real edge appears)
tests/test_autotrait.rs             False      False       0         0
tests/test_backtrace.rs             False      False       0         0
tests/test_boxed.rs                 False      False       0         0
tests/test_chain.rs                 False      False       0         0
tests/test_context.rs               True       False       1         0          <-- CHANGED (self-edge gone)
tests/test_convert.rs               True       False       1         0          <-- CHANGED (self-edge gone)
tests/test_downcast.rs              True       False       1         0          <-- CHANGED (self-edge gone)
tests/test_ensure.rs                False      False       0         0
tests/test_ffi.rs                   False      False       0         0
tests/test_fmt.rs                   False      False       0         0
tests/test_macros.rs                True       False       1         0          <-- CHANGED (self-edge gone)
tests/test_repr.rs                  True       False       1         0          <-- CHANGED (self-edge gone)
tests/test_source.rs                False      False       0         0
tests/ui/chained-comparison.rs      False      False       0         0
tests/ui/empty-ensure.rs            False      False       0         0
tests/ui/ensure-nonbool.rs          False      False       0         0
tests/ui/must-use.rs                False      False       0         0
tests/ui/no-impl.rs                 False      False       0         0
tests/ui/temporary-value.rs         False      False       0         0
tests/ui/wrong-interpolation.rs     False      False       0         0
```

Computed by chunking every `.rs` file with `@liendev/parser`'s real `chunkFile` + calling the real `findDependents` (the same primitives `get_dependents` uses), swapping `rust.ts` between the pre-fix (`git show HEAD:...`) and post-fix content and rebuilding in between, corpus held fixed.

**All 5 fabricated self-edges are gone** (`tests/test_context.rs`, `tests/test_convert.rs`, `tests/test_downcast.rs`, `tests/test_macros.rs`, `tests/test_repr.rs`), and it's not merely deletion: `tests/drop/mod.rs` gains a *new, real* dependent (`tests/test_context.rs`, 3→4), confirming `mod drop;` in that file now resolves to the correct sibling (`tests/drop` → matches `tests/drop/mod.rs`) rather than just having its wrong edge deleted. (`tests/common/mod.rs`'s dependents are unchanged, 2/2 — the two files that declare `mod common;` also have a `use self::common::*` that already resolved correctly before this fix, since `self::` resolution doesn't depend on `isRustModuleRootFile`; only their own `mod common;` edge changed, from self-referencing to the same already-counted target.)

Note: the anyhow repo currently has 37 `.rs` files by direct count; `lien index` (via `test:e2e:rust` below) reports "40 files" because it also indexes non-`.rs` files (`Cargo.toml`, `README.md`, etc.) — not a discrepancy, just two different counts.

### 2. Pre-existing self-edges — unaffected, as expected

`src/chain.rs` (4/4, self=true/true), `src/context.rs` (2/2, self=true/true), `src/error.rs` (9/9, self=true/true) are **byte-for-byte unchanged** before vs. after. These come from a `use crate::x` bare-word path fuzzy-matching back onto its own file (`convertRustModulePath`'s `crate::` branch has no directory anchor) — a distinct, older bug, not touched by this fix, as the issue asked.

### 3. #1008's gains held

- **`lien-review-testbed/rust`** (rebuilt parser, same measurement script):
  ```
  src/reporter.rs  | deps= ['src/main.rs']
  src/formatter.rs | deps= ['src/main.rs', 'src/reporter.rs']
  src/parser.rs    | deps= ['src/main.rs', 'src/analyzer.rs', 'src/reporter.rs']
  ```
  `reporter.rs` is exactly `['src/main.rs']`; `formatter.rs`/`parser.rs` both include `src/main.rs`. No self-edges anywhere in the testbed (all flat `src/*.rs`, unaffected by the crate-root fix).
- **anyhow `lib.rs`**: all 11 top-level `mod` declarations (`backtrace`, `chain`, `context`, `ensure`, `error`, `fmt`, `kind`, `macros`, `nightly`, `ptr`, `wrapper`) still produce edges (verified via `chunkFile` on `lib.rs` directly — all 11 `src/xxx` specifiers present); the inline `pub mod __private { ... }` still produces none.

### 4. Regression fixture — fails on `main`, passes with the fix

Added a `describe('Cargo crate roots -- tests/benches/examples/src/bin (#1016)', ...)` block to `packages/parser/src/ast/languages/rust.test.ts` (the existing fixture set — `mod.rs`/`lib.rs`/`main.rs` and one flat leaf file — structurally couldn't express a `tests/` crate-root shape at all). 8 new tests; confirmed 5 of them fail against the pre-fix code (`git show HEAD:...` swapped in temporarily, then restored) — exactly the ones exercising the bug:
- `mod drop;` from `tests/test_context.rs` resolving to a sibling, not a phantom subdir
- benches/examples/src-bin crate-root recognition (3 tests)
- the `#[path]`-override self-edge-guard test

The other 3 (nested-`tests/foo/bar.rs` non-regression, the leaf-file false-positive check, and the "never equals importer's own path" assertion) correctly pass in both states — they're invariant/non-regression checks, not bug-discriminating assertions.

### 5. Mandatory gates

```
npm run format:check   # pass
npm run lint           # pass, 0 errors (37 pre-existing warnings elsewhere, none touched)
npm run typecheck      # pass
npm run build          # pass
npm test               # pass — 0 FAIL across all 6 workspaces (parser/core/review/cli/action), incl. new tests (91/91 in rust.test.ts)
lien delta             # exit 0 (2 "worsened but still under threshold" notes on isRustModuleRootFile/extractModImportPath — no crossing)
npm run test:e2e:rust -w packages/cli   # pass, 14/14 (140 skipped, other languages) — live clone+index+reindex of dtolnay/anyhow
```

## Conflict note

Per instructions, stayed entirely within `packages/parser/src/ast/languages/rust.ts` + its test file + a changeset. Did not touch `packages/review/`.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR fixes a Rust parser regression where Cargo integration-test, benchmark, example, and additional-binary files were misclassified as leaf modules, causing fabricated self-edges. The fix adds directory-based crate-root recognition for `tests/`, `benches/`, `examples/`, and `src/bin/` plus an exact-equality self-edge guard in `mod` resolution. The changes are well-scoped to Rust `mod` resolution, thoroughly tested with 8 new regression tests covering both the bug and the adjacent unchanged cases, and the blast radius is limited to same-file callers.
>
> - isRustModuleRootFile now recognizes Cargo crate-root directory conventions (tests/benches/examples direct children and src/bin/*.rs)
> - extractModImportPath adds an exact-equality self-edge guard scoped to mod resolution only
> - Adds regression tests for the #1016 self-edge shape and the leaf-file false-positive case

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 20cca2b. Updates automatically on new commits.</sup>
<!-- /lien-stats -->