### PR TITLE
fix(parser): gate PHP namespace matching (Strategy 4) by language

### DIFF
--- a/.changeset/php-namespace-matching-language-gate.md
+++ b/.changeset/php-namespace-matching-language-gate.md
@@ -1,0 +1,53 @@
+---
+"@liendev/parser": patch
+---
+
+Fix `matchesFile`'s Strategy 4 (`matchesPHPNamespace`) — a case-insensitive,
+directory-mirroring namespace matcher intended for PHP's PSR-4 convention —
+being applied unconditionally to every language, fabricating false
+dependency edges wherever an unrelated bare/qualified specifier
+case-insensitively collided with a target's basename within one leading
+directory segment (#1028).
+
+Root cause: `matchesPHPNamespace`'s bare-single-component leniency (added by
+#883 for an unrelated Swift/Go/Ruby fix) is case-insensitive, unlike
+Strategy 2's equivalent (case-sensitive) one-leading-segment convention —
+but it ran for every language, not just PHP. Confirmed live on
+`dtolnay/anyhow`: `src/error.rs`'s own `use crate::{Error, StdError};`
+extracts to the bare, first-wins specifier `"Error"`, which
+case-insensitively self-matched `src/error.rs` — the same mechanism made
+`src/chain.rs` and `src/context.rs` their own dependents too, via their own
+self-referential `pub(crate) use crate::{Self};` re-exports. This was not a
+self-edge-only bug: the identical leniency also fabricated edges between
+completely different files whenever a bare specifier and a target's
+basename coincided case-insensitively — confirmed on real `expressjs/express`
+(`require('router')`, an external npm package, wrongly matched the
+project's own `test/Router.js`) and `go-chi/chi` (a package-qualified
+`middleware` import wrongly singled out `middleware/middleware.go` for
+edges its sibling files in the same package correctly never received).
+
+Fix: added `LanguageDefinition.namespaceStyleImports` (set only for PHP) and
+threaded a new `allowNamespaceMatching` parameter through `matchesFile`,
+mirroring the established per-language-gate pattern `singleFileImports`
+(#887) and the Python-bare-module guard (#929) already use.
+`importMatchesTarget` derives it from the importer's language via the new
+`hasNamespaceMatchingSemantics`, so PHP keeps Strategy 4 exactly as before
+and every other language now skips it entirely. `matchesFile` itself
+defaults the new parameter to `true`, preserving its own pre-#1028 behavior
+for direct/raw callers (mirroring `allowPythonModuleMatching`'s own
+precedent) — the real fix lives at the `importMatchesTarget` layer, the one
+place a language is actually known.
+
+Verified: `dtolnay/anyhow`'s full before/after dependent table is
+byte-for-byte identical except for the three self-edges and five related
+cross-file false positives (all case-insensitivity-dependent) disappearing;
+a deeper-nested control fixture (`src/deep/nested/error.rs`) and #883's own
+Go/Ruby/Swift regression cases are unchanged. Swept the whole real-project
+corpus (requests, zod, express, monolog, anyhow, chi, javapoet, mediatr,
+sinatra, klaxon, swiftyjson): `monolog` (PHP) is byte-for-byte identical
+before/after; `requests`/`zod`/`mediatr`/`sinatra`/`javapoet`/`klaxon`/
+`swiftyjson` are unaffected; `express` and `chi` each lose a small number of
+confirmed false-positive edges (detailed above), `anyhow` loses its three
+self-edges plus five related false positives. Two new regression fixtures
+(self-edge and different-files false-positive shapes) confirmed failing on
+main before this fix.

--- a/packages/parser/src/ast/languages/php.ts
+++ b/packages/parser/src/ast/languages/php.ts
@@ -526,6 +526,12 @@ export const phpDefinition: LanguageDefinition = {
   importExtractor: new PHPImportExtractor(),
   symbolExtractor: new PHPSymbolExtractor(),
 
+  // PSR-4 namespaces are case-insensitive and directory-mirroring -- the one
+  // language `matchesFile`'s Strategy 4 (`matchesPHPNamespace`) is a real
+  // semantic for, not an incidental leniency. See `LanguageDefinition.namespaceStyleImports`'s
+  // doc comment (#1028) for the Rust false-positive this flag now excludes.
+  namespaceStyleImports: true,
+
   complexity: {
     decisionPoints: [
       'if_statement',

--- a/packages/parser/src/ast/languages/registry.ts
+++ b/packages/parser/src/ast/languages/registry.ts
@@ -224,6 +224,19 @@ export function hasDependentAttributionBlindSpot(language: SupportedLanguage): b
 }
 
 /**
+ * True when `language` sets `LanguageDefinition.namespaceStyleImports` (#1028)
+ * -- i.e. its import specifiers use case-insensitive, directory-mirroring
+ * namespaces, the one confirmed real semantic `matchesFile`'s Strategy 4
+ * (`matchesPHPNamespace`) exists for. Only PHP sets this today. See that
+ * flag's own doc comment for the Rust `dtolnay/anyhow` false-positive
+ * (`use crate::{Error}` self-matching `src/error.rs`) this excludes for
+ * every other language.
+ */
+export function hasNamespaceStyleImports(language: SupportedLanguage): boolean {
+  return getLanguage(language).namespaceStyleImports === true;
+}
+
+/**
  * Get all registered language definitions.
  */
 export function getAllLanguages(): readonly LanguageDefinition[] {

--- a/packages/parser/src/ast/languages/types.ts
+++ b/packages/parser/src/ast/languages/types.ts
@@ -211,4 +211,45 @@ export interface LanguageDefinition {
    * shape has been verified against real code.
    */
   sameUnitAccessWithoutImport?: boolean;
+
+  /**
+   * True when this language's import specifiers use case-insensitive,
+   * directory-structure-mirroring namespaces, so `matchesFile`'s Strategy 4
+   * (`matchesPHPNamespace`) is a real, intended semantic for it rather than
+   * an incidental leniency (#1028).
+   *
+   * PHP confirmed: PSR-4 autoloading maps a namespace like `App\Models\User`
+   * onto a file path (`app/Models/User.php`) where the FIRST segment's case
+   * routinely differs from the directory's actual case on disk (Laravel's
+   * `App\` vs. `app/`), and case-insensitive filesystems make this doubly
+   * real. That is a genuine per-language semantic worth its own matching
+   * strategy, unlike `matchesFile`'s other case-sensitive boundary strategies.
+   *
+   * `matchesPHPNamespace` was applied UNCONDITIONALLY to every language
+   * (never gated on this flag, because this flag didn't exist before
+   * #1028) — harmless for the other ten languages' *legitimate* matches
+   * (which all resolve through Strategies 1-3 first, see #1028's own
+   * investigation), but its bare-single-component leniency (added by #883
+   * for an unrelated Swift/Go/Ruby fix — see `matchesPHPNamespace`'s doc
+   * comment) is ALSO case-insensitive, unlike Strategy 2's equivalent
+   * one-leading-segment leniency. On Rust, `use crate::{Error, StdError}`'s
+   * first-wins bare specifier `"Error"` case-insensitively self-matched
+   * `src/error.rs` (a real `dtolnay/anyhow` repro: `chain.rs`/`context.rs`/
+   * `error.rs` each became their own dependent via a self-referential bare
+   * `use crate::X` naming their own type). The same case-insensitivity can
+   * also fabricate an edge between two DIFFERENT files whenever an unrelated
+   * bare specifier happens to share a target's basename modulo case, within
+   * the same one-leading-directory window — not just the self-edge shape.
+   *
+   * Absent/false (the default for every language except PHP) means
+   * `matchesFile` skips Strategy 4 entirely for that language's imports —
+   * see `allowNamespaceMatching` in `../../utils/path-matching.ts` and
+   * `hasNamespaceMatchingSemantics`, the one place this flag is consulted
+   * (mirroring the established `singleFileImports`/#887 and Python/#929
+   * per-language-gate pattern, rather than adding an eighteenth patch to the
+   * shared matcher itself, per #1028's own recommendation). Only set this
+   * where the case-insensitive-namespace-to-directory convention has been
+   * verified against real code.
+   */
+  namespaceStyleImports?: boolean;
 }

--- a/packages/parser/src/dependency-analyzer.test.ts
+++ b/packages/parser/src/dependency-analyzer.test.ts
@@ -988,3 +988,104 @@ describe('Rust mod-derived edges end-to-end (#1021 regression)', () => {
     ).toEqual(['src/engine.rs']);
   });
 });
+
+describe('bare crate-relative `use` edges end-to-end (#1028 regression)', () => {
+  // #1028: `matchesFile`'s Strategy 4 (`matchesPHPNamespace`) was applied
+  // unconditionally to every language, not just PHP. Its bare-single-
+  // component branch is case-INSENSITIVE and allows up to one leading
+  // directory segment (added by #883 for an unrelated Swift/Go/Ruby fix) --
+  // on Rust, this let a bare `use crate::{Error, StdError}` specifier
+  // (the import extractor's "first wins" grouped-use handling, mirroring
+  // Go's own precedent) case-insensitively self-match its own file. Real
+  // `dtolnay/anyhow` repro, parsed through the REAL Rust extractor
+  // (`chunkByAST`) exactly like the #1021 fixtures above, not a hand-built
+  // `imports: [...]` array.
+  const workspaceRoot = '/test/workspace';
+
+  it('fixture 1 (self-edge): a file whose own re-exported type name case-insensitively matches its own basename must not become its own dependent', () => {
+    // Mirrors anyhow's real src/error.rs: `pub(crate) use crate::{Error,
+    // StdError};` extracts the bare "Error" specifier (first-wins), which
+    // case-insensitively collides with this file's own basename ("error").
+    const chunks = chunkByAST(
+      'src/error.rs',
+      'pub(crate) use crate::{Error, StdError};\n\npub(crate) struct ErrorImpl<E = ()> {\n    x: E,\n}\n',
+    );
+
+    expect(analyzeDependencies('src/error.rs', chunks, workspaceRoot).dependents).toEqual([]);
+  });
+
+  it('fixture 2 (different-files false positive): a bare specifier must not fabricate an edge to an unrelated file that merely shares its basename case-insensitively', () => {
+    // src/other.rs's bare `Config` specifier names the type declared in
+    // src/lib.rs -- src/config.rs is a completely unrelated file that
+    // happens to share "config" as its basename. Before #1028, Strategy 4's
+    // case-insensitive, up-to-one-leading-segment leniency fabricated an
+    // edge from src/other.rs to src/config.rs anyway (the same class of bug
+    // as the self-edge above, just between two DIFFERENT files) -- proving
+    // a self-edge guard alone would not have been sufficient.
+    const chunks = [
+      ...chunkByAST('src/lib.rs', 'pub struct Config {\n    pub debug: bool,\n}\n'),
+      ...chunkByAST(
+        'src/other.rs',
+        'use crate::Config;\n\npub fn make() -> Config {\n    Config { debug: false }\n}\n',
+      ),
+      ...chunkByAST('src/config.rs', 'pub fn helper() -> u32 {\n    1\n}\n'),
+    ];
+
+    expect(analyzeDependencies('src/config.rs', chunks, workspaceRoot).dependents).toEqual([]);
+  });
+
+  it('verified boundary: a same-shaped self-reference one directory deeper was never affected (control, unchanged by this fix)', () => {
+    // Issue #1028's own verified boundary: a file directly under ONE
+    // top-level directory is the exact trigger shape (targetComponents.length
+    // <= 2). One level deeper, `matchesPHPNamespace`'s bare-import guard
+    // already rejected the match before this fix (4 target components), so
+    // this fixture pins that this control path stays correct, not that this
+    // fix changed it.
+    const chunks = chunkByAST(
+      'src/deep/nested/error.rs',
+      'pub(crate) use crate::Error;\n\npub(crate) struct ErrorImpl;\n',
+    );
+
+    expect(
+      analyzeDependencies('src/deep/nested/error.rs', chunks, workspaceRoot).dependents,
+    ).toEqual([]);
+  });
+
+  it("#883's own repro stays fixed end-to-end (Swift bare system-framework import must not match an unrelated same-named file)", () => {
+    // #883 fixed this exact shape directly in `matchesPHPNamespace` (the
+    // bare-import ≤2-target-component guard this fix now additionally gates
+    // by language) -- confirms #1028 didn't reopen it for the language #883
+    // was originally protecting.
+    const chunks = [
+      ...chunkByAST('Source/Features/Combine.swift', 'struct Combine {\n}\n'),
+      ...chunkByAST(
+        'Tests/CombineTests.swift',
+        'import Combine\n\nclass CombineTests {\n    func testIt() {}\n}\n',
+      ),
+    ];
+
+    // Swift's whole-module import guard (#884) already suppresses this bare
+    // `import Combine` from ever reaching `matchesFile` for a per-file
+    // relationship -- the honest #869 "not determinable" outcome, not a
+    // match. Either way, it must not resolve to the unrelated file.
+    expect(
+      analyzeDependencies('Source/Features/Combine.swift', chunks, workspaceRoot).dependents,
+    ).toEqual([]);
+  });
+
+  it("PHP's own namespace matching is completely unaffected end-to-end (the language Strategy 4 is a real semantic for)", () => {
+    const chunks = [
+      ...chunkByAST(
+        'Controller.php',
+        '<?php\nnamespace App;\nuse App\\Models\\User;\n\nclass Controller {\n    function index() { return new User(); }\n}\n',
+      ),
+      ...chunkByAST('app/Models/User.php', '<?php\nnamespace App\\Models;\n\nclass User {\n}\n'),
+    ];
+
+    expect(
+      analyzeDependencies('app/Models/User.php', chunks, workspaceRoot).dependents.map(
+        d => d.filepath,
+      ),
+    ).toEqual(['Controller.php']);
+  });
+});

--- a/packages/parser/src/utils/path-matching.test.ts
+++ b/packages/parser/src/utils/path-matching.test.ts
@@ -9,6 +9,7 @@ import {
   importMatchesTarget,
   hasSingleFileImportSemantics,
   hasPythonModuleSemantics,
+  hasNamespaceMatchingSemantics,
 } from './path-matching.js';
 import { markRustModSpecifier } from './rust-mod-marker.js';
 
@@ -206,6 +207,43 @@ describe('matchesFile - Path Boundary Checking', () => {
     it('should NOT apply PHP matching to non-namespace imports', () => {
       // Regular file paths should not use PHP namespace matching
       expect(testMatchesFile('src/models/user', 'src/models/product')).toBe(false);
+    });
+
+    describe('allowNamespaceMatching gate (#1028)', () => {
+      // Real dtolnay/anyhow repro: a Rust bare `use crate::{Error, StdError}`
+      // (first-wins) extracts to the bare specifier "Error", which
+      // case-insensitively self-matches src/error.rs purely via Strategy 4's
+      // bare-import <=2-target-component leniency (added by #883 for an
+      // unrelated Swift fix) -- unrelated to PHP namespace semantics.
+      it("matchesFile alone stays permissive by default (this function stays language-agnostic, mirroring #929's own precedent)", () => {
+        expect(testMatchesFile('Error', 'src/error')).toBe(true);
+      });
+
+      it('allowNamespaceMatching=false disables Strategy 4 entirely, closing the Rust false-positive', () => {
+        expect(matchesFile(normalize('Error'), normalize('src/error'), false, true, false)).toBe(
+          false,
+        );
+      });
+
+      it('allowNamespaceMatching=false does not disturb Strategies 1-3 (a real, case-matching relationship still resolves)', () => {
+        // src/auth.rs's own basename-matching convention (Strategy 2) is
+        // untouched by this gate.
+        expect(matchesFile(normalize('auth'), normalize('src/auth.rs'), false, true, false)).toBe(
+          true,
+        );
+      });
+
+      it('allowNamespaceMatching=true (the default) preserves every existing PHP namespace assertion above', () => {
+        expect(
+          matchesFile(
+            normalize('App\\Models\\User'),
+            normalize('app/Models/User.php'),
+            false,
+            true,
+            true,
+          ),
+        ).toBe(true);
+      });
     });
   });
 
@@ -822,6 +860,50 @@ describe('importMatchesTarget (#886)', () => {
       ).toBe(true);
     });
   });
