### PR TITLE
fix(parser): give mod-derived Rust import specifiers single-file semantics (#1021)

### DIFF
--- a/.changeset/rust-mod-single-file-semantics.md
+++ b/.changeset/rust-mod-single-file-semantics.md
@@ -1,0 +1,65 @@
+---
+"@liendev/parser": patch
+---
+
+Fix `mod dir;` fabricating dependency edges to every file under `dir/`,
+including files no `mod` statement declares, and fix a related fabricated
+self-edge shape #1016/#1020 didn't catch (#1021).
+
+Root cause: Rust doesn't set `LanguageDefinition.singleFileImports`, so a
+`mod`-derived specifier fell through to `matchesFile`'s Go-package-directory
+matching (`requireExactTailForMultiSegment: false`) — the same permissive
+rule that correctly lets Go's `import "internal/fs"` match every file inside
+that package. A Rust `mod x;` is not a package reference like that: it
+resolves to exactly one of `x.rs` or `x/mod.rs`, never a grandchild, an
+unrelated sibling, or the declaring file itself.
+
+That one mismatch produced two symptom families:
+1. **Fabricated descendant edges** — `mod thing;` in `src/main.rs` matched
+   every file under `src/thing/` (`src/thing/sibling.rs`,
+   `src/thing/undeclared.rs`, ...), not just the real `src/thing/mod.rs`.
+2. **Fabricated self-edges**, in a shape #1020's exact-equality self-edge
+   guard doesn't catch: a leaf file that owns a submodule subdirectory
+   (`src/engine.rs`'s `mod helpers;` -> `src/engine/helpers`) fuzzy-matched
+   back onto `src/engine.rs` itself, since `src/engine` is a boundary-prefix
+   of `src/engine/helpers`. #1020's guard is exact-string equality at
+   extraction time and this specifier is never exactly equal to the
+   importer's own path, so it passed through untouched; the self-edge was
+   created downstream, in matching.
+
+Fix: `mod`-derived specifiers (`extractModImportPath` in `rust.ts`) are now
+tagged with a reversible marker (`rust-mod-marker.ts`) and, when present,
+`importMatchesTarget` routes them through a dedicated `matchesRustModSpecifier`
+check — exact match, or the target being exactly the specifier plus `/mod`
+(the sole `x.rs`/`x/mod.rs` alternative Rust's file-to-module convention
+allows) — bypassing `matchesFile`'s generic boundary strategies entirely.
+`use crate::...`/`self::`/`super::` specifiers are unaffected: they're
+never marked, and keep resolving through the existing, unchanged logic
+(needed because a `use` path is crate-root-relative, missing its real
+`src/`-style prefix, and some `use` shapes carry a trailing symbol-name
+segment in the raw specifier — both rely on the same leniency this fix
+narrows for `mod` alone).
+
+Also fixed a second, related bug the first fixture's own repro surfaced:
+`mod x;`'s `processImportSymbols` used to report the wildcard marker
+`symbols: ['*']` — the same shape a genuine `use crate::models::*;`
+reports — so `findReExportedSymbolsForFile` treated a plain `pub mod
+sibling;` namespace declaration as if it flattened `sibling`'s exports into
+the declaring file, crediting every one of that file's own, unrelated `pub`
+exports as "re-exported from sibling" and fabricating transitive
+dependents through `mergeReExportTransitiveDependents`. A `mod` declaration
+doesn't flatten anything (`sibling::declared_fn` is never reachable as
+`mod::declared_fn`), so it now reports an empty symbols list instead.
+
+Verified: both fixtures added as regression tests (confirmed failing on
+main first). `lien-review-testbed/rust` and a fresh `dtolnay/anyhow` clone
+are both unaffected — anyhow's `mod` declarations are all single-file
+(no directory-module fan-out shape exists there), so its full
+before/after dependent table is byte-for-byte identical, including the
+pre-existing, unrelated `use`-based self-edges on `chain.rs`/`context.rs`/
+`error.rs` (#1016's documented non-catch, left untouched). On a fresh
+`serde-rs/serde` clone — which does have real multi-file directory modules
+(`serde_derive/src/internals/`) — `serde_derive/src/lib.rs` was fabricated
+as a dependent of 7 of the module's 9 submodule files before this fix, and
+is correctly removed after, while the real edge to `internals/mod.rs` is
+unchanged.

--- a/packages/parser/src/ast/languages/rust.test.ts
+++ b/packages/parser/src/ast/languages/rust.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { mustParse } from '../test/helpers/parse-fixture.js';
 import type { SyntaxNode } from '../types.js';
 import { chunkByAST } from '../chunker.js';
+import { markRustModSpecifier } from '../../utils/rust-mod-marker.js';
 import {
   RustTraverser,
   RustExportExtractor,
@@ -533,7 +534,7 @@ pub static COUNTER: i32 = 0;`;
         const root = mustParse(code, 'rust');
         const modNode = root.namedChild(0)!;
         expect(importExtractor.extractImportPath(modNode, undefined, 'src/main.rs')).toBe(
-          'src/reporter',
+          markRustModSpecifier('src/reporter'),
         );
       });
 
@@ -542,7 +543,7 @@ pub static COUNTER: i32 = 0;`;
         const root = mustParse(code, 'rust');
         const modNode = root.namedChild(0)!;
         expect(importExtractor.extractImportPath(modNode, undefined, 'src/main.rs')).toBe(
-          'src/reporter',
+          markRustModSpecifier('src/reporter'),
         );
       });
 
@@ -551,7 +552,7 @@ pub static COUNTER: i32 = 0;`;
         const root = mustParse(code, 'rust');
         const modNode = root.namedChild(0)!;
         expect(importExtractor.extractImportPath(modNode, undefined, 'src/foo.rs')).toBe(
-          'src/foo/bar',
+          markRustModSpecifier('src/foo/bar'),
         );
       });
 
@@ -562,7 +563,7 @@ pub static COUNTER: i32 = 0;`;
         const innerNode = outerNode.childForFieldName('body')!.namedChild(0)!;
         expect(innerNode.type).toBe('mod_item');
         expect(importExtractor.extractImportPath(innerNode, undefined, 'src/main.rs')).toBe(
-          'src/outer/inner',
+          markRustModSpecifier('src/outer/inner'),
         );
       });
 
