### PR TITLE
fix(cli): stop complexity/annotate false-cleaning and creating an index on an unindexed repo

### DIFF
--- a/.changeset/complexity-noindex-staleness.md
+++ b/.changeset/complexity-noindex-staleness.md
@@ -1,0 +1,17 @@
+---
+"@liendev/lien": patch
+---
+
+Fix `lien complexity` reporting a false clean (exit 0, "no violations found") on a project that has never been indexed, and silently materializing an empty `structural.db` as a side effect — the worst possible gate failure mode, since `--fail-on error` is meant to be a CI gate.
+
+Root cause: `complexityCommand()` called `createVectorDB(rootDir).initialize()` before checking whether an index existed. `SqliteBackend.initialize()` unconditionally `mkdir`s the index directory and opens the database with `CREATE TABLE IF NOT EXISTS` (`schema.ts`'s `openDatabase`), which materializes a valid, empty store even for a project that was never indexed — and the existing `ensureIndexExists` check only caught a thrown exception, never an empty-but-valid result, so it never fired. The created store then made a subsequent `lien status` wrongly report the project as indexed.
+
+`lien api-delta` had already solved exactly this with a cheap, side-effect-free existence check (`hasStructuralIndex`, a plain `fs.access` on `structural.db`) run BEFORE ever calling `createVectorDB`. This consolidates that pattern into a shared `packages/cli/src/utils/index-freshness.ts` and applies it at every read-only call site that had the same bug:
+
+- `lien complexity` now checks `hasStructuralIndex` first and, on a missing index, prints the existing "Index not found" error and exits 1 — unconditionally, independent of `--fail-on` — without ever touching the database file.
+- `lien annotate` (both its full-annotation path and its `--tests-only`/`lookupTestAssociations` path, also used by `lien verify-tests note-edit`) had the identical bug: `createVectorDB(rootDir).initialize()` ran before the `hasData()` check that prints its own "no index found" warning, so a single `Read` or `Edit` in an unindexed repo silently created `structural.db` too. Since several of this plugin's own hooks (`augment-explore-task.sh`, `test-reminder.sh`) gate on "does `structural.db` exist on disk?" as their sole signal for "is this repo indexed?", that one side effect permanently flipped those hooks' gate open for the rest of the session, making them act on an empty index. Fixed the same way: check existence before ever calling `createVectorDB`.
+- `lien api-delta` now imports the shared `hasStructuralIndex` instead of keeping its own copy.
+
+Also added: `lien complexity` now warns (via `getIndexStalenessWarning`, reusing `lien status`'s existing "git state changed" detection against `.git-state.json`) when the on-disk index's recorded git state no longer matches the working tree, instead of silently serving stale results with no signal at all. `lien serve`'s auto-reindex machinery (`git-detection.ts`) doesn't run for this one-shot command, so this is a warning, not an auto-reindex — `lien status`'s own staleness check (`status.ts`) was refactored to share the same read (`readIndexGitState`) rather than re-deriving it a third time.
+
+A genuinely clean, up-to-date, indexed project is unaffected: `lien complexity` still reports "no violations found" at exit 0, and `lien index` still creates the store on a virgin directory exactly as before — only read-only commands that have no business creating index state were changed.

--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -3,6 +3,9 @@ import path from 'path';
 import os from 'os';
 import * as coreModule from '@liendev/core';
 import * as dependencyAnalyzerModule from '../mcp/handlers/dependency-analyzer.js';
+import * as indexFreshnessModule from '../utils/index-freshness.js';
+import { resolveProjectRoot } from './project-root.js';
+import { toAbsolutePath } from '../types/paths.js';
 import {
   annotateCommand,
   annotateCli,
@@ -25,6 +28,25 @@ vi.mock('@liendev/core', async () => {
   return {
     ...actual,
     createVectorDB: vi.fn(actual.createVectorDB),
+  };
+});
+
+// `hasStructuralIndex` is a real filesystem check against this MACHINE's
+// actual home directory for this ACTUAL repo path (most of these tests don't
+// redirect LIEN_HOME/os.homedir — only the "annotateCommand (integration)"
+// block below does, via a real empty tmp home). Default it to `true` so
+// every block that mocks `createVectorDB` directly (and assumes an
+// already-indexed project) isn't at the mercy of whether this real machine
+// happens to have this real repo indexed. The "annotateCommand (integration)"
+// block restores the real implementation for the two tests that specifically
+// exercise the "never indexed" path against its own empty tmp home.
+vi.mock('../utils/index-freshness.js', async () => {
+  const actual = await vi.importActual<typeof import('../utils/index-freshness.js')>(
+    '../utils/index-freshness.js',
+  );
+  return {
+    ...actual,
+    hasStructuralIndex: vi.fn().mockResolvedValue(true),
   };
 });
 
@@ -593,6 +615,15 @@ describe('annotateCommand (integration)', () => {
     const fs = await import('fs/promises');
     tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-annotate-test-'));
     homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(tmpHome);
+    // This block specifically exercises the real "never indexed" path (an
+    // empty tmp home has no structural.db) — restore the real
+    // `hasStructuralIndex` here instead of the file-wide `true` default.
+    const actualIndexFreshness = await vi.importActual<
+      typeof import('../utils/index-freshness.js')
+    >('../utils/index-freshness.js');
+    vi.mocked(indexFreshnessModule.hasStructuralIndex).mockImplementation(
+      actualIndexFreshness.hasStructuralIndex,
+    );
   });
 
   afterEach(async () => {
@@ -600,6 +631,7 @@ describe('annotateCommand (integration)', () => {
     logSpy.mockRestore();
     errSpy.mockRestore();
     homeSpy.mockRestore();
+    vi.mocked(indexFreshnessModule.hasStructuralIndex).mockResolvedValue(true);
     await fs.rm(tmpHome, { recursive: true, force: true });
   });
 
@@ -660,6 +692,23 @@ describe('annotateCommand (integration)', () => {
     expect(errSpy).not.toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy.mock.calls[0][0]).toContain('Lien: no index found at the resolved project root');
+  });
+
+  // HOOKS-7 regression: a single `lien annotate` (the read-hook's underlying
+  // command) on a never-indexed repo used to create an empty structural.db
+  // as a side effect of `createVectorDB(rootDir).initialize()` — which then
+  // made OTHER hooks (whose gate is "does a structural store exist?") wrongly
+  // believe the repo was indexed for the rest of the session. Assert the
+  // database is never even opened, and nothing gets created on disk.
+  it('never opens or creates the structural store on a never-indexed root', async () => {
+    const fs = await import('fs/promises');
+    vi.mocked(coreModule.createVectorDB).mockClear();
+
+    await annotateCommand('packages/cli/src/cli/index.ts');
+
+    expect(coreModule.createVectorDB).not.toHaveBeenCalled();
+    const indexDir = coreModule.getIndexDir(resolveProjectRoot(toAbsolutePath(process.cwd())));
+    await expect(fs.access(path.join(indexDir, 'structural.db'))).rejects.toThrow();
   });
 });
 

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -31,6 +31,7 @@ import {
 import { resolveProjectRoot } from './project-root.js';
 import { type AbsolutePath, type RelativePath, toAbsolutePath } from '../types/paths.js';
 import { canonicalizePath } from '../utils/canonicalize-path.js';
+import { hasStructuralIndex } from '../utils/index-freshness.js';
 
 // Complexity threshold lives in @liendev/core (dependency-analyzer's
 // COMPLEXITY_THRESHOLDS.HIGH_COMPLEXITY_DEPENDENT = 10) and surfaces
@@ -513,11 +514,24 @@ async function run(file: string, options?: AnnotateOptions): Promise<boolean> {
   const needsChdir = originalCwd !== rootDir;
   if (needsChdir) process.chdir(rootDir);
   try {
+    // #894 + HOOKS-7: check existence BEFORE createVectorDB/initialize() —
+    // that call unconditionally materializes an empty structural.db on a
+    // project that has never been indexed (see `hasStructuralIndex`'s doc
+    // comment), which is exactly the side effect that let a single Read on
+    // an unindexed repo permanently flip other hooks' "is this repo
+    // indexed?" gate for the rest of the session.
+    if (!(await hasStructuralIndex(rootDir))) {
+      console.log(formatNoIndexWarning(rootDir));
+      return false;
+    }
+
     const vectorDB = await createVectorDB(rootDir);
     await vectorDB.initialize();
 
     // #894: warn loudly instead of silently analyzing an empty store — see
-    // `formatNoIndexWarning`.
+    // `formatNoIndexWarning`. Kept as defense-in-depth for the rarer case
+    // where the store file exists but genuinely has zero rows; the
+    // `hasStructuralIndex` check above only catches "never indexed at all".
     if (!(await vectorDB.hasData())) {
       console.log(formatNoIndexWarning(rootDir));
       return false;
@@ -634,27 +648,45 @@ export interface FileTestAssociations {
  * callers print via the same `formatTestReminder`, so the reminder text an
  * agent sees can never drift between the two commands.
  */
+/** The `indexMissing: true` shape `scanTestAssociations` returns from either of its two "no usable index" early-returns. */
+function noIndexTestAssociations(
+  filepath: RelativePath,
+  rootDir: AbsolutePath,
+): FileTestAssociations {
+  return {
+    filepath,
+    rootDir,
+    tests: [],
+    packageLevelTests: [],
+    symbolUsageTests: [],
+    csharpTypeReferenceTests: [],
+    indexMissing: true,
+  };
+}
+
 async function scanTestAssociations(paths: ResolvedPaths): Promise<FileTestAssociations> {
   const { originalCwd, rootDir, filepath } = paths;
   const needsChdir = originalCwd !== rootDir;
   if (needsChdir) process.chdir(rootDir);
   try {
+    // #894 + HOOKS-7: same pre-check as `run()` above — see
+    // `hasStructuralIndex`'s doc comment for why this must run BEFORE
+    // `createVectorDB`/`initialize()` rather than after.
+    if (!(await hasStructuralIndex(rootDir))) {
+      return noIndexTestAssociations(filepath, rootDir);
+    }
+
     const vectorDB = await createVectorDB(rootDir);
     await vectorDB.initialize();
     // #894: check before scanning, not after — an empty scan result is
     // indistinguishable from "no tests" otherwise. `hasData()` is the same
     // signal the MCP server's auto-index gate uses, and is worktree/overlay-
-    // aware (true when either the base or the overlay has rows).
+    // aware (true when either the base or the overlay has rows). Kept as
+    // defense-in-depth for the rarer case where the store file exists but
+    // genuinely has zero rows — `hasStructuralIndex` above only catches
+    // "never indexed at all".
     if (!(await vectorDB.hasData())) {
-      return {
-        filepath,
-        rootDir,
-        tests: [],
-        packageLevelTests: [],
-        symbolUsageTests: [],
-        csharpTypeReferenceTests: [],
-        indexMissing: true,
-      };
+      return noIndexTestAssociations(filepath, rootDir);
     }
     const allChunks = adaptChunkImports(await vectorDB.scanAll());
     const tests =

--- a/packages/cli/src/cli/api-delta-cmd.ts
+++ b/packages/cli/src/cli/api-delta-cmd.ts
@@ -7,9 +7,7 @@
  */
 
 import chalk from 'chalk';
-import fs from 'node:fs/promises';
-import path from 'node:path';
-import { createVectorDB, getIndexDir } from '@liendev/core';
+import { createVectorDB } from '@liendev/core';
 import { computeBlastRadiusRisk, type FileContentChange } from '@liendev/parser';
 import { getRepoRoot, collectFileChanges, collectFileChange } from './delta-git.js';
 import {
@@ -23,6 +21,7 @@ import {
 } from '../utils/signature-delta.js';
 import { recordBlastEvent, type BlastEvent } from '../utils/blast-events.js';
 import { findDocReferences } from '../utils/doc-references.js';
+import { hasStructuralIndex } from '../utils/index-freshness.js';
 
 export interface ApiDeltaOptions {
   format: 'text' | 'json';
@@ -103,16 +102,6 @@ function computeRisk(analysis: DependencyAnalysisResult): string {
     hasHighComplexityUncovered,
     complexityRiskBoost: complexityMetrics.complexityRiskBoost,
   }).level;
-}
-
-/** Cheap existence check — avoids `createVectorDB().initialize()`'s side effect of creating an empty structural.db where none exists yet. */
-async function hasStructuralIndex(rootDir: string): Promise<boolean> {
-  try {
-    await fs.access(path.join(getIndexDir(rootDir), 'structural.db'));
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 /**

--- a/packages/cli/src/cli/complexity.test.ts
+++ b/packages/cli/src/cli/complexity.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import { complexityCommand } from './complexity.js';
 import * as coreModule from '@liendev/core';
 import type { ChunkMetadata } from '@liendev/parser';
+
+const execFileAsync = promisify(execFile);
 
 // Mock dependencies
 vi.mock('@liendev/core', async () => {
@@ -16,13 +23,47 @@ describe('complexityCommand', () => {
   let mockVectorDB: any;
   let consoleLogSpy: any;
   let consoleErrorSpy: any;
+  let consoleWarnSpy: any;
   let processExitSpy: any;
+  let dir: string;
+  let home: string;
+  let originalCwd: string;
+  let originalHome: string | undefined;
 
-  beforeEach(() => {
+  /** Real per-repo index dir for `dir`, resolved the same way `hasStructuralIndex` does. */
+  async function indexDir(): Promise<string> {
+    const { getIndexDir } = await import('@liendev/core');
+    return getIndexDir(dir);
+  }
+
+  /** Stub `structural.db` on real disk — its content never matters here since `createVectorDB` itself is mocked below; only its existence is what `hasStructuralIndex` checks. */
+  async function writeIndexStub(): Promise<void> {
+    const dbDir = await indexDir();
+    await fs.mkdir(dbDir, { recursive: true });
+    await fs.writeFile(path.join(dbDir, 'structural.db'), '', 'utf-8');
+  }
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-complexity-cmd-'));
+    dir = await fs.realpath(dir); // resolve macOS /var -> /private/var
+    originalCwd = process.cwd();
+    process.chdir(dir);
+
+    // Isolate under a temp LIEN_HOME so these tests never touch the real
+    // developer machine's ~/.lien/indices, and the "index exists" check
+    // below reflects only what each test sets up.
+    originalHome = process.env.LIEN_HOME;
+    home = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-complexity-cmd-home-'));
+    process.env.LIEN_HOME = home;
+
+    // Most tests below assume an already-indexed project and only exercise
+    // report/exit-code behavior — set that up by default; the "missing
+    // index" test removes it.
+    await writeIndexStub();
+
     // Mock VectorDB instance methods
     mockVectorDB = {
       initialize: vi.fn().mockResolvedValue(undefined),
-      scanWithFilter: vi.fn(), // Used for index existence check
       scanAll: vi.fn(), // Used for actual analysis
     };
 
@@ -32,6 +73,7 @@ describe('complexityCommand', () => {
     // Spy on console
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     // Spy on process.exit - don't make it throw, just track calls
     processExitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
@@ -39,8 +81,14 @@ describe('complexityCommand', () => {
     }) as any);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.restoreAllMocks();
+    vi.mocked(coreModule.createVectorDB).mockReset();
+    process.chdir(originalCwd);
+    if (originalHome === undefined) delete process.env.LIEN_HOME;
+    else process.env.LIEN_HOME = originalHome;
+    await fs.rm(dir, { recursive: true, force: true });
+    await fs.rm(home, { recursive: true, force: true });
   });
 
   it('should output text format by default', async () => {
@@ -62,9 +110,7 @@ describe('complexityCommand', () => {
       },
     ];
 
-    // Mock index check and actual scan
-    mockVectorDB.scanWithFilter.mockResolvedValue([{ id: 'test' }]); // Check if index exists
-    mockVectorDB.scanAll.mockResolvedValue(chunks); // Actual analysis
+    mockVectorDB.scanAll.mockResolvedValue(chunks);
 
     await complexityCommand({
       format: 'text',
@@ -94,9 +140,7 @@ describe('complexityCommand', () => {
       },
     ];
 
-    // Mock index check and actual scan
-    mockVectorDB.scanWithFilter.mockResolvedValue([{ id: 'test' }]); // Check if index exists
-    mockVectorDB.scanAll.mockResolvedValue(chunks); // Actual analysis
+    mockVectorDB.scanAll.mockResolvedValue(chunks);
 
     await complexityCommand({
       format: 'json',
@@ -131,9 +175,7 @@ describe('complexityCommand', () => {
       },
     ];
 
-    // Mock index check and actual scan
-    mockVectorDB.scanWithFilter.mockResolvedValue([{ id: 'test' }]); // Check if index exists
-    mockVectorDB.scanAll.mockResolvedValue(chunks); // Actual analysis
+    mockVectorDB.scanAll.mockResolvedValue(chunks);
 
     await complexityCommand({
       format: 'sarif',
@@ -183,9 +225,7 @@ describe('complexityCommand', () => {
       },
     ];
 
-    // Mock index check and actual scan
-    mockVectorDB.scanWithFilter.mockResolvedValue([{ id: 'test' }]); // Check if index exists
-    mockVectorDB.scanAll.mockResolvedValue(chunks); // Actual analysis
+    mockVectorDB.scanAll.mockResolvedValue(chunks);
 
     await complexityCommand({
       files: ['src/file1.ts'],
@@ -219,9 +259,7 @@ describe('complexityCommand', () => {
       },
     ];
 
-    // Mock index check and actual scan
-    mockVectorDB.scanWithFilter.mockResolvedValue([{ id: 'test' }]); // Check if index exists
-    mockVectorDB.scanAll.mockResolvedValue(chunks); // Actual analysis
+    mockVectorDB.scanAll.mockResolvedValue(chunks);
 
     await complexityCommand({
       format: 'text',
@@ -250,9 +288,7 @@ describe('complexityCommand', () => {
       },
     ];
 
-    // Mock index check and actual scan
-    mockVectorDB.scanWithFilter.mockResolvedValue([{ id: 'test' }]); // Check if index exists
-    mockVectorDB.scanAll.mockResolvedValue(chunks); // Actual analysis
+    mockVectorDB.scanAll.mockResolvedValue(chunks);
 
     await complexityCommand({
       format: 'text',
@@ -281,9 +317,7 @@ describe('complexityCommand', () => {
       },
     ];
 
-    // Mock index check and actual scan
-    mockVectorDB.scanWithFilter.mockResolvedValue([{ id: 'test' }]); // Check if index exists
-    mockVectorDB.scanAll.mockResolvedValue(chunks); // Actual analysis
+    mockVectorDB.scanAll.mockResolvedValue(chunks);
 
     await complexityCommand({
       format: 'text',
@@ -316,8 +350,27 @@ describe('complexityCommand', () => {
     expect(processExitSpy).toHaveBeenCalledWith(1);
   });
 
-  it('should handle missing index gracefully', async () => {
-    mockVectorDB.scanWithFilter.mockRejectedValue(new Error('Index not found'));
+  // Regression test for the false-clean-on-never-indexed-directory bug: a
+  // virgin project (no structural.db on disk at all) used to sail through
+  // `createVectorDB(rootDir).initialize()` — which itself creates an empty,
+  // valid store via `CREATE TABLE IF NOT EXISTS` — and then report "0
+  // violations, exit 0" as if the codebase were clean. It must instead fail
+  // loudly, and it must never create the store as a side effect.
+  it('should error loudly on a never-indexed project, without creating a structural.db', async () => {
+    await fs.rm(await indexDir(), { recursive: true, force: true });
+
+    await complexityCommand({ format: 'text' });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Index not found'));
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    // The whole point of the fix: never even open the database for a
+    // project that has never been indexed.
+    expect(coreModule.createVectorDB).not.toHaveBeenCalled();
+    await expect(fs.access(path.join(await indexDir(), 'structural.db'))).rejects.toThrow();
+  });
+
+  it('should handle a thrown error from the database gracefully once the index exists', async () => {
+    mockVectorDB.scanAll.mockRejectedValue(new Error('corrupt store'));
 
     await complexityCommand({
       format: 'text',
@@ -325,5 +378,65 @@ describe('complexityCommand', () => {
 
     expect(consoleErrorSpy).toHaveBeenCalled();
     expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+
+  describe('index staleness warning', () => {
+    async function git(...args: string[]): Promise<void> {
+      await execFileAsync('git', args, { cwd: dir });
+    }
+
+    async function initRepoWithCommit(): Promise<void> {
+      await git('init', '-q');
+      await git('config', 'user.email', 'test@example.com');
+      await git('config', 'user.name', 'Test');
+      await git('config', 'commit.gpgsign', 'false');
+      await fs.writeFile(path.join(dir, 'a.ts'), 'export const a = 1;\n');
+      await git('add', '-A');
+      await git('-c', 'commit.gpgsign=false', 'commit', '-q', '-m', 'init');
+    }
+
+    it('warns but still reports when the on-disk index git state differs from the current working tree', async () => {
+      await initRepoWithCommit();
+      await fs.writeFile(
+        path.join(await indexDir(), '.git-state.json'),
+        JSON.stringify({ branch: 'stale-branch', commit: '0'.repeat(40) }),
+        'utf-8',
+      );
+      mockVectorDB.scanAll.mockResolvedValue([]);
+
+      await complexityCommand({ format: 'text' });
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('stale'));
+      // Still ran the real analysis — a staleness warning doesn't block.
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('Complexity Analysis'));
+    });
+
+    it('does not warn when the on-disk index git state matches the current working tree', async () => {
+      await initRepoWithCommit();
+      const { getCurrentBranch, getCurrentCommit } = await import('@liendev/core');
+      const branch = await getCurrentBranch(dir);
+      const commit = await getCurrentCommit(dir);
+      await fs.writeFile(
+        path.join(await indexDir(), '.git-state.json'),
+        JSON.stringify({ branch, commit }),
+        'utf-8',
+      );
+      mockVectorDB.scanAll.mockResolvedValue([]);
+
+      await complexityCommand({ format: 'text' });
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not warn when the index has no recorded git state (indexed before git tracking, or non-repo)', async () => {
+      // No .git-state.json written, no git repo initialized: a genuinely
+      // clean, freshly-indexed project must not get a false staleness
+      // warning.
+      mockVectorDB.scanAll.mockResolvedValue([]);
+
+      await complexityCommand({ format: 'text' });
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/cli/src/cli/complexity.ts
+++ b/packages/cli/src/cli/complexity.ts
@@ -4,7 +4,8 @@ import path from 'path';
 import { createVectorDB } from '@liendev/core';
 import { ComplexityAnalyzer } from '@liendev/core';
 import { formatReport } from '@liendev/core';
-import type { OutputFormat, VectorDBInterface } from '@liendev/core';
+import type { OutputFormat } from '@liendev/core';
+import { hasStructuralIndex, getIndexStalenessWarning } from '../utils/index-freshness.js';
 
 interface ComplexityOptions {
   files?: string[];
@@ -51,19 +52,35 @@ function validateFilesExist(files: string[] | undefined, rootDir: string): void 
   }
 }
 
-/** Check if index exists */
-async function ensureIndexExists(vectorDB: VectorDBInterface): Promise<void> {
-  try {
-    await vectorDB.scanWithFilter({ limit: 1 });
-  } catch {
-    console.error(chalk.red('Error: Index not found'));
-    console.log(
-      chalk.yellow('\nRun'),
-      chalk.bold('lien index'),
-      chalk.yellow('to index your codebase first'),
-    );
-    process.exit(1);
-  }
+/**
+ * Check if the project has ever been indexed, and exit loudly if not.
+ *
+ * Deliberately a plain filesystem existence check (`hasStructuralIndex`)
+ * rather than opening the database and probing for rows: `createVectorDB(
+ * rootDir).initialize()` unconditionally creates the index directory and an
+ * empty-but-valid `structural.db` (see `schema.ts`'s `openDatabase`), so
+ * calling it first — then discovering there's no data — is too late to
+ * distinguish "never indexed" from "empty index," and leaves behind exactly
+ * the store this command has no business creating. `lien complexity` is a
+ * gate-shaped command (`--fail-on`), so a missing index is always a hard
+ * error here, independent of `--fail-on`.
+ *
+ * Returns whether the index exists. `process.exit(1)` terminates the process
+ * for real in production, but the boolean return (checked by the caller) is
+ * what actually stops this function's caller from proceeding to
+ * `createVectorDB` in a test environment where `process.exit` is mocked —
+ * belt-and-suspenders against ever opening the database on a missing index.
+ */
+async function ensureIndexExists(rootDir: string): Promise<boolean> {
+  if (await hasStructuralIndex(rootDir)) return true;
+  console.error(chalk.red('Error: Index not found'));
+  console.log(
+    chalk.yellow('\nRun'),
+    chalk.bold('lien index'),
+    chalk.yellow('to index your codebase first'),
+  );
+  process.exit(1);
+  return false;
 }
 
 /**
@@ -78,11 +95,22 @@ export async function complexityCommand(options: ComplexityOptions) {
     validateFormat(options.format);
     validateFilesExist(options.files, rootDir);
 
+    // Cheap existence check BEFORE ever opening the database — see
+    // `ensureIndexExists`'s doc comment for why this must come first.
+    if (!(await ensureIndexExists(rootDir))) return;
+
+    // `lien serve`'s auto-reindex machinery (git-detection.ts) doesn't run
+    // for this one-shot command, so a repo whose working tree has moved on
+    // since the last `lien index`/`lien serve` reindex would otherwise
+    // report a silent false clean. Warn, don't block or auto-reindex —
+    // reuses the same staleness check `lien status` already computes.
+    const stalenessWarning = await getIndexStalenessWarning(rootDir);
+    if (stalenessWarning) console.warn(chalk.yellow(stalenessWarning));
+
     // Initialize database via the factory so reads hit the same backend
     // `lien index` wrote
     const vectorDB = await createVectorDB(rootDir);
     await vectorDB.initialize();
-    await ensureIndexExists(vectorDB);
 
     // Run analysis and output (uses default thresholds)
     const analyzer = new ComplexityAnalyzer(vectorDB);

--- a/packages/cli/src/cli/status.ts
+++ b/packages/cli/src/cli/status.ts
@@ -20,6 +20,7 @@ import {
 } from '@liendev/core';
 import { DEFAULT_CHUNK_SIZE, DEFAULT_CHUNK_OVERLAP } from '@liendev/parser';
 import { showCompactBanner } from '../utils/banner.js';
+import { readIndexGitState } from '../utils/index-freshness.js';
 
 const VALID_FORMATS = ['text', 'json'];
 
@@ -84,17 +85,6 @@ async function resolveBackend(): Promise<string> {
   return (await loadGlobalConfig()).backend ?? 'sqlite';
 }
 
-async function getStoredGitState(
-  indexPath: string,
-): Promise<{ branch: string; commit: string } | null> {
-  try {
-    const content = await fs.readFile(path.join(indexPath, '.git-state.json'), 'utf-8');
-    return JSON.parse(content);
-  } catch {
-    return null;
-  }
-}
-
 // --- Display helpers (text format) ---
 
 async function printIndexStatus(indexPath: string) {
@@ -141,7 +131,7 @@ async function printGitStatus(rootDir: string, indexPath: string) {
   console.log(chalk.dim('  Current branch:'), gitState.branch);
   console.log(chalk.dim('  Current commit:'), gitState.commit.substring(0, 8));
 
-  const storedGit = await getStoredGitState(indexPath);
+  const storedGit = await readIndexGitState(indexPath);
   if (storedGit && (storedGit.branch !== gitState.branch || storedGit.commit !== gitState.commit)) {
     console.log(chalk.yellow('  ⚠️  Git state changed - will reindex on next serve'));
   }

--- a/packages/cli/src/cli/verify-tests-cmd.test.ts
+++ b/packages/cli/src/cli/verify-tests-cmd.test.ts
@@ -31,6 +31,20 @@ vi.mock('@liendev/core', async () => {
   };
 });
 
+// `hasStructuralIndex` is a real filesystem check — none of this file's
+// tests write a real `structural.db` stub (they simulate "index exists"
+// purely by mocking `createVectorDB`), so default it to `true`. No test in
+// this file exercises the "never indexed" path, unlike annotate-cmd.test.ts.
+vi.mock('../utils/index-freshness.js', async () => {
+  const actual = await vi.importActual<typeof import('../utils/index-freshness.js')>(
+    '../utils/index-freshness.js',
+  );
+  return {
+    ...actual,
+    hasStructuralIndex: vi.fn().mockResolvedValue(true),
+  };
+});
+
 // A stable, real file (must exist on disk — `resolvePaths` checks) with no
 // requirement that it actually be associated with any test in the real
 // index; `createVectorDB`'s `scanAll` is mocked per-test to control that.

--- a/packages/cli/src/utils/index-freshness.ts
+++ b/packages/cli/src/utils/index-freshness.ts
@@ -1,0 +1,103 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { getIndexDir, isGitRepo, getCurrentBranch, getCurrentCommit } from '@liendev/core';
+
+/**
+ * Filename of the SQLite structural store inside the index directory.
+ * Mirrors `@liendev/core`'s internal `STRUCTURAL_DB_FILENAME`
+ * (`packages/core/src/vectordb/sqlite/schema.ts`), which isn't part of the
+ * package's public surface — duplicated here rather than exported solely for
+ * this cheap existence check.
+ */
+const STRUCTURAL_DB_FILENAME = 'structural.db';
+
+/**
+ * Cheap, side-effect-free existence check for the structural store: does
+ * `<indexDir>/structural.db` exist on disk?
+ *
+ * Every read-only CLI command that needs to tell "this project has never
+ * been indexed" apart from "the index is just empty" MUST call this BEFORE
+ * `createVectorDB(rootDir).initialize()` — that call unconditionally
+ * `mkdir`s the index directory and opens the database with
+ * `CREATE TABLE IF NOT EXISTS` (see `schema.ts`'s `openDatabase`), which
+ * silently materializes a valid, empty store where none existed. For a
+ * read-only command that has no business creating index state, that side
+ * effect is actively harmful: it makes a later `lien status` claim the
+ * project is indexed, and (for a gate-shaped command like
+ * `lien complexity --fail-on error`) it turns "I have no data" into a false
+ * "no violations found" success.
+ *
+ * This consolidates what used to be `lien api-delta`'s own local
+ * `hasStructuralIndex` — the same guard, reused rather than re-invented at
+ * every new read-only call site (`lien complexity`, `lien annotate`).
+ */
+export async function hasStructuralIndex(rootDir: string): Promise<boolean> {
+  try {
+    await fs.access(path.join(getIndexDir(rootDir), STRUCTURAL_DB_FILENAME));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+interface StoredGitState {
+  branch: string;
+  commit: string;
+}
+
+/**
+ * Read the git state (branch/commit) recorded at the index's last
+ * `lien index` or `lien serve` reindex — written by `GitStateTracker` to
+ * `<indexDir>/.git-state.json`. Returns null when the file doesn't exist or
+ * doesn't parse (no index yet, or an index built before git tracking ran).
+ * Never throws.
+ *
+ * Single source of truth for reading this file — `lien status`'s
+ * `printGitStatus` and `getIndexStalenessWarning` below both go through this
+ * rather than each re-deriving their own read of the same on-disk state.
+ */
+export async function readIndexGitState(indexDir: string): Promise<StoredGitState | null> {
+  try {
+    const content = await fs.readFile(path.join(indexDir, '.git-state.json'), 'utf-8');
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * One-line warning when the on-disk index's recorded git state no longer
+ * matches the working tree's current branch/commit — i.e. the same
+ * "⚠️ Git state changed" condition `lien status` already detects
+ * (`status.ts`'s `printGitStatus`), factored out so a one-shot read-only
+ * command (like `lien complexity`, which has no auto-reindex machinery of
+ * its own — that lives only in `lien serve`'s `git-detection.ts`) can warn
+ * instead of silently serving stale results.
+ *
+ * Returns null (no warning) when: not a git repo, the index has no recorded
+ * git state (never indexed, or indexed before git tracking existed), or
+ * nothing has changed. Never throws — failing to determine staleness must
+ * not block the command's real work.
+ */
+export async function getIndexStalenessWarning(rootDir: string): Promise<string | null> {
+  try {
+    if (!(await isGitRepo(rootDir))) return null;
+
+    const stored = await readIndexGitState(getIndexDir(rootDir));
+    if (!stored) return null;
+
+    const [branch, commit] = await Promise.all([
+      getCurrentBranch(rootDir),
+      getCurrentCommit(rootDir),
+    ]);
+    if (stored.branch === branch && stored.commit === commit) return null;
+
+    return (
+      'Warning: the index looks stale — git state has changed since the last `lien index` ' +
+      '(or `lien serve` reindex). Results may not reflect the current working tree. ' +
+      'Run `lien index` to refresh.'
+    );
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Two confirmed findings sharing one root cause, plus a related finding (HOOKS-7) surfaced mid-fix that turned out to be the same bug at a third call site — folded into this PR rather than shipping a second one for the identical root cause.

- **CLI-1**: `lien complexity` reports a false clean (exit 0, "no violations found") on a project that has never been indexed, and silently creates an empty `structural.db` as a side effect.
- **CLI-2**: `lien complexity` silently serves a stale index with no staleness warning, even though `lien status` already knows the git state has changed.
- **HOOKS-7**: the same `structural.db` side effect, hit via `lien annotate` (the read-hook's underlying command), permanently flips the plugin hooks' "is this repo indexed?" gate (`augment-explore-task.sh`, `test-reminder.sh`) open for the rest of the session after a single `Read` on an unindexed repo.

## Root cause

`createVectorDB(rootDir).initialize()` → `SqliteBackend.openConnection()` → `openDatabase()` (`packages/core/src/vectordb/sqlite/schema.ts`) unconditionally `mkdir`s the index directory and runs `CREATE TABLE IF NOT EXISTS` — materializing a valid, empty store even when the project has never been indexed. `lien complexity`'s `ensureIndexExists` and `lien annotate`'s `hasData()` check both ran *after* this call, so they correctly reported "no index" but too late to avoid creating one.

`lien api-delta` had already solved this with a cheap, side-effect-free existence check (`hasStructuralIndex`, a plain `fs.access` on `structural.db`) run *before* ever calling `createVectorDB` — the exact "one decision, N sites, applied at fewer than N" shape. This PR consolidates that pattern into a shared `packages/cli/src/utils/index-freshness.ts` and applies it everywhere the bug existed, instead of inventing a fourth variant.

## Fix

- New `packages/cli/src/utils/index-freshness.ts`:
  - `hasStructuralIndex(rootDir)` — the consolidated existence check (moved out of `api-delta-cmd.ts`, which now imports it).
  - `readIndexGitState(indexDir)` — the `.git-state.json` read, factored out of `status.ts`'s private `getStoredGitState` (now removed; `status.ts` imports the shared version instead — same read, one place).
  - `getIndexStalenessWarning(rootDir)` — reuses `readIndexGitState` + the current branch/commit to produce a one-line staleness warning, mirroring `lien status`'s existing "⚠️ Git state changed" detection exactly.
- `complexity.ts`: `ensureIndexExists` now checks `hasStructuralIndex` *before* `createVectorDB` is ever called, and exits 1 unconditionally (independent of `--fail-on`) on a missing index — this is a gate-shaped command, so "no data" must never look like "no violations". Also prints `getIndexStalenessWarning`'s warning (non-blocking) before running the analysis.
- `annotate-cmd.ts`: both call sites that construct a `VectorDB` (`run()`'s full annotation path, and `scanTestAssociations()` — shared by `--tests-only` and `lien verify-tests note-edit`) now check `hasStructuralIndex` first, printing the existing `formatNoIndexWarning`/"index missing" result without ever opening the database. The existing `hasData()` check is kept as defense-in-depth for the rarer case of a store that exists but is genuinely empty.
- `api-delta-cmd.ts`: dropped its local `hasStructuralIndex` copy in favor of the shared one.

**Design decisions:**
- *Error vs warn on missing index*: `lien complexity` errors (exit 1) unconditionally — it's a gate. `lien annotate` keeps its existing behavior (prints the #894 warning, exits 0) — it's a best-effort nudge tool that must never break a hook pipeline. `annotate`'s message was the in-repo precedent named in the brief; it required no wording change, only moving the check earlier.
- *Where the guard lives*: at the `hasStructuralIndex` call-site level (in each read-only command), not inside `openDatabase`/`SqliteBackend`. A `createIfMissing`/`readOnly` flag threaded through `initialize()` would have to be audited against every caller including the indexing pipeline and worktree-overlay backend — much larger blast radius for the same outcome. The existing `hasStructuralIndex` pattern already solves this cheaply and was proven out in `api-delta-cmd.ts`; consolidating it is the smaller, more consistent fix, and it's what the brief asked to reuse rather than reinvent.
- *Staleness: warn, don't auto-reindex*: `lien serve`'s auto-reindex machinery (`git-detection.ts`/`reindexStateManager`) is MCP-server-only and too heavy for a one-shot CLI command. Reused `lien status`'s existing git-state comparison instead of re-deriving a third copy of it.

**Sibling sweep:** every `createVectorDB` call site in `packages/cli/src` was audited. Besides the three fixed above: `mcp/server.ts` (`lien serve`) and `index-cmd.ts`/`indexer/index.ts` (`lien index`, incl. `--force`) legitimately create the store by design and were left untouched. No other read-only command touches `VectorDB` directly.

## Verification

All commands run against this branch's own build (`node packages/cli/dist/index.js`), never the global `lien`, each with a per-test `LIEN_HOME` in `/tmp` scratch dirs.

### CLI-1 — before (verified on `origin/main` @ `22f8a63d`, per the original report)

```
$ cd /tmp/vdir
$ lien status
Index status: ✗ Not indexed / Run lien index to index your codebase

$ lien complexity --fail-on error; echo EXIT=$?
Files analyzed: 0
Violations: 0 (0 errors, 0 warnings)
✓ No violations found!
EXIT=0

$ lien status
Index status: ✓ Exists          <-- the complexity command created it
```

### CLI-1 — after (this branch)

```
$ cd /tmp/lien-verify-vdir
$ LIEN_HOME=/tmp/lien-verify-home node .../packages/cli/dist/index.js complexity --fail-on error; echo EXIT=$?
Error: Index not found

Run lien index to index your codebase first
EXIT=1

$ find /tmp/lien-verify-home -type f
(no output — nothing created)

$ LIEN_HOME=/tmp/lien-verify-home node .../packages/cli/dist/index.js status
Index status: ✗ Not indexed     <-- still correct, unflipped
```

Then confirmed `lien index` still works on the same virgin directory, and `lien complexity --fail-on error` afterward reports the real violations (3 violations, 1 error, exit 1) for a `gnarly()` function with cognitive complexity 51/mental-load and cyclomatic paths well over threshold.

### CLI-2 — before (per the original report)

```
$ lien index                                  # clean
$ (add an over-threshold function, commit)
$ lien status
⚠️  Git state changed - will reindex on next serve
$ lien complexity --files src/content-hash.ts; echo EXIT=$?
Violations: 0 (0 errors, 0 warnings)
✓ No violations found!                        <-- false clean, no staleness note
EXIT=0
```

### CLI-2 — after (this branch)

```
$ cd /tmp/lien-verify-stale && git init && ... commit content-hash.ts
$ LIEN_HOME=... node .../index.js index
$ (append gnarly() to content-hash.ts, commit)
$ LIEN_HOME=... node .../index.js status
⚠️  Git state changed - will reindex on next serve

$ LIEN_HOME=... node .../index.js complexity --files content-hash.ts; echo EXIT=$?
Warning: the index looks stale — git state has changed since the last `lien index`
(or `lien serve` reindex). Results may not reflect the current working tree.
Run `lien index` to refresh.
🔍 Complexity Analysis
Violations: 0 (0 errors, 0 warnings)
✓ No violations found!
EXIT=0
```

(The stale index still can't see the new function's violations — same as before — but now says so, instead of a silent false clean.) Then ran `lien index` again and re-ran `complexity --files content-hash.ts`: 3 violations reported (1 error, 2 warnings), and `lien status` shows no staleness warning anymore.

### True-clean control (must NOT become a false alarm)

```
$ cd /tmp/lien-verify-clean  # a single trivial add() function
$ node .../index.js index && node .../index.js complexity --fail-on error; echo EXIT=$?
Violations: 0 (0 errors, 0 warnings)
✓ No violations found!
EXIT=0
```

### HOOKS-7 — before/after, real hook-shaped stdin

Ran the actual plugin hook scripts (`plugins/claude/hooks/*.sh`) with real Claude-Code-shaped JSON stdin, `PATH` pointed at a shim resolving `lien` to this branch's own build (never the stale global 0.65.0), against a fresh git repo with no index:

```
augment-explore-task.sh (Task/Explore payload)  -> silent, exit 0 (correct: no index)
annotate-read.sh (Read payload on a.ts)          -> prints the #894 "no index found" warning
                                                     via additionalContext, exit 0
$ find $LIEN_HOME -type f
  .../nudge-events.jsonl
  .../nudge-build/<session>.json
  .../annotated-sessions/<session>/<hash>
  (no structural.db)
augment-explore-task.sh (SAME payload again)     -> still silent, exit 0 (gate stayed closed)
test-reminder.sh (Edit payload)                  -> silent, exit 0 (gate stayed closed,
                                                     never spawns verify-tests)
```

## Gates

```
npm run format:check   # pass
npm run lint           # pass, 0 errors (40 pre-existing warnings, unrelated)
npm run typecheck      # pass
npm run build          # pass
npm test               # pass — 69 CLI test files + all other workspaces
lien delta             # exit 0 — 3 worsened (below threshold), 1 improved, no new crossing
```

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 2 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR consolidates a side-effect-free index-existence check into a shared utility and applies it before any read-only CLI command opens the VectorDB, fixing the false-clean/empty-store-creation bugs in `lien complexity`, `lien annotate`, and the hook paths that call them. It also adds a non-blocking staleness warning to `lien complexity` by reusing `lien status`'s git-state comparison. The refactor is straightforward: internal helpers were moved or renamed but not exported, the new guard runs before `createVectorDB`, and the existing tests were updated to mock the shared helper and cover the missing-index and stale-index paths.
>
> - New shared `packages/cli/src/utils/index-freshness.ts` provides `hasStructuralIndex`, `readIndexGitState`, and `getIndexStalenessWarning`.
> - `lien complexity` now exits 1 on a missing index before ever calling `createVectorDB`, and warns when the recorded git state no longer matches the working tree.
> - `lien annotate` and its `--tests-only`/`verify-tests note-edit` path check `hasStructuralIndex` before opening the database, preventing the hook-gate flip bug.
> - `lien api-delta` and `lien status` import the shared helpers instead of duplicating the logic locally.

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit d857e18. Updates automatically on new commits.</sup>
<!-- /lien-stats -->