+
+  describe('#1028 PHP-namespace guard (Rust false-positive exclusion)', () => {
+    // Real dtolnay/anyhow repro at the exact primitive `findDependentChunks`'s
+    // fuzzy loop calls per (chunk, rawSpecifier) entry -- see `matchesFile`'s
+    // doc comment for the full mechanism.
+    it('closes the self-edge shape: a Rust file whose bare `use crate::{Self}` re-export case-insensitively matches its own basename', () => {
+      expect(
+        importMatchesTarget('Error', 'src/error.rs', normalize('src/error.rs'), normalize),
+      ).toBe(false);
+      expect(
+        importMatchesTarget('Context', 'src/context.rs', normalize('src/context.rs'), normalize),
+      ).toBe(false);
+      expect(
+        importMatchesTarget('Chain', 'src/chain.rs', normalize('src/chain.rs'), normalize),
+      ).toBe(false);
+    });
+
+    it('closes the different-files false-positive shape: a bare specifier must not match an unrelated file sharing its basename case-insensitively', () => {
+      // "CONFIG" (e.g. a re-exported constant) must not fabricate an edge to
+      // src/config.rs just because they coincide case-insensitively within
+      // Strategy 4's <=2-target-component window -- Strategy 2's equivalent
+      // leniency is case-SENSITIVE and never produces this false positive.
+      expect(
+        importMatchesTarget('CONFIG', 'src/lib.rs', normalize('src/config.rs'), normalize),
+      ).toBe(false);
+    });
+
+    it('leaves Strategies 1-3 fully intact for a Rust importer (the legitimate case-matching relationship still resolves)', () => {
+      expect(
+        importMatchesTarget('auth', 'src/consumer.rs', normalize('src/auth.rs'), normalize),
+      ).toBe(true);
+    });
+
+    it("PHP's own namespace matching is untouched (the language this guard stays permissive for)", () => {
+      expect(
+        importMatchesTarget(
+          'App\\Models\\User',
+          'Controller.php',
+          normalize('app/Models/User.php'),
+          normalize,
+        ),
+      ).toBe(true);
+    });
+  });
 });
 
 describe('hasPythonModuleSemantics (#929)', () => {
@@ -849,6 +931,24 @@ describe('hasSingleFileImportSemantics (#887)', () => {
 
   it('is false for an importer file in an unrecognized/undetectable language', () => {
     expect(hasSingleFileImportSemantics('README.md')).toBe(false);
+  });
+});
+
+describe('hasNamespaceMatchingSemantics (#1028)', () => {
+  it('is true for a PHP importer file', () => {
+    expect(hasNamespaceMatchingSemantics('app/Http/Controllers/UserController.php')).toBe(true);
+  });
+
+  it('is false for a Rust importer file (the dtolnay/anyhow false-positive this excludes)', () => {
+    expect(hasNamespaceMatchingSemantics('src/error.rs')).toBe(false);
+  });
+
+  it('is false for a Go importer file (the chi middleware/middleware.go false-positive this excludes)', () => {
+    expect(hasNamespaceMatchingSemantics('render/html.go')).toBe(false);
+  });
+
+  it('is false for an importer file in an unrecognized/undetectable language', () => {
+    expect(hasNamespaceMatchingSemantics('README.md')).toBe(false);
   });
 });
 

--- a/packages/parser/src/utils/path-matching.ts
+++ b/packages/parser/src/utils/path-matching.ts
@@ -12,6 +12,7 @@ import {
   detectLanguage,
   hasWholeModuleImports,
   hasSingleFileImports,
+  hasNamespaceStyleImports,
 } from '../ast/languages/registry.js';
 import { hasRustModMarker, stripRustModMarker } from './rust-mod-marker.js';
 
@@ -289,6 +290,21 @@ export function isUnresolvableWholeModuleImport(
  * `findDependentChunks`'s fuzzy loop no longer belongs on this list as of
  * #994 Phase 3).
  *
+ * Strategy 4 has the identical per-language shape (#1028): `matchesPHPNamespace`
+ * is a real semantic for PHP's case-insensitive, directory-mirroring PSR-4
+ * namespaces, but `matchesFile` used to run it unconditionally for every
+ * language too. Its bare-single-component branch's case-insensitivity (added
+ * by #883 for an unrelated Swift fix) let a Rust bare `use crate::{Error}`
+ * specifier (the import extractor's "first wins" grouped-use handling)
+ * case-insensitively self-match `src/error.rs` on a real `dtolnay/anyhow`
+ * clone -- confirmed for three files (`chain.rs`/`context.rs`/`error.rs`),
+ * each via a self-referential `pub(crate) use crate::Self type;` naming its
+ * own type. See `allowNamespaceMatching` and `importMatchesTarget`, the only
+ * caller that derives it from the importer's language via
+ * `hasNamespaceMatchingSemantics`. Every other caller passes the default
+ * (`true`), preserving this function's pre-#1028 behavior exactly, mirroring
+ * `allowPythonModuleMatching`'s own scoping precedent immediately above.
+ *
  * @param normalizedImport - Normalized import path
  * @param normalizedTarget - Normalized target file path
  * @param requireExactTailForMultiSegment - When true, a multi-segment bare
@@ -300,6 +316,11 @@ export function isUnresolvableWholeModuleImport(
  *   matching) is skipped entirely. Defaults to `true` (this function's
  *   pre-#929 behavior); `importMatchesTarget` passes `false` for any
  *   non-Python importer -- see the doc comment above.
+ * @param allowNamespaceMatching - When false, Strategy 4 (PHP namespace
+ *   matching) is skipped entirely. Defaults to `true` (this function's
+ *   pre-#1028 behavior); `importMatchesTarget` passes `false` for any
+ *   importer whose language doesn't set `namespaceStyleImports` -- see the
+ *   doc comment above.
  * @returns True if the import matches the target file
  */
 export function matchesFile(
@@ -307,6 +328,7 @@ export function matchesFile(
   normalizedTarget: string,
   requireExactTailForMultiSegment = false,
   allowPythonModuleMatching = true,
+  allowNamespaceMatching = true,
 ): boolean {
   // Exact match
   if (normalizedImport === normalizedTarget) return true;
@@ -352,7 +374,7 @@ export function matchesFile(
 
   // Strategy 4: PHP namespace matching
   // PHP imports use namespaces like "App\Models\User" which should match "app/Models/User.php"
-  if (matchesPHPNamespace(normalizedImport, normalizedTarget)) {
+  if (allowNamespaceMatching && matchesPHPNamespace(normalizedImport, normalizedTarget)) {
     return true;
   }
 
@@ -399,7 +421,7 @@ function matchesRustModSpecifier(normalizedImport: string, normalizedTarget: str
  * The single guarded import-matching decision: does `importSpecifier` (as
  * written in `importerFile`) resolve to `normalizedTarget`?
  *
- * Couples four guards to `matchesFile` so neither can drift apart from a
+ * Couples five guards to `matchesFile` so neither can drift apart from a
  * match-side call site again:
  * - The #884 whole-module guard (`isUnresolvableWholeModuleImport`) --
  *   `matchesFile` is language-agnostic and cannot know the importer's
@@ -418,15 +440,22 @@ function matchesRustModSpecifier(normalizedImport: string, normalizedTarget: str
  *   a Python identifier shape (see `matchesFile`'s doc comment for the real
  *   hono/TypeScript repro). Derived from the importer's language the same
  *   way as the #887 guard, at this same call site.
+ * - The #1028 PHP-namespace guard (`allowNamespaceMatching`) --
+ *   `matchesFile`'s Strategy 4 is a real PHP PSR-4 semantic, but a false hub
+ *   for any other language whose resolved bare/qualified specifier
+ *   case-insensitively coincides with a target's basename (see `matchesFile`'s
+ *   doc comment for the real `dtolnay/anyhow` Rust self-edge repro). Derived
+ *   from the importer's language via `hasNamespaceMatchingSemantics`, the
+ *   same way as the #887/#929 guards, at this same call site.
  * - The #1021 Rust-mod single-file guard (`hasRustModMarker`) -- unlike the
- *   other three, this is derived from the SPECIFIER, not the importer's
+ *   other four, this is derived from the SPECIFIER, not the importer's
  *   language: a single Rust file can have both a `mod x;` (needs
  *   `matchesRustModSpecifier`'s strict semantics) and a `use crate::y;`
  *   (needs `matchesFile`'s existing leniency) among its own imports, so a
  *   per-language flag can't disambiguate between two entries in the same
- *   file's import list the way it can for #887/#929. When present, this
- *   guard short-circuits entirely -- `matchesFile` never runs at all for a
- *   marked specifier.
+ *   file's import list the way it can for #887/#929/#1028. When present,
+ *   this guard short-circuits entirely -- `matchesFile` never runs at all
+ *   for a marked specifier.
  *
  * Every match-side reverse-dependency call path that used to open-code
  * `!isUnresolvableWholeModuleImport(imp, f) && matchesFile(normalize(imp), t)`
@@ -486,6 +515,7 @@ export function importMatchesTarget(
     normalizedTarget,
     hasSingleFileImportSemantics(importerFile),
     hasPythonModuleSemantics(importerFile),
+    hasNamespaceMatchingSemantics(importerFile),
   );
 }
 
@@ -519,6 +549,24 @@ export function hasSingleFileImportSemantics(importerFile: string): boolean {
  */
 export function hasPythonModuleSemantics(importerFile: string): boolean {
   return detectLanguage(importerFile) === 'python';
+}
+
+/**
+ * True when `importerFile`'s language sets `LanguageDefinition.namespaceStyleImports`
+ * (PHP today) -- see that flag's doc comment for the case-insensitive
+ * PSR-4-vs-Rust distinction this drives (#1028). Unlike `hasPythonModuleSemantics`
+ * above, this IS backed by a `LanguageDefinition` flag, mirroring
+ * `hasSingleFileImportSemantics`: `matchesPHPNamespace`'s case-insensitive,
+ * directory-mirroring semantic is a genuine per-language toggle another
+ * language's own namespace convention could legitimately opt into later,
+ * unlike Python's dotted-module parsing. Shared by `importMatchesTarget`'s
+ * `allowNamespaceMatching` argument -- see `matchesFile`'s doc comment for
+ * the false-hub (a Rust bare `use crate::{Error}` self-matching
+ * `src/error.rs`) this guards against.
+ */
+export function hasNamespaceMatchingSemantics(importerFile: string): boolean {
+  const language = detectLanguage(importerFile);
+  return language !== null && hasNamespaceStyleImports(language);
 }
 
 /**
@@ -668,6 +716,14 @@ function matchesPythonModule(importPath: string, targetPath: string): boolean {
  *
  * Also useful for case-insensitive file systems.
  *
+ * Only ever reached for a PHP importer as of #1028 (see `allowNamespaceMatching`
+ * on `matchesFile` and `hasNamespaceMatchingSemantics`) -- this function's own
+ * case-insensitivity is exactly what made it unsafe to run unconditionally for
+ * every language: a Rust bare `use crate::{Error}` specifier case-insensitively
+ * self-matched `src/error.rs` on a real `dtolnay/anyhow` clone, a false
+ * positive Strategy 2's equivalent (case-SENSITIVE) one-leading-segment
+ * leniency never produces.
+ *
  * A single-component (bare) importPath is the same ambiguous case
  * `matchesAtBoundaryPrecise` (above) guards for `matchesFile`'s strategies
  * 1/2: on its own it doesn't name a specific file, so matching it against the
@@ -675,7 +731,11 @@ function matchesPythonModule(importPath: string, targetPath: string): boolean {
  * directory" limit -- otherwise a bare `import Combine` (system framework)
  * would match `Source/Features/Combine.swift` purely because the basenames
  * coincide, exactly like the multi-segment case this function otherwise
- * guards against.
+ * guards against. (That specific Swift shape is now additionally excluded
+ * by the #1028 gate above, since Swift doesn't set `namespaceStyleImports`
+ * either -- but the guard stays, since this function is still reachable
+ * directly by `matchesFile`'s other callers, which default
+ * `allowNamespaceMatching` to `true`.)
  *
  * @param importPath - The normalized import path
  * @param targetPath - The normalized file path


### PR DESCRIPTION
Fixes #1028.

## The bug

`matchesFile`'s Strategy 4 (`matchesPHPNamespace`, `packages/parser/src/utils/path-matching.ts`) is a case-insensitive, directory-mirroring matcher intended for PHP's PSR-4 namespace convention, but it ran **unconditionally for every language**. Its bare-single-component leniency (added by #883/`0867ea37` for an unrelated Swift/Go/Ruby fix) allows a bare specifier to match a target with at most one leading directory segment — but unlike Strategy 2's equivalent (case-sensitive) leniency, this one is case-insensitive.

On Rust, `src/error.rs`'s own `use crate::{Error, StdError};` extracts (via the import extractor's "first wins" grouped-use handling) to the bare specifier `"Error"`, which case-insensitively self-matches `src/error.rs`. `chain.rs` and `context.rs` self-match the same way via their own `pub(crate) use crate::{Self};` re-exports.

## The fix

Added `LanguageDefinition.namespaceStyleImports` (set only for PHP) and threaded a new `allowNamespaceMatching` parameter through `matchesFile`, exactly mirroring the two existing per-language gates on this same function: `singleFileImports` (#887) and the Python-bare-module guard (#929). `importMatchesTarget` — the single primitive every match-side caller (`get_dependents`, test-associations, review's dependency graph, etc.) already routes through — derives it from the importer's language via the new `hasNamespaceMatchingSemantics`. PHP keeps Strategy 4 exactly as before; every other language now skips it entirely.

`matchesFile` itself still defaults the new parameter to `true`, preserving raw/direct-caller behavior unchanged (mirroring `allowPythonModuleMatching`'s own precedent) — the real fix lives at the `importMatchesTarget` layer, the one place a language is actually known.

I considered the alternative (a self-edge guard only) and rejected it per the issue's own reasoning: the same case-insensitive leniency fabricates edges between different files too (see the Express/Go findings below), so a self-edge-only patch would leave that class of bug live.

## Verification

### 1. `dtolnay/anyhow` — full before/after table

Self-edges gone; only 5 other entries changed, all removed for the identical case-insensitivity reason (detailed below), nothing else moved.

```
file                    before deps                                                          after deps
src/chain.rs            [chain.rs, error.rs, fmt.rs, lib.rs]                                  [error.rs, fmt.rs, lib.rs]
src/context.rs          [context.rs, lib.rs]                                                  [lib.rs]
src/error.rs            [context.rs, ensure.rs, error.rs, fmt.rs, kind.rs, lib.rs,             [context.rs, fmt.rs, lib.rs]
                         tests/test_autotrait.rs, tests/test_downcast.rs, tests/test_repr.rs]
(all other 37 files)    unchanged                                                             unchanged
```

Aggregate: `files=40 totalEdges=35→27 selfEdgeCount=3→0`.

The 5 non-self entries removed from `error.rs`'s dependents (`ensure.rs`, `kind.rs`, `tests/test_autotrait.rs`, `tests/test_downcast.rs`, `tests/test_repr.rs`) all resolved solely via a bare `Error`/`anyhow::Error` specifier matching `src/error` case-insensitively — and it turns out that edge was **already wrong**, not just coincidentally case-insensitive: the real `pub struct Error` is declared in `lib.rs` (line 390), not `error.rs` (which only holds the private `ErrorImpl`/`ContextError`). Strategy 2 (case-sensitive) never credited these because of the case mismatch; only Strategy 4 did. Removing it produces an *honest* zero rather than a wrong file.

Every other real edge into/out of `error.rs`/`chain.rs`/`context.rs` (via lowercase, case-matching qualified specifiers like `crate::error::ContextError` → indexed bare key `"error"`, or the `mod`-marker mechanism from #1021) is untouched — those go through Strategies 1-3, never Strategy 4.

### 2. Nested-file control (issue's own verified boundary)

Added as `dependency-analyzer.test.ts`'s "verified boundary" fixture: `src/deep/nested/error.rs` with `pub(crate) use crate::Error;` — 4 target path components, already rejected by `matchesPHPNamespace`'s own `targetComponents.length <= 2` guard before this fix, and still correctly resolves to zero dependents after. Unaffected either way, confirming the fix targets exactly the reported shape.

### 3. #883's own cases still pass

Ran the full existing `path-matching.test.ts` suite (all pre-existing Go/Ruby/Swift #868/#883/#887 fixtures, 151 tests) — all green, unchanged. None of those three languages' *passing* assertions actually depend on Strategy 4 to reach their correct answer — they're resolved by Strategies 1-3 (verified by hand-tracing each one). The **one** #883 case that does exercise Strategy 4 directly — `Combine` (bare, Swift system framework) must not match `Source/Features/Combine.swift` — is re-asserted end-to-end in the new `dependency-analyzer.test.ts` describe block (`"#883's own repro stays fixed end-to-end"`) and still passes (via Swift's separate #884 whole-module guard, unaffected by this change).

### 4. Full corpus sweep (before → after, `totalEdges` / `selfEdgeCount`)

| Project | Language | Before | After | Notes |
|---|---|---|---|---|
| requests | python | 353 / 6 self | 353 / 6 self | byte-identical (self-edges are a pre-existing, unrelated Strategy-5/Python mechanism, out of scope) |
| zod | typescript | 1270 / 0 | 1270 / 0 | byte-identical |
| express | javascript | 2924 / 23 self | 2920 / 23 self | **-4**: `test/Router.js` incorrectly listed `lib/application.js`/`lib/express.js`/2 examples as dependents — all via `require('router')` (an *external npm package*) case-insensitively matching the project's own test file. Confirmed false positive, not a real relationship (`test/Router.js` is a pure Mocha spec, no exports) |
| **monolog** | **php** | **405 / 0** | **405 / 0** | **byte-for-byte identical** (full JSON diff, not just the count) — the language this heuristic is *for* |
| anyhow | rust | 35 / 3 self | 27 / 0 | the reported bug — see table above |
| chi | go | 20 / 0 | 11 / 0 | **-9**: `middleware/middleware.go` alone (not its sibling files in the same package) was credited with 9 dependents via a package-qualified `middleware` import colliding with its own basename == directory name. Confirmed false positive — every sibling file in the same package correctly shows zero, this one was a coincidental outlier |
| javapoet | java | 0 / 0 | 0 / 0 | known gap (#1005), unaffected |
| mediatr | csharp | 578 / 0 | 578 / 0 | byte-identical |
| sinatra | ruby | 109 / 0 | 109 / 0 | byte-identical |
| klaxon | kotlin | 0 / 0 | 0 / 0 | known gap (#1005), unaffected |
| swiftyjson | swift | 0 / 0 | 0 / 0 | known gap (#1005), unaffected |

Full JSON diffs (not just aggregate counts) were taken for every project in the table; `requests`/`zod`/`monolog`/`mediatr`/`sinatra`/`javapoet`/`klaxon`/`swiftyjson` are exact-byte-identical, `express`/`chi`/`anyhow` diffs are exactly the entries called out above and nothing else. Methodology: indexed each project once, then computed `findDependents` twice against the same chunks — once with the fix's 4 files reverted to `HEAD` (`git checkout HEAD -- <files>` + parser rebuild), once restored — so any diff is attributable solely to this change, not re-indexing noise.

### 5. Regression fixtures, confirmed failing on main first

Added to `packages/parser/src/dependency-analyzer.test.ts` (new describe block, real `chunkByAST` extraction, not hand-built `imports` arrays) and `packages/parser/src/utils/path-matching.test.ts` (unit-level `matchesFile`/`importMatchesTarget`/`hasNamespaceMatchingSemantics` assertions):
- Self-edge shape (mirrors anyhow's real `src/error.rs`)
- Different-files false-positive shape (`src/other.rs`'s `Config` must not fabricate an edge to unrelated `src/config.rs`, mirroring the chi/express findings above)
- Nested-file boundary control (unaffected either way)
- PHP end-to-end (unaffected)

Reverted the 4 fix files to `HEAD` and reran: **9 new assertions failed exactly as expected** (self-edge / different-files / gate-parameter / `hasNamespaceMatchingSemantics` tests); all pre-existing control fixtures stayed green. Restored the fix: all 206 tests in these two files pass.

## Gates

```
npm run format:check   # pass
npm run lint           # pass (0 errors, only pre-existing warnings)
npm run typecheck      # pass
npm run build          # pass
npm test               # pass (parser 206/206 incl. new fixtures, core, review, cli non-e2e, action — all green)
lien delta             # exit 0 (2 "worsened" advisories, no new-over-threshold crossings)
```

Plus the requested language E2E suites, all against fresh real clones:
```
npm run test:e2e:rust  -w packages/cli   # 16/16 pass, dependency stats: 27 edges (matches the table above)
npm run test:e2e:php   -w packages/cli   # 16/16 pass, dependency stats: 163/232 edges swept
npm run test:e2e:go    -w packages/cli   # 16/16 pass, dependency stats: 11 edges (matches the table above)
npm run test:e2e:ruby  -w packages/cli   # 16/16 pass, dependency stats: 96/170 edges swept
```

Changeset added (`@liendev/parser`, patch).

## Dogfood

The verification above **is** the dogfood: this is a `findDependents`/parser-internals change with no CLI-surface UX, so "exercise the change the way its real consumer experiences it" means running `get_dependents`'s exact production entry point (`findDependents`, via the E2E harness's `countDependents`/`computeDependencyStats` helpers *and* a standalone verification script) against real, freshly-cloned OSS repos — which is what sections 1 and 4 above are — rather than a synthetic-only check.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR gates `matchesFile`'s Strategy 4 (PHP-style namespace matching) by importer language, fixing false-positive dependency edges for non-PHP languages like Rust, Go, and JavaScript. It adds an optional `namespaceStyleImports` flag to `LanguageDefinition` (set only for PHP), threads `allowNamespaceMatching` through `matchesFile` with a default of `true` to preserve direct-caller behavior, and derives the flag in `importMatchesTarget` via the new `hasNamespaceMatchingSemantics` helper. The change mirrors the existing `singleFileImports`/`allowPythonModuleMatching` gating pattern, is backwards-compatible, and is extensively covered by new regression fixtures.
>
> - Added `LanguageDefinition.namespaceStyleImports` (PHP-only) and `hasNamespaceStyleImports`/`hasNamespaceMatchingSemantics` helpers.
> - Added `allowNamespaceMatching` parameter to `matchesFile`, defaulting to `true`; `importMatchesTarget` now passes `false` for all non-PHP importers.
> - Added end-to-end and unit regression tests for Rust self-edges, cross-file false positives, nested-file boundary control, Swift #883 repro, and PHP preservation.

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 11c101b. Updates automatically on new commits.</sup>
<!-- /lien-stats -->