@@ -585,7 +586,7 @@ pub static COUNTER: i32 = 0;`;
         const root = mustParse(code, 'rust');
         const modNode = root.namedChildren.find(n => n.type === 'mod_item')!;
         expect(importExtractor.extractImportPath(modNode, undefined, 'src/main.rs')).toBe(
-          'src/custom_path',
+          markRustModSpecifier('src/custom_path'),
         );
       });
 
@@ -593,24 +594,30 @@ pub static COUNTER: i32 = 0;`;
         const adjacent = mustParse('#[cfg(test)]\n#[path = "other.rs"]\nmod combo;', 'rust');
         const adjacentMod = adjacent.namedChildren.find(n => n.type === 'mod_item')!;
         expect(importExtractor.extractImportPath(adjacentMod, undefined, 'src/main.rs')).toBe(
-          'src/other',
+          markRustModSpecifier('src/other'),
         );
 
         const reversed = mustParse('#[path = "other.rs"]\n#[cfg(test)]\nmod combo;', 'rust');
         const reversedMod = reversed.namedChildren.find(n => n.type === 'mod_item')!;
         expect(importExtractor.extractImportPath(reversedMod, undefined, 'src/main.rs')).toBe(
-          'src/other',
+          markRustModSpecifier('src/other'),
         );
       });
 
-      it('processImportSymbols reports the whole-module wildcard, like a use_wildcard', () => {
+      it("processImportSymbols reports an empty symbols list -- NOT the use_wildcard `['*']` marker (#1021)", () => {
+        // A `mod x;` namespace declaration doesn't flatten its target's
+        // exports the way a genuine `use crate::x::*;` does -- reusing that
+        // wildcard marker here made `findReExportedSymbolsForFile` credit
+        // every one of the declaring file's OWN unrelated exports as
+        // "re-exported from" the named submodule. See the doc comment on
+        // this branch in rust.ts for the full incident.
         const code = 'mod reporter;';
         const root = mustParse(code, 'rust');
         const modNode = root.namedChild(0)!;
         const result = importExtractor.processImportSymbols(modNode, undefined, 'src/main.rs');
         expect(result).not.toBeNull();
-        expect(result!.importPath).toBe('src/reporter');
-        expect(result!.symbols).toEqual(['*']);
+        expect(result!.importPath).toBe(markRustModSpecifier('src/reporter'));
+        expect(result!.symbols).toEqual([]);
       });
 
       it('processImportSymbols returns null for an inline mod (no separate file to attribute symbols to)', () => {
@@ -625,7 +632,7 @@ pub static COUNTER: i32 = 0;`;
         const root = mustParse(code, 'rust');
         const modNode = root.namedChild(0)!;
         expect(importExtractor.extractImportPaths(modNode, undefined, 'src/main.rs')).toEqual([
-          'src/reporter',
+          markRustModSpecifier('src/reporter'),
         ]);
       });
     });
@@ -649,7 +656,7 @@ pub static COUNTER: i32 = 0;`;
         const root = mustParse(code, 'rust');
         const modNode = root.namedChild(0)!;
         expect(importExtractor.extractImportPath(modNode, undefined, 'tests/test_context.rs')).toBe(
-          'tests/drop',
+          markRustModSpecifier('tests/drop'),
         );
       });
 
@@ -664,6 +671,7 @@ pub static COUNTER: i32 = 0;`;
         );
         expect(resolved).not.toBeNull();
         expect(resolved).not.toBe('tests/test_context');
+        expect(resolved).not.toBe(markRustModSpecifier('tests/test_context'));
       });
 
       it('treats a file directly under benches/ as a crate root the same way', () => {
@@ -671,7 +679,7 @@ pub static COUNTER: i32 = 0;`;
         const root = mustParse(code, 'rust');
         const modNode = root.namedChild(0)!;
         expect(importExtractor.extractImportPath(modNode, undefined, 'benches/my_bench.rs')).toBe(
-          'benches/helper',
+          markRustModSpecifier('benches/helper'),
         );
       });
 
@@ -680,7 +688,7 @@ pub static COUNTER: i32 = 0;`;
         const root = mustParse(code, 'rust');
         const modNode = root.namedChild(0)!;
         expect(importExtractor.extractImportPath(modNode, undefined, 'examples/demo.rs')).toBe(
-          'examples/util',
+          markRustModSpecifier('examples/util'),
         );
       });
 
@@ -689,7 +697,7 @@ pub static COUNTER: i32 = 0;`;
         const root = mustParse(code, 'rust');
         const modNode = root.namedChild(0)!;
         expect(importExtractor.extractImportPath(modNode, undefined, 'src/bin/mytool.rs')).toBe(
-          'src/bin/helper',
+          markRustModSpecifier('src/bin/helper'),
         );
       });
 
@@ -701,7 +709,7 @@ pub static COUNTER: i32 = 0;`;
         // tests/foo.rs (or tests/foo/main.rs), not a fresh crate root
         // itself -- falls through to the ordinary LEAF rule.
         expect(importExtractor.extractImportPath(modNode, undefined, 'tests/foo/bar.rs')).toBe(
-          'tests/foo/bar/baz',
+          markRustModSpecifier('tests/foo/bar/baz'),
         );
       });
 
@@ -723,7 +731,7 @@ pub static COUNTER: i32 = 0;`;
         // wrongly reject this ubiquitous, correct convention. Exact-path
         // equality does not.
         expect(importExtractor.extractImportPath(modNode, undefined, 'src/foo.rs')).toBe(
-          'src/foo/bar',
+          markRustModSpecifier('src/foo/bar'),
         );
       });
     });
@@ -1044,7 +1052,7 @@ fn main() {
       const chunks = chunkByAST('src/main.rs', content);
       const funcChunk = chunks.find(c => c.metadata.symbolName === 'main');
       expect(funcChunk).toBeDefined();
-      expect(funcChunk?.metadata.imports).toContain('src/reporter');
+      expect(funcChunk?.metadata.imports).toContain(markRustModSpecifier('src/reporter'));
     });
 
     // An inline `mod tests { ... }` (e.g. `#[cfg(test)] mod tests`) has no

--- a/packages/parser/src/ast/languages/rust.ts
+++ b/packages/parser/src/ast/languages/rust.ts
@@ -16,6 +16,7 @@ import {
 } from '../extractors/symbol-helpers.js';
 import { calculateComplexity } from '../complexity/index.js';
 import { resolveRustCrateImport } from '../../rust-crate-map.js';
+import { markRustModSpecifier } from '../../utils/rust-mod-marker.js';
 
 // =============================================================================
 // TRAVERSER
