### PR TITLE
fix(review): correct blast-radius confidence legend and doc-truth defects

### DIFF
--- a/packages/review/src/blast-radius-render.ts
+++ b/packages/review/src/blast-radius-render.ts
@@ -28,8 +28,12 @@ const NON_SUBSTITUTION_NOTE =
   "this PR's change; Complexity = a static metric, not a correctness check. " +
   'This table does not substitute for get_files_context / read_file on a ' +
   'dependent when you need to confirm the change is actually handled there. ' +
-  'Confidence: verified = a real import/call-site edge; inferred = a ' +
-  'name-matched, same-namespace, or text-matched guess — weight it lower.';
+  'Confidence: verified = same-file, or a guarded import that resolves to ' +
+  'this specific symbol (whether or not a call site literally names it — ' +
+  "e.g. PHP's `new Order()` still counts); inferred = the file-symbol link " +
+  'relies on a name/namespace convention instead of a resolved import ' +
+  '(includes a resolved import of the FILE with no symbol-level match at ' +
+  'all, e.g. Ruby `require`) — weight it lower.';
 
 /**
  * Render a blast-radius report as markdown wrapped in a `<blast_radius>` XML tag.

--- a/packages/review/src/comparison-change-signals.ts
+++ b/packages/review/src/comparison-change-signals.ts
@@ -623,21 +623,35 @@ export function computeComparisonChanges(context: ReviewContext): ComparisonChan
 // Rendering
 // ---------------------------------------------------------------------------
 
-const HEADER =
-  'Pre-computed by a deterministic diff scan — the comparison/threshold-shaped ' +
-  'edit discovery is done for you; do not re-scan the whole diff line-by-line ' +
-  'looking for these. Each entry is a removed/added line pair this PR changed ' +
-  'that shifts a comparison operator, a numeric literal in a conditional ' +
-  'context, or index arithmetic adjacent to indexing. Discovery only — this ' +
-  'block does NOT judge whether the change is intentional, disclosed, or ' +
-  "breaking, and it does NOT substitute for the boundary-change protocol's " +
-  'MANDATORY get_files_context call: knowing the file:line here does not tell ' +
-  'you the test associations for that file, so you must still call ' +
-  'get_files_context on it to find and inspect the covering tests, per the ' +
-  'protocol. Apply the full protocol to each entry: identify the divergence ' +
-  'input, check test coverage for it via get_files_context, and consult ' +
-  '<blast_radius>. This scan can miss compound changes (operator AND literal ' +
-  'changed on the same line) — the <diff> section is still the ground truth.';
+/**
+ * `blastRadiusPresent` gates the "consult <blast_radius>" clause: that tag
+ * only exists in the prompt when `renderBlastRadius` (system-prompt.ts)
+ * actually rendered a non-empty section — the two are otherwise assembled
+ * independently (this section is gated on the `boundary-change` rule alone),
+ * so without this flag the instruction could tell the agent to consult a
+ * section that isn't in its context at all (e.g. blast radius resolved to
+ * zero seeds, or a caller like the harness's build-prompts.ts never computed
+ * it in the first place).
+ */
+function buildHeader(blastRadiusPresent: boolean): string {
+  const blastRadiusClause = blastRadiusPresent ? ', and consult <blast_radius>' : '';
+  return (
+    'Pre-computed by a deterministic diff scan — the comparison/threshold-shaped ' +
+    'edit discovery is done for you; do not re-scan the whole diff line-by-line ' +
+    'looking for these. Each entry is a removed/added line pair this PR changed ' +
+    'that shifts a comparison operator, a numeric literal in a conditional ' +
+    'context, or index arithmetic adjacent to indexing. Discovery only — this ' +
+    'block does NOT judge whether the change is intentional, disclosed, or ' +
+    "breaking, and it does NOT substitute for the boundary-change protocol's " +
+    'MANDATORY get_files_context call: knowing the file:line here does not tell ' +
+    'you the test associations for that file, so you must still call ' +
+    'get_files_context on it to find and inspect the covering tests, per the ' +
+    'protocol. Apply the full protocol to each entry: identify the divergence ' +
+    `input, check test coverage for it via get_files_context${blastRadiusClause}. ` +
+    'This scan can miss compound changes (operator AND literal changed on the ' +
+    'same line) — the <diff> section is still the ground truth.'
+  );
+}
 
 function renderEntry(c: ComparisonChangeCandidate): string {
   return `- ${c.file}:${c.line} — \`${c.oldFragment}\` → \`${c.newFragment}\` (${c.kind}): ${c.reason}`;
@@ -647,11 +661,17 @@ function renderEntry(c: ComparisonChangeCandidate): string {
  * Render comparison-change candidates as a `<comparison_change_candidates>`
  * block. Returns '' when there are none. Caps at MAX_CANDIDATES with an
  * explicit omission note — never truncates silently. Exposed for testing.
+ *
+ * `blastRadiusPresent` (default `true`, matching every existing caller's
+ * prior behavior) — see `buildHeader`'s doc comment.
  */
-export function renderComparisonChangeCandidates(candidates: ComparisonChangeCandidate[]): string {
+export function renderComparisonChangeCandidates(
+  candidates: ComparisonChangeCandidate[],
+  blastRadiusPresent = true,
+): string {
   if (candidates.length === 0) return '';
 
-  const lines: string[] = ['<comparison_change_candidates>', HEADER];
+  const lines: string[] = ['<comparison_change_candidates>', buildHeader(blastRadiusPresent)];
   const shown = candidates.slice(0, MAX_CANDIDATES);
   for (const c of shown) lines.push(renderEntry(c));
 
@@ -669,8 +689,12 @@ export function renderComparisonChangeCandidates(candidates: ComparisonChangeCan
 /**
  * Build the `<comparison_change_candidates>` section from the review
  * context. Returns '' when the PR's diff has no qualifying comparison
- * change, or there's no diff at all.
+ * change, or there's no diff at all. `blastRadiusPresent` — see
+ * `buildHeader`'s doc comment; forwarded to `renderComparisonChangeCandidates`.
  */
-export function renderComparisonChangeSection(context: ReviewContext): string {
-  return renderComparisonChangeCandidates(computeComparisonChanges(context));
+export function renderComparisonChangeSection(
+  context: ReviewContext,
+  blastRadiusPresent = true,
+): string {
+  return renderComparisonChangeCandidates(computeComparisonChanges(context), blastRadiusPresent);
 }

--- a/packages/review/src/dependency-graph.ts
+++ b/packages/review/src/dependency-graph.ts
@@ -93,9 +93,25 @@ export type EdgeProvenance =
   | 'oop-method-import'
   | 'namespace-inferred';
 
-/** True for the two tiers backed by a verified import statement (same-file counts as trivially verified). */
+/**
+ * True for the three tiers where the SPECIFIC seed symbol is verifiably
+ * imported/declared in the dependent — same-file trivially, import-verified
+ * via a named call site, import-only via the import alone (no call site
+ * names it, but `resolveOneChunkImports` still confirmed this exact symbol
+ * resolves to this exact file through `importMatchesTarget`'s guards — see
+ * `EdgeProvenance`'s doc comment). Deliberately excludes `require-only`
+ * despite it also being a guarded, resolved import: that tier only verifies
+ * a FILE-level relationship (Ruby's `require`/`load` names no symbol at
+ * all), never that THIS symbol is the one depended on — see `require-only`'s
+ * own doc for why it ranks below `import-only`. The remaining tiers
+ * (`symbol-name-match`, `oop-method-import`, `namespace-inferred`) resolve
+ * the specific file via a name/namespace convention rather than a verified
+ * import, so they stay imprecise regardless of language.
+ */
 export function isPreciseProvenance(provenance: EdgeProvenance): boolean {
-  return provenance === 'same-file' || provenance === 'import-verified';
+  return (
+    provenance === 'same-file' || provenance === 'import-verified' || provenance === 'import-only'
+  );
 }
 
 export interface SymbolNode {

--- a/packages/review/src/plugins/agent/system-prompt.ts
+++ b/packages/review/src/plugins/agent/system-prompt.ts
@@ -191,7 +191,10 @@ export interface BuildInitialMessageOptions {
    * type-literal/class field with no read site anywhere in the corpus) —
    * all three are the same partial-implementation-gap shape that rule
    * targets, just at different granularity (variant vs. family vs. field).
-   * `boundary-change` likewise gates `<comparison_change_candidates>`.
+   * `boundary-change` likewise gates `<comparison_change_candidates>`; that
+   * section's own prose additionally only names `<blast_radius>` when this
+   * options object's `blastRadius` actually rendered a non-empty section —
+   * see `renderComparisonChangeSection`'s `blastRadiusPresent` parameter.
    * Omit (CLI callers that don't resolve rules) to skip that gating.
    */
   rules?: ResolvedRules;
@@ -213,7 +216,8 @@ export function buildInitialMessage(
   appendIfPresent(sections, renderDiff(context));
   appendIfPresent(sections, renderComplexityRegressions(context));
   appendIfPresent(sections, renderChangedFunctions(context));
-  appendIfPresent(sections, renderBlastRadius(opts));
+  const blastRadiusSection = renderBlastRadius(opts);
+  appendIfPresent(sections, blastRadiusSection);
   appendIfPresent(sections, renderRemovedExportsSection(context));
   // stale-duplicate's `always: true` trigger meant this rendered
   // unconditionally before the candidate-loop pilot's LIEN_STALE_DUP_MAIN
@@ -233,7 +237,7 @@ export function buildInitialMessage(
     appendIfPresent(sections, renderVariantSweepSection(context));
   }
   if (isRuleActive(opts.rules, 'boundary-change')) {
-    appendIfPresent(sections, renderComparisonChangeSection(context));
+    appendIfPresent(sections, renderComparisonChangeSection(context, blastRadiusSection !== null));
   }
   appendIfPresent(sections, renderUntrustedInputSection(context));
   appendIfPresent(sections, renderRenameSweepSection(context));

--- a/packages/review/test/blast-radius-render.test.ts
+++ b/packages/review/test/blast-radius-render.test.ts
@@ -171,4 +171,53 @@ describe('renderBlastRadiusMarkdown', () => {
     const out = renderBlastRadiusMarkdown(makeReport());
     expect(out.includes('[truncated')).toBe(false);
   });
+
+  // ---------------------------------------------------------------------
+  // Confidence column — see dependency-graph.ts's `isPreciseProvenance` for
+  // the tier ranking this bucketing is derived from. `import-only` renders
+  // "verified": the import itself is guarded/resolved for this exact symbol,
+  // it just lacks a literal call site naming it (e.g. PHP's `new Order()`).
+  // ---------------------------------------------------------------------
+  describe('Confidence column', () => {
+    function renderWithProvenance(
+      provenance?: BlastRadiusEntry['dependents'][number]['provenance'],
+    ): string {
+      return renderBlastRadiusMarkdown(
+        makeReport({
+          entries: [
+            makeEntry({
+              dependents: [
+                {
+                  filepath: 'src/a.ts',
+                  symbolName: 'a',
+                  hops: 1,
+                  callSiteLine: 3,
+                  hasTestCoverage: true,
+                  provenance,
+                },
+              ],
+            }),
+          ],
+        }),
+      );
+    }
+
+    it.each([
+      ['same-file', 'verified'],
+      ['import-verified', 'verified'],
+      ['import-only', 'verified'],
+      ['require-only', 'inferred'],
+      ['symbol-name-match', 'inferred'],
+      ['oop-method-import', 'inferred'],
+      ['namespace-inferred', 'inferred'],
+    ] as const)('renders %s as %s', (provenance, expected) => {
+      const out = renderWithProvenance(provenance);
+      expect(out).toContain(`| ${expected} |`);
+    });
+
+    it('renders as verified when provenance is absent (pre-#994-Phase-5 fixtures)', () => {
+      const out = renderWithProvenance(undefined);
+      expect(out).toContain('| verified |');
+    });
+  });
 });

--- a/packages/review/test/comparison-change-signals.test.ts
+++ b/packages/review/test/comparison-change-signals.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { ReviewContext } from '../src/plugin-types.js';
+import type { BlastRadiusReport } from '../src/blast-radius.js';
 import type { ReviewRule, ResolvedRules } from '../src/plugins/agent/types.js';
 import {
   classifyLinePair,
@@ -348,6 +349,36 @@ describe('renderComparisonChangeCandidates', () => {
     ]);
     expect(rendered).not.toContain('omitted');
   });
+
+  // -------------------------------------------------------------------
+  // blastRadiusPresent — the header must not tell the agent to consult
+  // <blast_radius> when that section isn't actually in the prompt.
+  // -------------------------------------------------------------------
+  const oneCandidate = [
+    {
+      file: 'src/example.ts',
+      line: 11,
+      kind: 'operator' as const,
+      oldFragment: '>',
+      newFragment: '>=',
+      reason: 'x',
+    },
+  ];
+
+  it('mentions <blast_radius> by default (blastRadiusPresent omitted)', () => {
+    expect(renderComparisonChangeCandidates(oneCandidate)).toContain('<blast_radius>');
+  });
+
+  it('mentions <blast_radius> when blastRadiusPresent is true', () => {
+    expect(renderComparisonChangeCandidates(oneCandidate, true)).toContain('<blast_radius>');
+  });
+
+  it('omits any mention of <blast_radius> when blastRadiusPresent is false', () => {
+    const rendered = renderComparisonChangeCandidates(oneCandidate, false);
+    expect(rendered).not.toContain('<blast_radius>');
+    // The rest of the protocol instruction must still be intact.
+    expect(rendered).toContain('get_files_context');
+  });
 });
 
 describe('renderComparisonChangeSection', () => {
@@ -360,6 +391,14 @@ describe('renderComparisonChangeSection', () => {
     const rendered = renderComparisonChangeSection(makeContext(patches));
     expect(rendered).toContain('<comparison_change_candidates>');
     expect(rendered).toContain('src/example.ts:10');
+  });
+
+  it('forwards blastRadiusPresent to gate the <blast_radius> mention', () => {
+    const patches = patch('@@ -10,1 +10,1 @@', '-  if (a > 5) {', '+  if (a >= 5) {');
+    const withBlastRadius = renderComparisonChangeSection(makeContext(patches), true);
+    const withoutBlastRadius = renderComparisonChangeSection(makeContext(patches), false);
+    expect(withBlastRadius).toContain('<blast_radius>');
+    expect(withoutBlastRadius).not.toContain('<blast_radius>');
   });
 });
 
@@ -394,5 +433,70 @@ describe('buildInitialMessage injection (rule-gated)', () => {
     const context = makeContext();
     const message = buildInitialMessage(context, { rules: resolvedRulesWith('boundary-change') });
     expect(message).not.toContain('<comparison_change_candidates>');
+  });
+
+  // -------------------------------------------------------------------
+  // The comparison-change section's own <blast_radius> mention must track
+  // whether a <blast_radius> block actually rendered elsewhere in the SAME
+  // message — the two sections are otherwise assembled independently, so a
+  // caller (e.g. the harness's build-prompts.ts, which hardcodes
+  // `blastRadius: null`) must never see an instruction pointing at a tag
+  // that isn't present.
+  // -------------------------------------------------------------------
+  function sampleBlastRadiusReport(): BlastRadiusReport {
+    return {
+      entries: [
+        {
+          seed: { filepath: 'src/a.ts', symbolName: 'a', symbolType: 'function', complexity: 1 },
+          dependents: [
+            {
+              filepath: 'src/b.ts',
+              symbolName: 'b',
+              hops: 1,
+              callSiteLine: 3,
+              complexity: 2,
+              hasTestCoverage: true,
+            },
+          ],
+          risk: { level: 'low', reasoning: ['1 caller'] },
+          truncated: false,
+        },
+      ],
+      totalDistinctDependents: 1,
+      globalRisk: { level: 'low', reasoning: ['1 caller'] },
+      truncated: false,
+    };
+  }
+
+  it('mentions <blast_radius> in the comparison-change block when a blast-radius report renders', () => {
+    const message = buildInitialMessage(makeContext(patches), {
+      rules: resolvedRulesWith('boundary-change'),
+      blastRadius: sampleBlastRadiusReport(),
+    });
+    expect(message).toContain('<blast_radius>');
+    const comparisonBlock = message.slice(message.indexOf('<comparison_change_candidates>'));
+    expect(comparisonBlock).toContain('consult <blast_radius>');
+  });
+
+  it('never mentions <blast_radius> in the comparison-change block when no report renders', () => {
+    for (const opts of [
+      { rules: resolvedRulesWith('boundary-change') },
+      { rules: resolvedRulesWith('boundary-change'), blastRadius: null },
+      {
+        rules: resolvedRulesWith('boundary-change'),
+        blastRadius: {
+          entries: [],
+          totalDistinctDependents: 0,
+          globalRisk: { level: 'low' as const, reasoning: [] },
+          truncated: false,
+        },
+      },
+    ]) {
+      const message = buildInitialMessage(makeContext(patches), opts);
+      expect(message).not.toContain('<blast_radius>');
+      expect(message).toContain('<comparison_change_candidates>');
+      const comparisonBlock = message.slice(message.indexOf('<comparison_change_candidates>'));
+      expect(comparisonBlock).not.toContain('blast_radius');
+    }
   });
 });

--- a/packages/review/test/dependency-graph.test.ts
+++ b/packages/review/test/dependency-graph.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { buildDependencyGraph } from '../src/dependency-graph.js';
+import { buildDependencyGraph, isPreciseProvenance } from '../src/dependency-graph.js';
+import type { EdgeProvenance } from '../src/dependency-graph.js';
 import { createTestChunk } from '../src/test-helpers.js';
 
 // ---------------------------------------------------------------------------
@@ -1385,5 +1386,27 @@ describe('buildDependencyGraph — barrel transitive-walk regression (post-#1011
     const consumerEdge = transitive.callers.find(c => c.caller.filepath === 'src/consumer.ts');
     expect(consumerEdge).toBeDefined();
     expect(consumerEdge?.hops).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isPreciseProvenance — the "verified vs. inferred" boundary consumed by
+// blast-radius-render.ts's Confidence column. `import-only` is precise: the
+// import IS verified for this exact symbol (see resolveOneChunkImports), it
+// just lacks a literal call site. `require-only` stays imprecise despite
+// also being a guarded, resolved import: it only confirms a FILE-level
+// relationship, never that this specific symbol is the one depended on.
+// ---------------------------------------------------------------------------
+describe('isPreciseProvenance', () => {
+  it.each<[EdgeProvenance, boolean]>([
+    ['same-file', true],
+    ['import-verified', true],
+    ['import-only', true],
+    ['require-only', false],
+    ['symbol-name-match', false],
+    ['oop-method-import', false],
+    ['namespace-inferred', false],
+  ])('%s -> %s', (provenance, expected) => {
+    expect(isPreciseProvenance(provenance)).toBe(expected);
   });
 });

--- a/packages/review/test/harness/README.md
+++ b/packages/review/test/harness/README.md
@@ -184,13 +184,16 @@ these can never be swept into a paid `--calibrate` run by accident.
 
 Use this shape when you want a baseline for the dependency-resolution
 tiers themselves (which callers a seed symbol resolves to), not for what
-the agent says about them — e.g. measuring a resolution refactor's
-before/after impact on a language the precise (JS/TS-only) tier can't
-reach.
+the agent says about them — e.g. measuring a resolution-strategy change's
+before/after impact on a language whose call sites don't look like a plain
+JS/TS import (PHP's constructor-injected-property calls, Python module
+imports, Rust `use`/`mod`).
 
 | Fixture | PR | Seed | What it pins |
 |---|---|---|---|
-| `blast-radius/pr981-python-check-required-fields` | #981 | `check_required_fields` (Python, `lien-review-testbed/`) | 3 direct dependents resolved via the cross-package symbol-match fallback (`addCrossPackageEdges`) — hand-verified correct for this import shape (`from module import name`); says nothing about the OOP-method or same-namespace fallback strategies |
+| `blast-radius/pr981-python-check-required-fields` | #981 | `check_required_fields` (Python, `lien-review-testbed/`) | 3 direct dependents, all resolved at the TOP of the strategy ladder in `resolveCallSiteEdges` (same-file once, `import-verified` twice) — hand-verified correct for Python's `from module import name` shape; none of the fallback tiers (cross-package symbol-match, OOP-method, same-namespace) fire here, so this fixture says nothing about them |
+| `blast-radius/pr1003-php-pricingservice-guard` | #1003 | `PricingService` (PHP, `lien-review-testbed/`) | 2 direct dependents recovered via the import-only fallback (`buildImportOnlyEdges`, `provenance: 'import-only'`) — PHP's constructor-injected-property call shape (`$this->pricingService->method()`) never produces a literal `PricingService` call site, so this was 0 dependents pre-#994-Phase-5; 2 more same-namespace-only references remain a documented, not-yet-recovered gap |
+| `blast-radius/pr1003-rust-config-guard` | #1003 | `Config` (Rust, `lien-review-testbed/`) | Known-gap baseline, 1 of 5 hand-verified real dependents recovered: `main.rs` (via the require-only fallback recovering its `mod config;` declaration, `provenance: 'require-only'`); the other 4 (`use crate::config::Config;` sites) remain capped by `matchesAtBoundaryPrecise`'s `maxLeadingSegments` limit — a testbed-directory-depth artifact, not a real-world Rust concern |
 
 Regenerate:
 
@@ -198,12 +201,22 @@ Regenerate:
 npx tsx packages/review/test/harness/capture-pr.ts 981 \
   packages/review/test/harness/fixtures/blast-radius/pr981-python-check-required-fields.fixture.json \
   --sha 51c32d23f08a84ab195bc85d6f366594229f96aa
+
+npx tsx packages/review/test/harness/capture-pr.ts 1003 \
+  packages/review/test/harness/fixtures/blast-radius/pr1003-php-pricingservice-guard.fixture.json \
+  --sha 77820895632948747e1a95e2388549c8f5555616
+
+npx tsx packages/review/test/harness/capture-pr.ts 1003 \
+  packages/review/test/harness/fixtures/blast-radius/pr1003-rust-config-guard.fixture.json \
+  --sha 77820895632948747e1a95e2388549c8f5555616
 ```
 
-Run the check:
+Run the checks:
 
 ```bash
 npx tsx packages/review/test/harness/fixtures/blast-radius/pr981-python-check-required-fields.blast-radius.ts
+npx tsx packages/review/test/harness/fixtures/blast-radius/pr1003-php-pricingservice-guard.blast-radius.ts
+npx tsx packages/review/test/harness/fixtures/blast-radius/pr1003-rust-config-guard.blast-radius.ts
 ```
 
 ## Documented-miss fixtures (real bugs, not yet reliably caught)

--- a/packages/review/test/harness/fixtures/blast-radius/pr1003-rust-config-guard.blast-radius.ts
+++ b/packages/review/test/harness/fixtures/blast-radius/pr1003-rust-config-guard.blast-radius.ts
@@ -7,7 +7,8 @@
  * exists and why it's named `.blast-radius.ts` (not `.assertions.ts` — never
  * swept into a paid `--calibrate` run).
  *
- * THIS FIXTURE PINS A KNOWN GAP, NOT A FIX — read before "improving" it.
+ * THIS FIXTURE PINS A PARTIALLY-RECOVERED KNOWN GAP, NOT A FIX — read before
+ * "improving" it further.
  *
  * `Config` (the struct) is blast-radius's seed here for the same structural
  * reason as the PHP `PricingService` fixture: `config.rs`'s diff touches the
@@ -19,35 +20,47 @@
  * `Config::load(...)`/`Config::default_config()` call) — real, verified
  * dependents by any reasonable definition.
  *
- * Measured BOTH before and after #994 Phase 5 on this exact fixture: ZERO
- * dependents, `risk: low, reasoning: []`, in both cases — Phase 5's
- * import-only fallback (which fixed the equivalent PHP case, see
- * `pr1003-php-pricingservice-guard.blast-radius.ts`) does NOT recover this
- * one. Root cause, confirmed directly against `@liendev/parser`'s
- * `importMatchesTarget` (NOT this package's code):
- * `lien-review-testbed/rust/` nests each language's sample crate 2
- * directories below the repo root, so a bare Rust module specifier like
- * `config` (from `use crate::config::Config;`, recorded as
+ * Measured immediately after #994 Phase 5 on this exact fixture: ZERO
+ * dependents, `risk: low, reasoning: []` — Phase 5's import-only fallback
+ * (which fixed the equivalent PHP case, see
+ * `pr1003-php-pricingservice-guard.blast-radius.ts`) did NOT recover any of
+ * the 5. Root cause, confirmed directly against `@liendev/parser`'s
+ * `importMatchesTarget`: `lien-review-testbed/rust/` nests each language's
+ * sample crate 2 directories below the repo root, so a bare Rust module
+ * specifier like `config` (from `use crate::config::Config;`, recorded as
  * `importedSymbols: { config: ['Config'] }`) needs to match against
  * `lien-review-testbed/rust/src/config` — 3 leading path segments before the
  * bare name. `matchesAtBoundaryPrecise`'s `maxLeadingSegments: 1` cap (the
  * deliberate #868/#883 boundary for a bare specifier resolving via a single
  * `src/`-style prefix) rejects that as too deep, so `chunkImportMaps` (this
  * package's own verified-import index, `dependency-graph.ts`) never
- * populates an entry for ANY cross-file Rust reference in this testbed at
- * all — confirmed identically reproducible by calling parser's own
- * `findDependents(chunks, 'lien-review-testbed/rust/src/config.rs', ...,
- * 'Config', 1)` directly: same zero-dependent result, so this is a
- * pre-existing, ALREADY-shared parser-level limitation, not something Phase
- * 5 introduced or could fix by routing through parser more thoroughly — it's
- * the shared primitive itself that's capped for this depth. Almost certainly
- * a testbed-structure artifact rather than a real-world Rust concern (a
- * typical crate's `src/` sits 0-1 directories from its own repo root, not
- * 2+), but this fixture's job is to pin the measured truth, not the
- * probable-in-practice case.
+ * populates an entry for any `use crate::config::Config;`-style reference in
+ * this testbed. This part of the gap is STILL present today (confirmed
+ * against the current fixture below) — a testbed-structure artifact rather
+ * than a real-world Rust concern (a typical crate's `src/` sits 0-1
+ * directories from its own repo root, not 2+), but this fixture's job is to
+ * pin the measured truth, not the probable-in-practice case.
  *
- * Do NOT "fix" this fixture by loosening `maxLeadingSegments` to make it
- * pass — that primitive is shared by every other language's import
+ * ONE of the 5 has since been recovered — `main.rs`, and only `main.rs`,
+ * because it's the single file in this crate that DECLARES the module
+ * (`mod config;`, required exactly once per Rust's module tree) rather than
+ * just referencing it (`use crate::config::Config;`, what the other 4 do).
+ * `mod config;`-derived specifiers got single-file semantics in an unrelated
+ * follow-up (rust-mod-single-file-semantics): the raw specifier now records
+ * as the FULL sibling-relative path (`lien-review-testbed/rust/src/config`,
+ * from `chunk.metadata.imports` — verified directly against this fixture),
+ * not a bare `config` needing the same capped multi-segment resolution `use`
+ * imports go through. That full path resolves as a trivial match against
+ * `lien-review-testbed/rust/src/config.rs` via the RAW-imports fallback
+ * (`resolveRequireOnlyFallback` — "not gated to Ruby specifically", see
+ * `dependency-graph.ts`'s module doc), so `main.rs` now surfaces with
+ * `provenance: 'require-only'`. `cache.rs`/`analyzer.rs`/`parser.rs`/
+ * `reporter.rs` never declare `mod config;` (only `main.rs`, the crate root,
+ * does), so this fix cannot reach them — they remain capped exactly as
+ * before.
+ *
+ * Do NOT "fix" the remaining 4/5 gap by loosening `maxLeadingSegments` to
+ * make it pass — that primitive is shared by every other language's import
  * resolution and was deliberately capped at 1 to avoid false hubs (see its
  * own doc comment in `path-matching.ts`). If this gap is worth closing,
  * it's a parser-level follow-up (loosen the cap for `crate::`-style bare
@@ -77,8 +90,11 @@ const FIXTURE_PATH = join(HERE, 'pr1003-rust-config-guard.fixture.json');
 const SEED_FILEPATH = 'lien-review-testbed/rust/src/config.rs';
 const SEED_SYMBOL = 'Config';
 
-const EXPECTED_DEPENDENT_COUNT = 0;
-const EXPECTED_RISK_LEVEL = 'low';
+/** The 1 of 5 real dependents recovered so far — see module doc. */
+const EXPECTED_DEPENDENT_COUNT = 1;
+const EXPECTED_DEPENDENT_FILEPATH = 'lien-review-testbed/rust/src/main.rs';
+const EXPECTED_DEPENDENT_PROVENANCE = 'require-only';
+const EXPECTED_RISK_LEVEL = 'medium';
 
 function loadReport(): BlastRadiusReport {
   const ctx = JSON.parse(readFileSync(FIXTURE_PATH, 'utf8')) as ReviewContext;
@@ -92,38 +108,57 @@ function findSeedEntry(report: BlastRadiusReport): BlastRadiusEntry | undefined 
   );
 }
 
+/** Set-difference the single pinned dependent against the actual one dependent (count checked by the caller). Returns failure messages (empty = pass). */
+function checkDependent(entry: BlastRadiusEntry): string[] {
+  if (entry.dependents.length !== EXPECTED_DEPENDENT_COUNT) {
+    return [
+      `dependent count drifted — expected ${EXPECTED_DEPENDENT_COUNT}, got ${entry.dependents.length} ` +
+        `(${entry.dependents.map(d => `${d.filepath}::${d.symbolName} [${d.provenance}]`).join(', ')}). ` +
+        "If this is a GENUINE improvement (one of the 4 remaining 'use crate::config::Config;' " +
+        "sites described in this file's module doc got recovered too), update this fixture's " +
+        "expectations — don't just silence the failure.",
+    ];
+  }
+
+  const [dependent] = entry.dependents;
+  const failures: string[] = [];
+  if (dependent.filepath !== EXPECTED_DEPENDENT_FILEPATH) {
+    failures.push(
+      `dependent identity drifted — expected '${EXPECTED_DEPENDENT_FILEPATH}', got '${dependent.filepath}'`,
+    );
+  }
+  if (dependent.provenance !== EXPECTED_DEPENDENT_PROVENANCE) {
+    failures.push(
+      `dependent provenance drifted — expected '${EXPECTED_DEPENDENT_PROVENANCE}', got '${dependent.provenance}'`,
+    );
+  }
+  return failures;
+}
+
+/** Loose sanity bound on the risk classification. Returns failure messages (empty = pass). */
+function checkRisk(entry: BlastRadiusEntry): string[] {
+  if (entry.risk.level !== EXPECTED_RISK_LEVEL) {
+    return [
+      `risk level drifted — expected '${EXPECTED_RISK_LEVEL}', got '${entry.risk.level}' (${entry.risk.reasoning.join('; ')})`,
+    ];
+  }
+  return [];
+}
+
 function main(): void {
   const report = loadReport();
   const entry = findSeedEntry(report);
 
-  // No entry at all is ALSO consistent with the pinned "zero dependents"
-  // baseline: computeBlastRadius only emits an entry once its seed has been
-  // through getCallersTransitive, but an empty result for every seed can
-  // leave `entries` empty entirely depending on how seeds got ranked. Handle
-  // both shapes rather than asserting an entry must exist.
   if (!entry) {
-    console.log(
-      `OK — no blast-radius entry for ${SEED_SYMBOL}@${SEED_FILEPATH} ` +
-        `(consistent with the pinned ${EXPECTED_DEPENDENT_COUNT}-dependent baseline).`,
+    console.error(
+      `FAIL: no blast-radius entry for ${SEED_SYMBOL}@${SEED_FILEPATH} — expected ` +
+        `${EXPECTED_DEPENDENT_COUNT} dependent (${EXPECTED_DEPENDENT_FILEPATH}).`,
     );
+    process.exitCode = 1;
     return;
   }
 
-  const failures: string[] = [];
-  if (entry.dependents.length !== EXPECTED_DEPENDENT_COUNT) {
-    failures.push(
-      `dependent count drifted — expected ${EXPECTED_DEPENDENT_COUNT}, got ${entry.dependents.length} ` +
-        `(${entry.dependents.map(d => `${d.filepath}::${d.symbolName} [${d.provenance}]`).join(', ')}). ` +
-        `If this is a GENUINE improvement (the parser-level path-depth cap described in this file's ` +
-        `module doc got fixed), update this fixture's expectations — don't just silence the failure.`,
-    );
-  }
-  if (entry.risk.level !== EXPECTED_RISK_LEVEL) {
-    failures.push(
-      `risk level drifted — expected '${EXPECTED_RISK_LEVEL}', got '${entry.risk.level}' (${entry.risk.reasoning.join('; ')})`,
-    );
-  }
-
+  const failures = [...checkDependent(entry), ...checkRisk(entry)];
   if (failures.length > 0) {
     console.error(`FAIL:\n  - ${failures.join('\n  - ')}`);
     process.exitCode = 1;
@@ -131,8 +166,9 @@ function main(): void {
   }
 
   console.log(
-    `OK — ${SEED_SYMBOL}@${SEED_FILEPATH}: ${entry.dependents.length} dependents, risk=${entry.risk.level} ` +
-      `(pinned known-gap baseline — see module doc for the parser-level path-depth cap this is blocked on).`,
+    `OK — ${SEED_SYMBOL}@${SEED_FILEPATH}: ${entry.dependents.length} dependent, risk=${entry.risk.level} ` +
+      `(pinned partial-recovery baseline — see module doc for the 4/5 gap still blocked on the ` +
+      `parser-level path-depth cap).`,
   );
 }
 

--- a/packages/review/test/harness/fixtures/blast-radius/pr981-python-check-required-fields.blast-radius.ts
+++ b/packages/review/test/harness/fixtures/blast-radius/pr981-python-check-required-fields.blast-radius.ts
@@ -20,19 +20,29 @@
  * collection-emptiness check from `== 0` to `<= 1` (boundary-change shape),
  * giving blast radius a changed function with real cross-file dependents.
  *
- * Result as of this fixture's capture: the dependency graph's fallback tier
- * — Python has no precise-tier resolver, see `dependency-graph.ts`'s
- * `resolveImportPath` (relative-import + `.ts/.tsx/.js/.jsx/.mts/.mjs` only)
- * — resolves all 3 direct callers correctly via the cross-package
- * symbol-match strategy (`addCrossPackageEdges`, matching `from
- * pipeline.validator import check_required_fields`). This is a CORRECT
- * baseline for THIS import shape, not a weak one. It says nothing about the
- * OOP method-call fallback (`addOopMethodEdges`) or same-namespace fallback
- * (`addSameNamespaceEdges`) — those need a class-method-call fixture (e.g.
- * PHP) to exercise. NOTE: if a future resolution change (routing through
- * @liendev/parser's primitives) regresses this specific case, this baseline
- * will flag it; if it *improves* recall on the harder OOP/namespace shapes
- * this fixture doesn't cover, that's expected and this file won't move.
+ * Result as of this fixture's capture: all 3 direct callers resolve at the
+ * TOP of `resolveCallSiteEdges`'s strategy ladder in `dependency-graph.ts`
+ * (same-file, then a guarded import via `@liendev/parser`'s
+ * `importMatchesTarget`, before any fallback tier is even tried) — no
+ * fallback strategy fires for this fixture at all:
+ *   - `validate_record` -> `provenance: 'same-file'` (it's defined in
+ *     `validator.py` alongside `check_required_fields`, no import needed).
+ *   - `parse_raw_data` (loader.py) and `process_pipeline` (processor.py) ->
+ *     `provenance: 'import-verified'` (both do `from pipeline.validator
+ *     import check_required_fields` AND call it directly as a call site, so
+ *     the import resolves AND a call site names the symbol — see
+ *     `EdgeProvenance`'s doc comment in `dependency-graph.ts`).
+ * This is a CORRECT, strong baseline for Python's `from module import name`
+ * shape, not a weak one — and NOT an instance of the cross-package
+ * symbol-match fallback (`addCrossPackageEdges`, which only fires when the
+ * import can't be verified against a specific file and tags
+ * `symbol-name-match`): the import here verifies cleanly, so resolution
+ * never reaches that fallback. This fixture says nothing about the OOP
+ * method-call fallback (`addOopMethodEdges`), the cross-package
+ * symbol-match fallback (`addCrossPackageEdges`), or the same-namespace
+ * fallback (`addSameNamespaceEdges`) — those need a class-method-call
+ * fixture (e.g. PHP) to exercise. NOTE: if a future resolution change
+ * regresses this specific case, this baseline will flag it.
  *
  * Regenerate the fixture:
  *   npx tsx packages/review/test/harness/capture-pr.ts 981 \
@@ -60,20 +70,38 @@ const SEED_SYMBOL = 'check_required_fields';
 interface DependentPin {
   filepath: string;
   symbolName: string;
+  provenance: string;
 }
 
-/** The 3 real (hand-verified) direct callers — the baseline this pins. */
+/**
+ * The 3 real (hand-verified) direct callers — the baseline this pins,
+ * including `provenance` so a future resolution-strategy change that
+ * reroutes one of these through a weaker fallback tier fails loudly here
+ * instead of silently drifting from this file's module-doc claim.
+ */
 const EXPECTED_DIRECT_DEPENDENTS: DependentPin[] = [
-  { filepath: 'lien-review-testbed/python/pipeline/validator.py', symbolName: 'validate_record' },
-  { filepath: 'lien-review-testbed/python/pipeline/processor.py', symbolName: 'process_pipeline' },
-  { filepath: 'lien-review-testbed/python/pipeline/loader.py', symbolName: 'parse_raw_data' },
+  {
+    filepath: 'lien-review-testbed/python/pipeline/validator.py',
+    symbolName: 'validate_record',
+    provenance: 'same-file',
+  },
+  {
+    filepath: 'lien-review-testbed/python/pipeline/processor.py',
+    symbolName: 'process_pipeline',
+    provenance: 'import-verified',
+  },
+  {
+    filepath: 'lien-review-testbed/python/pipeline/loader.py',
+    symbolName: 'parse_raw_data',
+    provenance: 'import-verified',
+  },
 ];
 
 /** Total dependents (all hops, depth default 2) — a loose sanity bound on the transitive expansion. */
 const EXPECTED_TOTAL_DEPENDENTS = 12;
 const EXPECTED_RISK_LEVEL = 'high';
 
-function keyOf(d: DependentPin): string {
+function keyOf(d: { filepath: string; symbolName: string }): string {
   return `${d.filepath}::${d.symbolName}`;
 }
 
@@ -89,11 +117,9 @@ function findSeedEntry(report: BlastRadiusReport): BlastRadiusEntry | undefined 
   );
 }
 
-/** Set-difference the actual hop=1 dependents against the pinned baseline. Returns failure messages (empty = pass). */
+/** Set-difference the actual hop=1 dependents against the pinned baseline, including provenance. Returns failure messages (empty = pass). */
 function checkDirectDependents(entry: BlastRadiusEntry): string[] {
-  const actualDirect = entry.dependents
-    .filter(d => d.hops === 1)
-    .map(d => ({ filepath: d.filepath, symbolName: d.symbolName }));
+  const actualDirect = entry.dependents.filter(d => d.hops === 1);
   const actualKeys = new Set(actualDirect.map(keyOf));
   const expectedKeys = new Set(EXPECTED_DIRECT_DEPENDENTS.map(keyOf));
 
@@ -105,8 +131,18 @@ function checkDirectDependents(entry: BlastRadiusEntry): string[] {
     failures.push(`missing expected direct dependent(s): ${missing.map(keyOf).join(', ')}`);
   }
   if (extra.length > 0) {
-    failures.push(`unexpected extra direct dependent(s): ${extra.map(keyOf).join(', ')}`);
+    failures.push(`unexpected extra direct dependent(s): ${extra.map(d => keyOf(d)).join(', ')}`);
   }
+
+  for (const expected of EXPECTED_DIRECT_DEPENDENTS) {
+    const actual = actualDirect.find(d => keyOf(d) === keyOf(expected));
+    if (actual && actual.provenance !== expected.provenance) {
+      failures.push(
+        `${keyOf(expected)}: expected provenance '${expected.provenance}', got '${actual.provenance}'`,
+      );
+    }
+  }
+
   return failures;
 }
 


### PR DESCRIPTION
## Summary

Five confirmed findings from the #994 dogfood sweep (#1017), all re-verified against `origin/main` before fixing. Four are documentation-truth defects, one is a prompt-assembly bug. Scope: `packages/review/src/` and its harness docs only, per the brief.

### REVIEW-3 + REVIEW-5 (fixed together — same root cause)

The Confidence legend in `blast-radius-render.ts` called `import-only` a "guess", and `formatConfidence` bucketed it as `inferred` alongside genuinely weak tiers. But `import-only` means: the caller's import of *this specific symbol* is verified via `importMatchesTarget` (all of parser's #884/#887/#929 guards) — it just lacks a literal call site naming it (e.g. PHP's `new Order()`). That's real evidence, not a guess. Since PHP method calls (`$this->service->method()`) structurally never produce a named call site, the *entire* PHP blast radius was rendering "inferred" despite being backed by guarded import resolution — the exact case #1011 was written to add.

**Fix chosen:** widen `isPreciseProvenance` to include `import-only` (same-file / import-verified / import-only = "verified"; `require-only` / `symbol-name-match` / `oop-method-import` / `namespace-inferred` = "inferred"), and correct the legend prose. Rejected the alternatives: surfacing all 6 tier names would bloat the table for marginal gain over a principled 2-way split; widening further to include `require-only` would be wrong — that tier only verifies a *file*-level relationship (Ruby's `require` names no symbol at all), never that the specific queried symbol is what's depended on.

**Before/after, rendered from the real `pr1003-php-pricingservice-guard` fixture** (regenerated fresh via `capture-pr.ts`; both PHP dependents are `provenance: 'import-only'`):

Before (old bucketing):
```
| `.../PricingService.php:PricingService` | 1 | `.../OrderController.php:OrderController` (L13) | ✗ | — | inferred |
| `.../PricingService.php:PricingService` | 1 | `.../ProductController.php:ProductController` (L12) | ✗ | — | inferred |
```

After (this PR):
```
| `.../PricingService.php:PricingService` | 1 | `.../OrderController.php:OrderController` (L13) | ✗ | — | verified |
| `.../PricingService.php:PricingService` | 1 | `.../ProductController.php:ProductController` (L12) | ✗ | — | verified |
```

A same-PR Rust `main.rs` dependent (`provenance: 'require-only'`) renders `inferred` in **both** before and after — confirming the boundary is principled (verifies the specific symbol) rather than "make everything verified."

New legend text:
> Confidence: verified = same-file, or a guarded import that resolves to this specific symbol (whether or not a call site literally names it — e.g. PHP's `new Order()` still counts); inferred = the file-symbol link relies on a name/namespace convention instead of a resolved import (includes a resolved import of the FILE with no symbol-level match at all, e.g. Ruby `require`) — weight it lower.

Added `isPreciseProvenance` unit tests (all 7 tiers) and `formatConfidence` rendering tests (all 7 tiers + the pre-#994 undefined-provenance case) in `dependency-graph.test.ts` / `blast-radius-render.test.ts`.

### REVIEW-7 — fixture header cited a deleted function + wrong tier

`pr981-python-check-required-fields.blast-radius.ts`'s module doc claimed resolution went through `resolveImportPath` (deleted — only tombstone comments remain) and `addCrossPackageEdges`/`symbol-name-match`. Measured against a freshly regenerated fixture (`capture-pr.ts 981 --sha 51c32d23...`):

```
validator.py:validate_record   -> same-file
processor.py:process_pipeline  -> import-verified
loader.py:parse_raw_data       -> import-verified
```

None are `symbol-name-match` — the import resolves cleanly for all three, so resolution never reaches the cross-package fallback. Corrected the doc and added a `provenance` field to `EXPECTED_DIRECT_DEPENDENTS` so the checker itself now asserts this, closing the loop against silent re-drift.

### REVIEW-8 — harness README documented 1 of 3 fixtures

Added rows (+ regenerate commands) for `pr1003-php-pricingservice-guard` and `pr1003-rust-config-guard` (both shipped by #1011, previously undocumented). Table now matches `ls`:

```
$ ls packages/review/test/harness/fixtures/blast-radius/*.blast-radius.ts
pr1003-php-pricingservice-guard.blast-radius.ts
pr1003-rust-config-guard.blast-radius.ts
pr981-python-check-required-fields.blast-radius.ts
```

**Incidental fixture-drift fix found while regenerating (not one of the 5, disclosed per the brief's dogfooding norm):** `pr1003-rust-config-guard` pinned "0 dependents, known gap." Regenerating it fresh against current `origin/main` fails that pin: `main.rs` now resolves with 1 dependent (`provenance: 'require-only'`, `risk: medium`). Root-caused it — an *already-merged, unrelated* fix ("rust-mod-single-file-semantics", landed before the commit this task verified against) gave `mod X;` declarations full sibling-relative-path semantics, so `main.rs`'s `mod config;` (the one declaration site in this crate) now resolves through the require-only fallback, while the other 4 files' `use crate::config::Config;` sites remain capped by `matchesAtBoundaryPrecise`'s `maxLeadingSegments`, exactly as before. Confirmed via `chunk.metadata.imports` on the regenerated fixture. This is a genuine, narrow improvement (not a regression), and the fixture's own doc comment self-documents exactly this update policy ("if this is a GENUINE improvement... update this fixture's expectations"), so I updated the pin (1 dependent, `main.rs`, `require-only`, risk medium) rather than ship a README claiming a fixture state that fails on first regeneration.

### REVIEW-9 — prompt referenced `<blast_radius>` when the section wasn't rendered

`comparison-change-signals.ts`'s HEADER unconditionally said "consult `<blast_radius>`" whenever `boundary-change` was active, independent of whether `renderBlastRadius` actually emitted anything (structurally reachable whenever blast radius resolves to zero seeds, or a caller like the harness's `build-prompts.ts` hardcodes `blastRadius: null`).

**Fix:** `system-prompt.ts` now captures `renderBlastRadius(opts)`'s result once and forwards its presence to `renderComparisonChangeSection(context, blastRadiusPresent)`, which omits the clause when absent.

**Verification — `build-prompts.ts` on the committed `boundary-change/placeholder.fixture.json`** (which has a real `>` → `>=` diff and triggers `boundary-change`):

```
$ npm run test:harness:build-prompts -w @liendev/review -- test/harness/fixtures/boundary-change/placeholder.fixture.json
```

Result: `<blast_radius>` open-tag count 0, close-tag count 0, `Global risk:` absent, and the rendered block:

```
<comparison_change_candidates>
Pre-computed by a deterministic diff scan — ... Apply the full protocol to each entry: identify the divergence
input, check test coverage for it via get_files_context. This scan can miss compound changes (operator AND literal
changed on the same line) — the <diff> section is still the ground truth.
- src/risk.ts:13 — `>` → `>=` (operator): comparison operator changed from `>` to `>=`
</comparison_change_candidates>
```

No dangling reference to a tag that isn't in the prompt. Added unit tests (`blastRadiusPresent` gating on `renderComparisonChangeCandidates`/`renderComparisonChangeSection`) and an integration test in `buildInitialMessage` covering both a real blast-radius report present and every "absent" shape (omitted, `null`, zero-entries).

### Out of scope (per the brief)

REVIEW-1/-2 were judged stale (fixed by #1024) and intentionally **not** touched — a zero-dependent seed still renders `Global risk: LOW — 0 distinct dependents` with no "resolution incomplete" marker, and can vanish entirely from a populated table. My legend/render changes here don't make that trivially addressable (it's a separate render-completeness question, not a confidence-bucketing one), so no action taken.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint` (0 errors; 37 pre-existing warnings, none in touched files)
- [x] `npm run typecheck` (+ `npm run typecheck:harness -w @liendev/review` for the fixture `.ts` files)
- [x] `npm run build`
- [x] `npm test` (all packages — parser 1, core 53, review 59/1748, cli 69/1549, action 5/41 — all green)
- [x] `lien delta` — exit 0, no new-over-threshold crossings (advisory "worsened" notes only, e.g. `isPreciseProvenance` cyclomatic 2→3 for the added branch; `main` in the Rust fixture checker actually *improved* 5→2 after extracting `checkDependent`/`checkRisk`)
- [x] All 3 deterministic `.blast-radius.ts` checkers pass: `pr981-python-check-required-fields`, `pr1003-php-pricingservice-guard`, `pr1003-rust-config-guard`
- [x] `build-prompts.ts` dogfooded against the real `boundary-change/placeholder.fixture.json` (see REVIEW-9 above) — no paid model calls; `--calibrate` not used anywhere in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Blast-radius results now distinguish verified relationships from inferred relationships, making confidence levels clearer.
  * Dependency analysis more accurately identifies precise import relationships, including guarded and language-specific cases.
  * Comparison-change guidance now references blast-radius details only when relevant information is available.

* **Documentation**
  * Expanded deterministic analysis guidance and examples across Python, PHP, and Rust scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes documentation-truth and prompt-assembly defects in the review package's blast-radius confidence bucketing and comparison-change signal rendering. The core logic change widens `isPreciseProvenance` to treat `import-only` edges as 'verified' (matching the PR's principled rationale that the specific symbol is import-verified, just not call-site-named), updates the rendered legend prose accordingly, and gates the comparison-change section's `<blast_radius>` mention on whether a blast-radius block actually rendered. All changes are accompanied by targeted unit tests and fixture updates, and the touched surfaces are limited to `packages/review/src/` and harness docs/fixtures.
>
> - `isPreciseProvenance` now includes `import-only`, so PHP/Rust import-only dependents render as `verified` instead of `inferred`
> - `renderComparisonChangeSection`/`renderComparisonChangeCandidates` take a new `blastRadiusPresent` flag so the agent is never told to consult a missing `<blast_radius>` block
> - Fixture docs and expectations updated to reflect actual current resolution behavior, including the recovered Rust `main.rs` `require-only` dependent

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 562692a. Updates automatically on new commits.</sup>
<!-- /lien-stats -->