@@ -403,6 +404,16 @@ function extractPathAttributeValue(attributeItem: SyntaxNode): string | null {
  *
  * Returns null for an inline module (has a body — no separate file, no
  * edge) or when there's no `importerFile` to resolve against.
+ *
+ * The returned specifier is tagged with `markRustModSpecifier` (#1021): a
+ * `mod x;` resolves to EXACTLY one of `x.rs` / `x/mod.rs`, never a
+ * grandchild, an unrelated sibling, or the declaring file itself, which
+ * `matchesFile`'s generic (Go-package-directory-shaped) boundary leniency
+ * doesn't know how to enforce — see `matchesRustModSpecifier` in
+ * `../../utils/path-matching.ts` for the dedicated, marker-gated matching
+ * rule this specifier gets instead, and `rust-mod-marker.ts` for why a
+ * string marker (rather than a `use`-wide language flag) is how that
+ * distinction survives from here to match time.
  */
 function extractModImportPath(node: SyntaxNode, importerFile?: string): string | null {
   if (isInlineModDeclaration(node) || !importerFile) return null;
@@ -416,7 +427,7 @@ function extractModImportPath(node: SyntaxNode, importerFile?: string): string |
     ? joinFromDir(dirnameOf(normalizedImporter), pathOverride.replace(/\.rs$/, ''))
     : joinFromDir(rustModOwningDirectory(importerFile, node), nameNode.text);
 
-  return isModSelfEdge(resolved, normalizedImporter) ? null : resolved;
+  return isModSelfEdge(resolved, normalizedImporter) ? null : markRustModSpecifier(resolved);
 }
 
 /**
@@ -469,6 +480,17 @@ function extractModImportPath(node: SyntaxNode, importerFile?: string): string |
  *   imports that package's own name and resolves back to itself.
  * A Rust `mod x;` declaring itself has no such legitimate shape: it is
  * always either a mistake or, as here, a resolution bug.
+ *
+ * Still needed after #1021's stricter downstream matching
+ * (`matchesRustModSpecifier`), not made redundant by it: that fix rejects an
+ * INTERIOR hit (a specifier continuing past its target with anything other
+ * than the literal `/mod` suffix), but a crate-root file whose own basename
+ * coincides with a submodule it declares (this function's one documented
+ * non-catch aside) resolves to a specifier EQUAL to the importer's own path
+ * — an exact match, which `matchesRustModSpecifier` intentionally still
+ * allows (that's its `x.rs` case). Only this exact-equality check at
+ * extraction time catches that shape; #1021's fix operates entirely on
+ * interior hits and never sees this one at all.
  */
 function isModSelfEdge(resolvedSpecifier: string, importerFile: string): boolean {
   return resolvedSpecifier === importerFile.replace(/\.rs$/, '');
@@ -734,12 +756,31 @@ export class RustImportExtractor implements LanguageImportExtractor {
     importerFile?: string,
   ): { importPath: string; symbols: string[] } | null {
     if (node.type === 'mod_item') {
-      // A `mod x;` brings the whole module namespace into scope (consumers
-      // then use qualified `x::func()` calls) rather than naming specific
-      // symbols, the same "whole module" shape as `use crate::models::*;` —
-      // see `processUseWildcard` below.
+      // A `mod x;` brings the module NAMESPACE into scope (consumers then
+      // use qualified `x::func()` calls) rather than naming specific symbols
+      // -- deliberately NOT the wildcard marker `['*']` `processUseWildcard`
+      // below returns for a genuine `use crate::models::*;`, even though an
+      // earlier version of this comment called them "the same whole-module
+      // shape" (#1021 correction): a real wildcard `use` FLATTENS the
+      // source's exports into the importer's own namespace (and, if `pub`,
+      // re-exports them under the importer's own name) --
+      // `findReExportedSymbolsForFile` treats that `'*'` as "credit every
+      // one of my own exports as re-exported from this source." A `mod x;`
+      // does NOT flatten anything: `sibling::declared_fn` stays reachable
+      // only as `mod::sibling::declared_fn`, never as `mod::declared_fn`.
+      // Reusing the wildcard marker here made `pub mod sibling;` -- a plain
+      // namespace declaration -- misreport EVERY one of the declaring
+      // file's own, unrelated `pub` exports as "re-exported from sibling",
+      // fabricating transitive dependents through
+      // `mergeReExportTransitiveDependents` even after the direct-match
+      // fabrication (`matchesRustModSpecifier`'s whole reason for existing)
+      // was fixed. An empty symbols list loses no real signal: no other
+      // consumer treats a bare (non-`* as `-prefixed) `'*'` specially, and a
+      // qualified `x::func()` call site already resolves through
+      // `fileImportsSymbolFromAny`'s call-site fallback once the module
+      // path itself matches.
       const importPath = extractModImportPath(node, importerFile);
-      return importPath ? { importPath, symbols: ['*'] } : null;
+      return importPath ? { importPath, symbols: [] } : null;
     }
 
     const argument = node.childForFieldName('argument');

--- a/packages/parser/src/ast/languages/types.ts
+++ b/packages/parser/src/ast/languages/types.ts
@@ -113,14 +113,27 @@ export interface LanguageDefinition {
    * language except Ruby) preserves that permissive package-directory
    * matching. Every other currently-supported language is unaffected either
    * way and leaves this unset too: TypeScript/JavaScript resolve specifiers
-   * to a concrete file before `matchesFile` ever runs, Python/PHP use their
-   * own dedicated matching strategies (`matchesPythonModule`/
-   * `matchesPHPNamespace`), and Rust's multi-segment module paths already
-   * name an exact file — see `matchesFile`'s
-   * `requireExactTailForMultiSegment` parameter for how this flag is
-   * consumed (only `importMatchesTarget` derives it from the importer's
-   * language; the two build-side sites and the two stay-raw `matchesFile`
-   * call sites don't have a specific target to disambiguate against).
+   * to a concrete file before `matchesFile` ever runs, and Python/PHP use
+   * their own dedicated matching strategies (`matchesPythonModule`/
+   * `matchesPHPNamespace`). See `matchesFile`'s `requireExactTailForMultiSegment`
+   * parameter for how this flag is consumed (only `importMatchesTarget`
+   * derives it from the importer's language; the two build-side sites and
+   * the two stay-raw `matchesFile` call sites don't have a specific target
+   * to disambiguate against).
+   *
+   * Rust is a DELIBERATE non-example, not an oversight: its `mod x;`
+   * declarations do name an exact file (never a package directory), but
+   * this per-LANGUAGE flag can't express that alone -- a single Rust file
+   * routinely has both a `mod x;` (single-file) and a `use crate::y;`
+   * (needs this same package-directory leniency, since `crate::`-relative
+   * paths are missing their real `src/`-style prefix) among its own
+   * imports, and this flag can't disambiguate between two entries in one
+   * file's import list the way it disambiguates between two LANGUAGES.
+   * `mod`-derived specifiers instead carry their own per-specifier marker
+   * (#1021) straight past this flag entirely -- see `rust-mod-marker.ts`
+   * and `matchesRustModSpecifier` in `../../utils/path-matching.ts`. Rust's
+   * `use`/`self::`/`super::` specifiers are unaffected by that marker and
+   * keep relying on this flag staying unset for Rust, exactly as before.
    */
   singleFileImports?: boolean;
 

--- a/packages/parser/src/ast/symbols.test.ts
+++ b/packages/parser/src/ast/symbols.test.ts
@@ -10,6 +10,7 @@ import {
   extractCallSites,
 } from './symbols.js';
 import { matchesFile, normalizePath } from '../utils/path-matching.js';
+import { markRustModSpecifier } from '../utils/rust-mod-marker.js';
 
 describe('Symbol Extraction', () => {
   describe('extractImportedSymbols', () => {
@@ -1080,7 +1081,7 @@ use crate::auth::{AuthService, AuthError};
           undefined,
           'src/main.rs',
         );
-        expect(imports).toContain('src/reporter');
+        expect(imports).toContain(markRustModSpecifier('src/reporter'));
       });
 
       it('extracts nothing for a mod declaration without rustImporterFile — cannot resolve deterministically', () => {

--- a/packages/parser/src/dependency-analyzer.test.ts
+++ b/packages/parser/src/dependency-analyzer.test.ts
@@ -5,6 +5,7 @@ import {
   chunkImportsFrom,
   COMPLEXITY_THRESHOLDS,
 } from './dependency-analyzer.js';
+import { chunkByAST } from './ast/chunker.js';
 import type { CodeChunk, ChunkMetadata } from './types.js';
 
 describe('analyzeDependencies', () => {
@@ -929,5 +930,61 @@ describe('chunkImportsFrom', () => {
       const chunk = makeChunk('Tests/SessionTests.swift', { imports: ['./Networking/Session'] });
       expect(chunkImportsFrom(chunk, 'Source/Networking/Session', identity)).toBe(true);
     });
+  });
+});
+
+describe('Rust mod-derived edges end-to-end (#1021 regression)', () => {
+  // Both fixtures below are issue #1021's own reproductions, parsed through
+  // the REAL Rust extractor (`chunkByAST`) and run through the same
+  // `analyzeDependencies`/`findDependentChunks` engine `get_dependents` uses
+  // -- not a hand-built `imports: [...]` array -- so this exercises the
+  // full extraction-to-matching pipeline, not just one layer of it. Neither
+  // shape (a `mod dir;` with several files, or a leaf file owning a
+  // subdirectory) previously existed as a regression fixture anywhere in the
+  // repo, which is why two rounds of real-world validation (#1000/#1008,
+  // #1016/#1020) missed both bugs.
+  const workspaceRoot = '/test/workspace';
+
+  it('fixture 1: `mod thing;` (src/main.rs) fabricates edges to every file under thing/, not just the real ones', () => {
+    const chunks = [
+      ...chunkByAST('src/main.rs', 'mod thing;\n\nfn main() {\n    thing::declared_fn();\n}\n'),
+      ...chunkByAST('src/thing/mod.rs', 'pub fn declared_fn() -> u32 { 1 }\npub mod sibling;\n'),
+      ...chunkByAST('src/thing/sibling.rs', 'pub fn sibling_fn() -> u32 { 2 }\n'),
+      ...chunkByAST('src/thing/undeclared.rs', 'pub fn nobody_declares_me() -> u32 { 3 }\n'),
+    ];
+
+    expect(
+      analyzeDependencies('src/thing/mod.rs', chunks, workspaceRoot).dependents.map(
+        d => d.filepath,
+      ),
+    ).toEqual(['src/main.rs']);
+
+    expect(
+      analyzeDependencies('src/thing/sibling.rs', chunks, workspaceRoot).dependents.map(
+        d => d.filepath,
+      ),
+    ).toEqual(['src/thing/mod.rs']);
+
+    expect(
+      analyzeDependencies('src/thing/undeclared.rs', chunks, workspaceRoot).dependents,
+    ).toEqual([]);
+  });
+
+  it('fixture 2: a leaf file owning a submodule subdirectory (src/engine.rs -> mod helpers;) fabricates a self-edge', () => {
+    const chunks = [
+      ...chunkByAST('src/lib.rs', 'pub mod engine;\n'),
+      ...chunkByAST('src/engine.rs', 'mod helpers;\n\npub fn run() -> u32 { helpers::help() }\n'),
+      ...chunkByAST('src/engine/helpers.rs', 'pub fn help() -> u32 { 7 }\n'),
+    ];
+
+    expect(
+      analyzeDependencies('src/engine.rs', chunks, workspaceRoot).dependents.map(d => d.filepath),
+    ).toEqual(['src/lib.rs']);
+
+    expect(
+      analyzeDependencies('src/engine/helpers.rs', chunks, workspaceRoot).dependents.map(
+        d => d.filepath,
+      ),
+    ).toEqual(['src/engine.rs']);
   });
 });

--- a/packages/parser/src/utils/path-matching.test.ts
+++ b/packages/parser/src/utils/path-matching.test.ts
@@ -10,6 +10,7 @@ import {
   hasSingleFileImportSemantics,
   hasPythonModuleSemantics,
 } from './path-matching.js';
+import { markRustModSpecifier } from './rust-mod-marker.js';
 
 /**
  * Test cases for path matching logic in get_dependents tool.
@@ -699,6 +700,123 @@ describe('importMatchesTarget (#886)', () => {
           'flask',
           'flask/tests/test_app.py',
           normalize('flask/app.py'),
+          normalize,
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe('#1021 Rust mod-derived single-file guard', () => {
+    // Reproduces issue #1021's two fixtures directly against `importMatchesTarget`
+    // -- the same primitive `findDependentChunks`'s fuzzy loop calls per
+    // (chunk, rawSpecifier) entry, so this is the exact decision `get_dependents`
+    // makes for each candidate dependent.
+
+    it('fixture 1 (fabricated descendant edges): `mod thing;` in main.rs matches ONLY the real mod.rs sibling, never an undeclared/unrelated child', () => {
+      const mainImportsThing = markRustModSpecifier('src/thing');
+      const importerFile = 'src/main.rs';
+
+      // src/thing/mod.rs -- real: mod.rs is the module's own file (`x/mod.rs`
+      // convention).
+      expect(
+        importMatchesTarget(
+          mainImportsThing,
+          importerFile,
+          normalize('src/thing/mod.rs'),
+          normalize,
+        ),
+      ).toBe(true);
+
+      // src/thing/sibling.rs -- FABRICATED before #1021: only reachable via
+      // mod.rs's own `pub mod sibling;`, never via main.rs's `mod thing;`.
+      expect(
+        importMatchesTarget(
+          mainImportsThing,
+          importerFile,
+          normalize('src/thing/sibling.rs'),
+          normalize,
+        ),
+      ).toBe(false);
+
+      // src/thing/undeclared.rs -- FABRICATED before #1021: nothing declares
+      // `mod undeclared;` anywhere.
+      expect(
+        importMatchesTarget(
+          mainImportsThing,
+          importerFile,
+          normalize('src/thing/undeclared.rs'),
+          normalize,
+        ),
+      ).toBe(false);
+    });
+
+    it("fixture 1: mod.rs's `pub mod sibling;` still matches sibling.rs exactly (the real edge)", () => {
+      expect(
+        importMatchesTarget(
+          markRustModSpecifier('src/thing/sibling'),
+          'src/thing/mod.rs',
+          normalize('src/thing/sibling.rs'),
+          normalize,
+        ),
+      ).toBe(true);
+    });
+
+    it("fixture 2 (fabricated self-edges): a leaf file's own `mod helpers;` never matches the leaf file itself", () => {
+      // src/engine.rs contains `mod helpers;` -> resolves to
+      // src/engine/helpers (owning subdirectory named after the leaf file).
+      // Computing get_dependents('src/engine.rs') must not fabricate a
+      // self-edge from this.
+      expect(
+        importMatchesTarget(
+          markRustModSpecifier('src/engine/helpers'),
+          'src/engine.rs',
+          normalize('src/engine.rs'),
+          normalize,
+        ),
+      ).toBe(false);
+    });
+
+    it("fixture 2: lib.rs's `pub mod engine;` never matches engine/helpers.rs (only engine.rs does)", () => {
+      // src/lib.rs contains `pub mod engine;` -> resolves to src/engine.
+      // This must match engine.rs itself, but must NOT also match the
+      // unrelated grandchild engine/helpers.rs.
+      const libImportsEngine = markRustModSpecifier('src/engine');
+      expect(
+        importMatchesTarget(libImportsEngine, 'src/lib.rs', normalize('src/engine.rs'), normalize),
+      ).toBe(true);
+      expect(
+        importMatchesTarget(
+          libImportsEngine,
+          'src/lib.rs',
+          normalize('src/engine/helpers.rs'),
+          normalize,
+        ),
+      ).toBe(false);
+    });
+
+    it("fixture 2: engine.rs's own `mod helpers;` still matches engine/helpers.rs exactly (the real edge)", () => {
+      expect(
+        importMatchesTarget(
+          markRustModSpecifier('src/engine/helpers'),
+          'src/engine.rs',
+          normalize('src/engine/helpers.rs'),
+          normalize,
+        ),
+      ).toBe(true);
+    });
+
+    it('leaves an UNMARKED Rust specifier on the identical string value fully permissive, unaffected by the marker guard', () => {
+      // Same specifier value as fixture 1 ("src/thing"), but WITHOUT the
+      // #1021 marker -- as if some hypothetical `use`-derived path had
+      // resolved to this exact anchored string. Must keep matchesFile's
+      // existing (package-directory-style) leniency exactly as before this
+      // fix: the marker guard only ever narrows behavior for specifiers that
+      // carry it, never for ones that don't.
+      expect(
+        importMatchesTarget(
+          'src/thing',
+          'src/main.rs',
+          normalize('src/thing/sibling.rs'),
           normalize,
         ),
       ).toBe(true);

--- a/packages/parser/src/utils/path-matching.ts
+++ b/packages/parser/src/utils/path-matching.ts
@@ -13,6 +13,7 @@ import {
   hasWholeModuleImports,
   hasSingleFileImports,
 } from '../ast/languages/registry.js';
+import { hasRustModMarker, stripRustModMarker } from './rust-mod-marker.js';
 
 /**
  * Escape special regex characters in a string.
@@ -49,7 +50,18 @@ function getExtensionRegex(): RegExp {
  * @returns Normalized path
  */
 export function normalizePath(path: string, workspaceRoot: string): string {
-  let normalized = path.replace(/['"]/g, '').trim().replace(/\\/g, '/');
+  // Strip the #1021 Rust-mod marker (see `rust-mod-marker.ts`) first, before
+  // any other processing, so every caller that normalizes a raw specifier --
+  // including the two `isExactDirectImport` helpers (test-associations.ts,
+  // get_files_context's handler) that compare `normalize(imp) ===
+  // normalizedTarget` directly rather than routing through
+  // `importMatchesTarget` -- gets a clean, comparable value with no changes
+  // needed at those call sites. A no-op for every non-Rust-mod path (the
+  // marker is a Private-Use-Area code point no real specifier starts with).
+  let normalized = (hasRustModMarker(path) ? stripRustModMarker(path) : path)
+    .replace(/['"]/g, '')
+    .trim()
+    .replace(/\\/g, '/');
 
   // Normalize extensions: strip all AST-supported language extensions
   // This handles TypeScript's ESM requirement of .js imports for .ts files
@@ -354,10 +366,40 @@ export function matchesFile(
 }
 
 /**
+ * Rust `mod x;` resolution semantics (#1021): the specifier names EXACTLY
+ * one of two files -- `x.rs` (exact match) or `x/mod.rs` (the sole
+ * directory-module alternative Rust's file-to-module convention allows) --
+ * never a grandchild, an unrelated sibling, or the declaring file itself.
+ *
+ * Deliberately bypasses every `matchesFile` strategy: those exist to resolve
+ * AMBIGUOUS bare/relative specifiers, but a `mod`-derived specifier (see
+ * `rustModOwningDirectory` in `../ast/languages/rust.ts`) is already a fully
+ * resolved, directory-anchored path with no remaining ambiguity for a
+ * boundary-matching heuristic to add. That's exactly what let `matchesFile`
+ * fabricate edges to any file continuing past the specifier -- Go
+ * package-directory semantics wrongly applied to a Rust `mod`, in BOTH
+ * directions: Strategy 2's `requireExactTailForMultiSegment` leniency let
+ * `src/thing` (from `mod thing;`) match every file under `src/thing/`, not
+ * just `src/thing/mod.rs`; and Strategy 1 -- hardcoded to the same
+ * leniency regardless of caller/language, since its `pattern` position is
+ * normally a concrete target file, never a package name -- let a LEAF
+ * file's own `mod helpers;` specifier (`src/engine/helpers`, longer than
+ * the file's own path) match back against `src/engine` itself, fabricating
+ * a self-edge.
+ *
+ * Only called for specifiers carrying the #1021 marker (see
+ * `rust-mod-marker.ts`) -- i.e. never for `use crate::...`/`self::`/`super::`
+ * specifiers, which keep resolving through `matchesFile` exactly as before.
+ */
+function matchesRustModSpecifier(normalizedImport: string, normalizedTarget: string): boolean {
+  return normalizedImport === normalizedTarget || normalizedTarget === `${normalizedImport}/mod`;
+}
+
+/**
  * The single guarded import-matching decision: does `importSpecifier` (as
  * written in `importerFile`) resolve to `normalizedTarget`?
  *
- * Couples three guards to `matchesFile` so neither can drift apart from a
+ * Couples four guards to `matchesFile` so neither can drift apart from a
  * match-side call site again:
  * - The #884 whole-module guard (`isUnresolvableWholeModuleImport`) --
  *   `matchesFile` is language-agnostic and cannot know the importer's
@@ -376,6 +418,15 @@ export function matchesFile(
  *   a Python identifier shape (see `matchesFile`'s doc comment for the real
  *   hono/TypeScript repro). Derived from the importer's language the same
  *   way as the #887 guard, at this same call site.
+ * - The #1021 Rust-mod single-file guard (`hasRustModMarker`) -- unlike the
+ *   other three, this is derived from the SPECIFIER, not the importer's
+ *   language: a single Rust file can have both a `mod x;` (needs
+ *   `matchesRustModSpecifier`'s strict semantics) and a `use crate::y;`
+ *   (needs `matchesFile`'s existing leniency) among its own imports, so a
+ *   per-language flag can't disambiguate between two entries in the same
+ *   file's import list the way it can for #887/#929. When present, this
+ *   guard short-circuits entirely -- `matchesFile` never runs at all for a
+ *   marked specifier.
  *
  * Every match-side reverse-dependency call path that used to open-code
  * `!isUnresolvableWholeModuleImport(imp, f) && matchesFile(normalize(imp), t)`
@@ -424,6 +475,12 @@ export function importMatchesTarget(
   normalize: (p: string) => string,
 ): boolean {
   if (isUnresolvableWholeModuleImport(importSpecifier, importerFile)) return false;
+  if (hasRustModMarker(importSpecifier)) {
+    return matchesRustModSpecifier(
+      normalize(stripRustModMarker(importSpecifier)),
+      normalizedTarget,
+    );
+  }
   return matchesFile(
     normalize(importSpecifier),
     normalizedTarget,

--- a/packages/parser/src/utils/rust-mod-marker.test.ts
+++ b/packages/parser/src/utils/rust-mod-marker.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { markRustModSpecifier, hasRustModMarker, stripRustModMarker } from './rust-mod-marker.js';
+
+describe('rust-mod-marker (#1021)', () => {
+  it('marks a specifier so hasRustModMarker recognizes it', () => {
+    const marked = markRustModSpecifier('src/thing');
+    expect(hasRustModMarker(marked)).toBe(true);
+  });
+
+  it('round-trips: stripping a marked specifier returns the original', () => {
+    const original = 'src/engine/helpers';
+    expect(stripRustModMarker(markRustModSpecifier(original))).toBe(original);
+  });
+
+  it('does not flag an ordinary, unmarked specifier', () => {
+    expect(hasRustModMarker('src/thing')).toBe(false);
+    expect(hasRustModMarker('crate::auth::AuthService')).toBe(false);
+    expect(hasRustModMarker('')).toBe(false);
+  });
+
+  it('stripRustModMarker is a no-op on an unmarked specifier', () => {
+    expect(stripRustModMarker('src/thing')).toBe('src/thing');
+  });
+
+  it('the marker is not itself a plain ASCII path -- guards against collision with a real specifier', () => {
+    const marked = markRustModSpecifier('src/thing');
+    // The marker's char code should be a Private-Use-Area code point
+    // (0xE000-0xF8FF), well outside the ASCII range any real import
+    // specifier is written in.
+    expect(marked.charCodeAt(0)).toBeGreaterThanOrEqual(0xe000);
+    expect(marked.charCodeAt(0)).toBeLessThanOrEqual(0xf8ff);
+  });
+});

--- a/packages/parser/src/utils/rust-mod-marker.ts
+++ b/packages/parser/src/utils/rust-mod-marker.ts
@@ -1,0 +1,89 @@
+/**
+ * Marker distinguishing a Rust `mod x;` (or `pub mod x;`)-DERIVED import
+ * specifier -- produced only by `../ast/languages/rust.ts`'s
+ * `extractModImportPath` -- from every other Rust import (`use crate::...`,
+ * `self::`/`super::`, all produced by `convertRustModulePath`) (#1021).
+ *
+ * Why this distinction has to exist: a `mod x;` declaration resolves to
+ * EXACTLY one of `x.rs` / `x/mod.rs` -- it can never legally refer to a
+ * grandchild file, a sibling under an unrelated name, or its own declaring
+ * file. A `use` path doesn't carry that guarantee: after its `crate::`/
+ * `self::`/`super::` prefix is stripped it's crate-root-relative (missing the
+ * real `src/`-style directory prefix -- see `matchesAtBoundaryPrecise`'s
+ * `maxLeadingSegments` leniency for that convention), and for several `use`
+ * shapes (`use crate::thing::sibling::Thing;`) `extractImportPath`'s raw
+ * "imports" list variant keeps the imported item's own name glued onto the
+ * module path (`thing/sibling/Thing`) rather than isolating the module path
+ * alone. `use` specifiers -- ordinary or `self::`/`super::`-relative alike --
+ * therefore still need `matchesFile`'s existing interior-hit-tolerant
+ * (package-directory-style) matching to resolve at all; only `mod`-derived
+ * specifiers get the stricter treatment (`matchesRustModSpecifier` in
+ * `path-matching.ts`).
+ *
+ * Why a string marker rather than a richer per-import data shape:
+ * `chunk.metadata.imports` is a flat `string[]` (see `dependency-analyzer.ts`'s
+ * `ImportIndexEntry`, and `chunk.metadata.importedSymbols`'s keys, which reuse
+ * the identical string), with no room for a second field to carry this
+ * distinction alongside each specifier -- and every match-side consumer
+ * (`buildImportIndex`/`findDependentChunks`, `test-associations.ts`,
+ * `get_files_context`'s handler, `packages/review`'s `dependency-graph.ts`)
+ * reads that array as a plain list of strings, with no per-entry metadata
+ * slot. Widening that shared shape for one language's one import form would
+ * ripple through the scanner, the SQLite row mapping, and every one of those
+ * consumers -- exactly the repo-wide blast radius `path-matching.ts`'s own
+ * conservatism (it's imported by every supported language) argues against.
+ * Tagging the specifier string itself confines the change to its producer
+ * (`extractModImportPath`, via `markRustModSpecifier`) and its one consumer
+ * (`path-matching.ts`, via `hasRustModMarker`/`stripRustModMarker`).
+ *
+ * Why this is safe to embed directly in the string: the marker is a single
+ * Private-Use-Area code point, never producible by any real source file's
+ * import syntax in any currently-supported language, so `hasRustModMarker`
+ * cannot misfire on a coincidentally-matching literal specifier from another
+ * language. It's also safe to round-trip through `JSON.stringify` and SQLite
+ * TEXT storage (`row-mapping.ts` persists `chunk.metadata.imports` verbatim)
+ * -- unlike a NUL byte, which some C-string-based storage/tooling can
+ * truncate on.
+ *
+ * `normalizePath` (in `path-matching.ts`) strips the marker unconditionally
+ * as its very first step, so every existing consumer that calls `normalize()`
+ * on a raw specifier -- including the two `isExactDirectImport` helpers in
+ * `test-associations.ts` and `get_files_context`'s handler, which compare
+ * `normalize(imp) === normalizedTarget` directly rather than routing through
+ * `importMatchesTarget` -- gets a clean, comparable value for free, with no
+ * changes needed at those call sites.
+ *
+ * This module deliberately has NO imports of its own: `rust.ts` needs
+ * `markRustModSpecifier`, and `path-matching.ts` needs the other two.
+ * Routing either direction through the other file would create an import
+ * cycle -- `registry.ts` already imports `rust.ts` to register
+ * `rustDefinition`, and `path-matching.ts` already imports `registry.ts`, so
+ * `rust.ts` importing directly from `path-matching.ts` would close the loop
+ * (`rust.ts` -> `path-matching.ts` -> `registry.ts` -> `rust.ts`), and
+ * `path-matching.ts` importing directly from `rust.ts` would break its own
+ * "generic, language-agnostic" architecture (every other per-language fact it
+ * consumes is threaded through `registry.ts`'s abstractions, never a specific
+ * language file). A standalone module with no dependencies sidesteps both
+ * problems.
+ */
+// Spelled via fromCharCode, not embedded as a literal character in a string
+// -- a raw Private-Use-Area code point renders as an invisible glyph in most
+// editors/diff tools, so the numeric form keeps the source legible.
+const RUST_MOD_SPECIFIER_MARKER = String.fromCharCode(0xe000);
+
+/** Prefix `specifier` (a `mod`-derived resolved path) with the marker. */
+export function markRustModSpecifier(specifier: string): string {
+  return RUST_MOD_SPECIFIER_MARKER + specifier;
+}
+
+/** True when `specifier` was produced by `markRustModSpecifier`. */
+export function hasRustModMarker(specifier: string): boolean {
+  return specifier.startsWith(RUST_MOD_SPECIFIER_MARKER);
+}
+
+/** Remove the marker `markRustModSpecifier` added. No-op if it isn't present. */
+export function stripRustModMarker(specifier: string): string {
+  return hasRustModMarker(specifier)
+    ? specifier.slice(RUST_MOD_SPECIFIER_MARKER.length)
+    : specifier;
+}


### PR DESCRIPTION
## Summary

Fixes #1021 — completes what #1016/#1020 partially addressed.

**Root cause (confirmed single):** Rust never sets `LanguageDefinition.singleFileImports`, so every `mod`-derived specifier fell through to `matchesFile`'s Go-package-directory leniency (`requireExactTailForMultiSegment: false` / Strategy 1's hardcoded permissiveness). A Rust `mod x;` is not a package reference like Go's `import "internal/fs"` — it resolves to exactly one of `x.rs` / `x/mod.rs`, never a grandchild, an unrelated sibling, or the declaring file itself. That one mismatch produced two symptom families:

1. **Fabricated descendant edges** — `mod thing;` in `src/main.rs` matched every file under `src/thing/`, not just the real `src/thing/mod.rs`.
2. **Fabricated self-edges**, in a shape #1020's guard doesn't catch — a leaf file that owns a submodule subdirectory (`src/engine.rs`'s `mod helpers;` → `src/engine/helpers`) fuzzy-matched back onto `src/engine.rs` itself via Strategy 1 (hardcoded permissive regardless of language). #1020's guard is *exact*-equality at extraction time against the declaring file's own path; this specifier is never exactly equal to it, so it passed through untouched — the self-edge is created downstream, in matching.

## Fix

- New `packages/parser/src/utils/rust-mod-marker.ts`: a tiny, dependency-free module (avoids an import cycle between `rust.ts` → `path-matching.ts` → `registry.ts` → `rust.ts`) that tags a `mod`-derived specifier with a reversible Private-Use-Area marker.
- `extractModImportPath` (rust.ts) now tags its return value with the marker.
- `importMatchesTarget` (path-matching.ts), the single funnel every match-side reverse-dependency call path already goes through, detects the marker and routes to a new `matchesRustModSpecifier`: exact match, or the target being exactly `specifier + "/mod"` (the sole `x.rs`/`x/mod.rs` alternative Rust's file-to-module convention allows) — bypassing every other `matchesFile` strategy entirely.
- `normalizePath` strips the marker unconditionally as its first step, so the two `isExactDirectImport` helpers (test-associations.ts, get_files_context's handler) that compare `normalize(imp) === normalizedTarget` directly — bypassing `importMatchesTarget` — get a clean value for free, with no changes needed at those call sites.
- **`use crate::...`/`self::`/`super::` specifiers are completely untouched**: they're never marked, and keep resolving through the existing, unchanged `matchesFile` leniency those forms genuinely depend on (crate-root-relative paths missing their real `src/`-prefix; some `use` shapes carry a trailing symbol-name segment in the raw specifier).

**Second bug found and fixed along the way:** fixture 1's own repro revealed that `mod x;`'s `processImportSymbols` returned the wildcard marker `symbols: ['*']` — identical to what a genuine `use crate::models::*;` reports. `findReExportedSymbolsForFile` treats `'*'` as "this file flattens the source's exports into its own," so a plain `pub mod sibling;` namespace declaration was misreported as re-exporting *every one of the declaring file's own, unrelated `pub` exports* as if they came from `sibling`, fabricating transitive dependents through `mergeReExportTransitiveDependents` — a second, independent path to the same "fabricated `main.rs`" symptom, invisible before this PR because the direct-match bug already produced the same wrong answer. A `mod` declaration doesn't flatten anything (`sibling::declared_fn` is never reachable as `mod::declared_fn`), so it now reports an empty symbols list. No other consumer treated bare `'*'` specially (only `'* as '`-prefixed namespace imports get that treatment elsewhere), so nothing else regresses.

## #1012 interaction

**Does not interact with, and does not subsume, #1012.** #1012 is about `matchesAtBoundaryPrecise`'s `maxLeadingSegments` cap breaking bare, *unanchored* `use crate::x` resolution when a crate root sits >1 directory deep. `mod`-derived specifiers never reach `matchesAtBoundaryPrecise`/Strategies 1–2 at all anymore — `extractModImportPath` already produces a *fully directory-anchored* path (via `rustModOwningDirectory`), so there's no leading-segment ambiguity for `matchesRustModSpecifier` to resolve. #1012 remains open and unrelated.

## #1020's self-edge guard

**Still needed, not made redundant.** `isModSelfEdge` catches a narrow, *different* shape: a crate-root file (`tests/foo.rs`) whose own basename coincides with a submodule it declares (`mod foo;` → `tests/foo`, extension-collapsed to the importer's own path) — an *exact*-match self-edge, which `matchesRustModSpecifier` intentionally still permits (that's its `x.rs` case). #1021's fix only ever rejects *interior hits* (continuations other than the literal `/mod` suffix); it never sees this exact-equality shape at all. Both guards are load-bearing, for non-overlapping cases.

## Verification

### 1. Both fixtures, unit + full extraction-to-matching pipeline

Added as permanent regression tests in `path-matching.test.ts` (`importMatchesTarget` level) and `dependency-analyzer.test.ts` (real `chunkByAST` → `analyzeDependencies`, i.e. the exact `get_dependents` engine). **Confirmed both new `dependency-analyzer.test.ts` fixtures FAIL on unfixed code** (temporarily swapped in pre-fix `rust.ts`/`path-matching.ts`, reran — both red; restored the fix, reran — both green).

Fixture 1 (`src/main.rs` / `src/thing/{mod,sibling,undeclared}.rs`) — `analyzeDependencies` results:

| target | dependents (before) | dependents (after) |
|---|---|---|
| `src/thing/mod.rs` | `["src/main.rs"]` | `["src/main.rs"]` (unchanged, correct) |
| `src/thing/sibling.rs` | `["src/main.rs", "src/thing/mod.rs"]` | `["src/thing/mod.rs"]` |
| `src/thing/undeclared.rs` | `["src/main.rs"]` | `[]` |

Fixture 2 (`src/lib.rs` / `src/engine.rs` / `src/engine/helpers.rs`):

| target | dependents (before) | dependents (after) |
|---|---|---|
| `src/engine.rs` | `["src/engine.rs", "src/lib.rs"]` | `["src/lib.rs"]` |
| `src/engine/helpers.rs` | `["src/engine.rs", "src/lib.rs"]` | `["src/engine.rs"]` |

### 2. `lien-review-testbed/rust` (#1000/#1008 gains) — real MCP tool, real build

Copied to a scratch dir, indexed and queried via the actual `get_dependents` MCP tool (`scripts/experiments/dogfood-oss/mcp-call.mjs`, real stdio JSON-RPC, not a direct handler call):
```
reporter.rs  -> ["src/main.rs"]
formatter.rs -> ["src/main.rs", "src/reporter.rs"]
parser.rs    -> ["src/main.rs", "src/reporter.rs", "src/analyzer.rs"]
```
All match the required shape.

### 3. Fresh `dtolnay/anyhow` clone — full before/after dependent table, `use` resolution untouched

Indexed + queried (real MCP tool) all 12 `src/*.rs` + 16 `tests/*.rs` files, once on unfixed code and once on this fix. **The two tables are byte-for-byte identical** — zero diff across every file, every dependent. This includes the pre-existing, unrelated `use`-based self-edges on `chain.rs`/`context.rs`/`error.rs` (documented in #1016/#1020 as a distinct, pre-existing issue, explicitly left untouched here) — unchanged before and after, confirming `use` resolution is completely unaffected.
- `lib.rs`'s 11 top-level `mod` declarations (`backtrace`, `chain`, `context`, `ensure`, `error`, `fmt`, `kind`, `macros`, `nightly`, `ptr`, `wrapper`) all still resolve, each correctly listing `src/lib.rs` as a dependent.
- Inline `mod __private { ... }` / nested `mod kind { ... }` / `mod not { ... }` produce no fabricated edges (confirmed no phantom `__private`/`kind`/`not` paths appear anywhere).
- All 5 `tests/*.rs` self-edges #1020 fixed stay fixed (`test_context.rs`, `test_convert.rs`, `test_downcast.rs`, `test_macros.rs`, `test_repr.rs` all report `[]`), and `tests/drop/mod.rs`/`tests/common/mod.rs` still correctly show their real dependents.

### 4. Larger crate with real multi-file directory modules — fresh `serde-rs/serde` clone

anyhow's `mod` declarations are all single-`mod.rs`-file (no directory with multiple sibling files under a single `mod`), so it can't exercise symptom 1 at all — confirmed by the zero-diff result above. `serde_derive/src/internals/` is a real 9-file directory module (`ast.rs`, `attr.rs`, `case.rs`, `check.rs`, `ctxt.rs`, `name.rs`, `receiver.rs`, `respan.rs`, `symbol.rs`, declared via a plain top-level `mod internals;` in `serde_derive/src/lib.rs`, no macro involved). Indexed + queried (real MCP tool) once on unfixed code, once on this fix:

| target | `serde_derive/src/lib.rs` in dependents? |
|---|---|
| `internals/mod.rs` | yes (before and after — real edge, unchanged) |
| `internals/ast.rs` | **yes → no** |
| `internals/attr.rs` | **yes → no** |
| `internals/name.rs` | **yes → no** |
| `internals/case.rs` | **yes → no** |
| `internals/check.rs` | **yes → no** |
| `internals/respan.rs` | **yes → no** |
| `internals/symbol.rs` | **yes → no** |
| `internals/ctxt.rs` | no (before and after — never triggered) |
| `internals/receiver.rs` | no (before and after — never triggered) |

Confirmed each removed edge is genuinely false: `serde_derive/src/lib.rs` contains no `internals::ast`/`internals::attr`/etc. reference at all (`grep` came up empty) — the only real edge from `lib.rs` is to `internals/mod.rs` itself, which is unchanged. Net delta across this 10-file sample: **7 fabricated edges removed, 0 added.**

## Gates

```
npm run format:check   PASS
npm run lint           PASS (0 errors; 37 pre-existing warnings, none touching changed files)
npm run typecheck      PASS
npm run build          PASS
npm test               PASS (parser 1651, core 406, review 1723, cli 1525, action 41 — all green)
lien delta             exit 0 (3 worsened/1 improved noted, no new threshold crossings)
npm run test:e2e:rust  PASS
npm run test:e2e:go    PASS (Go is the most exposed to this shared file; unaffected)
```

## Test plan
- [x] Both #1021 fixtures added as regression tests, confirmed red on unfixed code, green on this fix
- [x] `lien-review-testbed/rust` dependents unchanged (real MCP tool)
- [x] Fresh `anyhow` clone: full dependent table byte-identical before/after
- [x] Fresh `serde` clone: 7 fabricated edges removed on a real multi-file directory module, 0 added, sampled and confirmed false
- [x] All six mandatory gates green, plus `test:e2e:rust` and `test:e2e:go`

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR fixes Rust `mod x;` dependency-edge fabrication by tagging mod-derived specifiers with a Private-Use-Area marker and routing them through a strict `matchesRustModSpecifier` check (exact match or `.../mod` only). The change is narrowly scoped: only `mod`-derived Rust specifiers are affected; `use crate::...`/`self::`/`super::` continue through the existing `matchesFile` path. A related re-export bug is fixed by returning an empty symbols list for `mod` declarations instead of the wildcard `['*']`. The PR includes comprehensive regression tests at both the `importMatchesTarget` unit level and the full `analyzeDependencies` pipeline, and verification against real Rust crates (anyhow, serde) is documented.
>
> - Introduces `rust-mod-marker.ts` to tag `mod`-derived Rust specifiers without widening the shared `chunk.metadata.imports` string[] shape.
> - `importMatchesTarget` short-circuits marked specifiers to `matchesRustModSpecifier`, bypassing `matchesFile`'s package-directory leniency for Rust `mod` only.
> - `normalizePath` strips the marker first, so direct-comparison consumers (`isExactDirectImport` helpers) need no changes.
> - `processImportSymbols` for `mod_item` now returns `symbols: []` instead of `['*']`, preventing fabricated transitive dependents via re-export flattening.

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit fcac23e. Updates automatically on new commits.</sup>
<!-- /lien-stats -->