### PR TITLE
fix: distinguish complexity risk from blast-radius risk; fix annotate's dependent population

### DIFF
--- a/.changeset/two-risk-concepts-and-population-parity.md
+++ b/.changeset/two-risk-concepts-and-population-parity.md
@@ -1,0 +1,41 @@
+---
+"@liendev/core": patch
+"@liendev/lien": patch
+---
+
+Fixes two confirmed defects where `riskLevel` disagreed for the same file at
+the same moment (CLI-4/REVIEW-6/#1017), plus a related population-parity bug
+found while investigating (HOOKS-2).
+
+**CLI-4/REVIEW-6 — `get_complexity`/`lien complexity` computed a genuinely
+different concept than `get_dependents`/`lien annotate`/`lien api-delta`,
+under the identical field name `riskLevel`.** The two are legitimately
+different questions — "how risky is this file's own complexity" (own
+violation severity, boosted but never downgraded by dependent count/
+complexity, no test-coverage term at all) vs "how risky is changing this
+file given who depends on it" (blast-radius risk: dependent breadth plus
+untested-dependent count, with a complexity floor) — so the fix renames
+rather than merges: `lien complexity --format json` and `get_complexity`'s
+`violations[]` now report `complexityRiskLevel` instead of `riskLevel`.
+`lien complexity`'s text output now prints "Complexity risk:" instead of
+bare "Risk:". `get_dependents`/`lien annotate`/`lien api-delta` are
+unchanged — they keep `riskLevel` for blast-radius risk. Both concepts are
+now documented side by side, with the divergence pinned by a dedicated test,
+in `docs/architecture/blast-radius-nudge.md`'s new "Two risk concepts"
+section.
+
+**HOOKS-2 — `lien annotate` fed the wrong population into blast-radius
+risk.** `get_dependents`/`lien api-delta` compute risk from
+`productionDependentCount` (test files calling the target don't weigh into
+risk the same way production callers do); `lien annotate` fed the wider
+`dependents.length` (production + test) instead — an internal mismatch too,
+since it already used the narrower `uncoveredProductionDependents` for the
+untested count in the same call. A file with many test-only importers and
+few production ones could read riskier from `lien annotate` than from
+`get_dependents` for the identical file at the identical moment. Fixed by
+feeding `productionDependentCount` into `lien annotate`'s risk computation
+too, and relabeling the "N callers" reasoning entry as "N production
+callers" (shared `relabelCallerReasoning`, used by both `get_dependents` and
+`lien annotate` — one implementation instead of two that can drift again).
+The displayed dependents list and count are unchanged (still the wider
+production + test total, sorted production-first).

--- a/docs/architecture/blast-radius-nudge.md
+++ b/docs/architecture/blast-radius-nudge.md
@@ -11,6 +11,50 @@ in CLAUDE.md that was still honor-system: "run `get_dependents` before changing
 the signature of an exported symbol." Within its covered shapes it's a nudge for
 that rule, not a complete enforcement of it.
 
+## Two risk concepts — read this before assuming every `riskLevel` agrees
+
+Lien computes **two genuinely different things** and, until CLI-4/REVIEW-6 were
+fixed, both were exposed under the identical field name `riskLevel`. They answer
+different questions, are computed by different formulas over different inputs,
+and are **expected to disagree** for the same file at the same moment. Treat
+that as a documented property, not a bug to chase — see
+`packages/parser/src/insights/complexity-vs-blast-radius-risk.test.ts`, which
+pins concrete cases where they diverge in both directions.
+
+| | **Complexity risk** (`get_complexity`/`lien complexity`) | **Blast-radius risk** (this doc's subject) |
+|---|---|---|
+| Question answered | "How risky is this file's own complexity?" | "How risky is *changing* this file, given who depends on it?" |
+| Field name | `complexityRiskLevel` (`lien complexity --format json`'s `files[x].complexityRiskLevel`; `get_complexity`'s `violations[].complexityRiskLevel`) | `riskLevel` (`get_dependents`, `lien annotate`, `lien api-delta`) |
+| Formula | `max(calculateRiskLevel(own violations' severity), calculateRiskLevelFromCount(dependentCount) boosted by dependents' complexity)` — a **ceiling that only ever rises**, never falls | `computeBlastRadiusRisk`: dependent breadth + untested-dependent count, with a complexity **floor** (one tier below `complexityRiskBoost`, never a ceiling) |
+| Test coverage of dependents | **Not a term in the formula at all** | Central: an untested dependent escalates risk; full coverage lowers it (but never below the complexity floor) |
+| Implementation | `packages/parser/src/insights/chunk-complexity.ts` (`calculateRiskLevel`, `enrichWithDependencies`) + `packages/parser/src/dependency-analyzer.ts` (`calculateRiskLevelFromCount`, `calculateComplexityRiskBoost`) | `packages/parser/src/risk/blast-radius-risk.ts` (`computeBlastRadiusRisk`) |
+| Internal type field | `FileComplexityData.riskLevel` (`packages/parser/src/insights/types.ts`) — kept as-is internally; renamed only at the `get_complexity`/`lien complexity --format json` output boundary, since that's where the same-named collision was actually observed | n/a |
+
+**Why the rename (not a formula merge).** Reading both implementations: these
+are legitimately different concepts, not one concept computed two
+inconsistent ways. Collapsing them into one formula would lose information —
+"this function's cyclomatic complexity is already over threshold" and "three
+of your five callers have no tests" are both real, independent signals a
+change author needs, and neither should silently override the other. The
+fix is the name collision, not the formula difference: `get_complexity`'s
+field is `complexityRiskLevel`; the three surfaces below keep `riskLevel` for
+blast-radius risk.
+
+**This can't silently re-converge (or re-diverge) unnoticed:**
+
+- The two-concepts comparison above is pinned by a test
+  (`complexity-vs-blast-radius-risk.test.ts`) that computes both formulas
+  against the same fixtures and asserts they land on *different* levels — if
+  a future change makes either formula start agreeing with the other on
+  those fixtures, that test fails and must be consciously updated (and this
+  table re-read), rather than drifting unnoticed.
+- Within blast-radius risk itself, all three surfaces (`get_dependents`,
+  `lien annotate`, `lien api-delta`) must feed `computeBlastRadiusRisk` the
+  **same population** — production dependents only, never production + test
+  — see "Enrichment: dependent counts and risk, best-effort" below for the
+  HOOKS-2 fix that made `lien annotate` match the other two, and why
+  production-only is the correct population.
+
 ## Motivation
 
 CLAUDE.md has had two "before you touch an exported symbol" rules for a while.
@@ -155,11 +199,34 @@ Only runs when at least one change was found (the rare event, so the common
 edit — no exported-signature change — pays only the cheap content check and
 never touches the index). For each changed symbol, calls the existing
 `findDependents(vectorDB, filepath, log, symbolName, indexVersion)` and composes
-a risk level via the shared `computeBlastRadiusRisk` primitive — the same two
-calls `get_dependents` and `annotate-read.sh` already make. `indexVersion` is
-captured once (`vectorDB.getCurrentVersion()`) so every symbol in one run shares
-`findDependents`'s internal scan cache — only the first symbol in a file pays
-the `scanAll`.
+a risk level via the shared `computeBlastRadiusRisk` primitive — the same
+primitive `get_dependents` and `lien annotate` compose their own risk from.
+`indexVersion` is captured once (`vectorDB.getCurrentVersion()`) so every
+symbol in one run shares `findDependents`'s internal scan cache — only the
+first symbol in a file pays the `scanAll`.
+
+**Population parity across all three surfaces (HOOKS-2).** Sharing
+`computeBlastRadiusRisk` is not sufficient for the three surfaces to agree —
+they must also feed it the *same* `dependentCount`. `get_dependents` and
+`lien api-delta` always have (`productionDependentCount`, excluding test
+files: a test importing the target isn't the same risk as production code
+importing it). `lien annotate` did not: until this fix it fed the WIDER
+`dependents.length` (production + test) into `computeBlastRadiusRisk` while
+already using the narrower `uncoveredProductionDependents` for the untested
+count in the same call — an internal mismatch as well as a cross-surface
+one. A file with many test-only importers and few or no production ones
+could come back a *higher* risk from `lien annotate` than `get_dependents`
+reported for the identical file at the identical moment (confirmed live:
+`lien annotate` read `risk: medium (8 callers, ...)` while `get_dependents`
+read `riskLevel: "low"` / `productionDependentCount: 2` for the same file,
+same index, same moment). Fixed by feeding `productionDependentCount` into
+`lien annotate`'s `computeBlastRadiusRisk` call too, and relabeling the
+reasoning's generic "N callers" entry as "N production callers" (shared
+`relabelCallerReasoning` in `packages/cli/src/utils/blast-radius-reasoning.ts`,
+used by both `get_dependents` and `lien annotate` — one implementation, not
+two copies that can drift again) so the wider dependents list this command
+also prints (production + test, sorted production-first) is never confused
+with the narrower count driving the risk verdict.
 
 **Graceful degrade**, in two layers:
 

--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -607,6 +607,7 @@ describe('annotateCommand (integration)', () => {
   let errSpy: ReturnType<typeof vi.spyOn>;
   let tmpHome: string;
   let homeSpy: ReturnType<typeof vi.spyOn>;
+  let originalLienHome: string | undefined;
 
   beforeEach(async () => {
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
@@ -615,6 +616,21 @@ describe('annotateCommand (integration)', () => {
     const fs = await import('fs/promises');
     tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-annotate-test-'));
     homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(tmpHome);
+    // Pre-existing test-isolation bug (found while rebasing this PR, unrelated
+    // to it — reproduces identically on main with zero code changes, and in
+    // real CI: getLienHome() is `process.env.LIEN_HOME || os.homedir()`, and
+    // vitest's own `global-setup.ts` already sets `LIEN_HOME` to ONE shared
+    // temp dir for the ENTIRE test run. That env var wins over the
+    // `os.homedir()` mock above, so every check that resolves the index dir
+    // via `getLienHome()` (this block's own `hasStructuralIndex` restoration
+    // below, and `resolveProjectRoot`'s `hasCompletedIndex`) was silently
+    // reading the SHARED run-wide home instead of this test's own pristine
+    // one -- polluted by any other test in the same run that legitimately
+    // indexes this repo's real root under that shared home. Redirecting
+    // `LIEN_HOME` itself (not just `os.homedir()`) gives this block the
+    // per-test isolation its own comment already claimed to provide.
+    originalLienHome = process.env.LIEN_HOME;
+    process.env.LIEN_HOME = tmpHome;
     // This block specifically exercises the real "never indexed" path (an
     // empty tmp home has no structural.db) — restore the real
     // `hasStructuralIndex` here instead of the file-wide `true` default.
@@ -631,6 +647,8 @@ describe('annotateCommand (integration)', () => {
     logSpy.mockRestore();
     errSpy.mockRestore();
     homeSpy.mockRestore();
+    if (originalLienHome === undefined) delete process.env.LIEN_HOME;
+    else process.env.LIEN_HOME = originalLienHome;
     vi.mocked(indexFreshnessModule.hasStructuralIndex).mockResolvedValue(true);
     await fs.rm(tmpHome, { recursive: true, force: true });
   });

--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -834,6 +834,90 @@ describe('annotateCommand — plan-time nudge (integration)', () => {
   });
 });
 
+describe('annotateCommand — blast-radius population parity (HOOKS-2, integration)', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  // Same stable target as the plan-time-nudge block above.
+  const target = 'packages/cli/src/cli/index.ts';
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    vi.mocked(coreModule.createVectorDB).mockClear();
+  });
+
+  function importerChunk(file: string, imports: string[]) {
+    return {
+      content: '',
+      metadata: {
+        file,
+        startLine: 1,
+        endLine: 5,
+        type: 'function',
+        language: 'typescript',
+        symbolName: 'fn',
+        symbolType: 'function',
+        imports,
+      },
+      score: 0,
+      relevance: 'not_relevant',
+    };
+  }
+
+  // Regression for HOOKS-2: `lien annotate` used to feed `dependents.length`
+  // (production + test) into `computeBlastRadiusRisk` instead of
+  // `productionDependentCount` (what `get_dependents`/`lien api-delta` feed).
+  // 2 production dependents (both individually test-covered, so
+  // uncoveredProductionDependents is 0) + 6 dependents that are themselves
+  // test files gives `dependents.length === 8` but `productionDependentCount
+  // === 2` -- the pre-fix bug fed 8 into `classifyLevel` (>5 -> "medium");
+  // the fix feeds 2 (<=5, 0 uncovered -> "low"). A file with many test-only
+  // importers and few production ones must not read riskier than it is.
+  it('computes risk from productionDependentCount, not the wider dependents.length', async () => {
+    // `findDependents` only searches for importers once the target itself
+    // resolves to a real chunk in the scanned universe (`targetIndexed`) --
+    // without this, it fails closed to zero dependents regardless of any
+    // import edges pointing at it.
+    const targetChunk = importerChunk(target, []);
+    const prod1 = importerChunk('src/prodCaller1.ts', [target]);
+    const prod1Test = importerChunk('src/prodCaller1.test.ts', ['src/prodCaller1.ts']);
+    const prod2 = importerChunk('src/prodCaller2.ts', [target]);
+    const prod2Test = importerChunk('src/prodCaller2.test.ts', ['src/prodCaller2.ts']);
+    const testOnlyCallers = Array.from({ length: 6 }, (_, i) =>
+      importerChunk(`src/testCaller${i}.test.ts`, [target]),
+    );
+    const allChunks = [targetChunk, prod1, prod1Test, prod2, prod2Test, ...testOnlyCallers];
+
+    vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      hasData: vi.fn().mockResolvedValue(true),
+      scanAll: vi.fn().mockResolvedValue(allChunks),
+    } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
+
+    await annotateCommand(target);
+
+    expect(errSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const printed = logSpy.mock.calls[0][0] as string;
+
+    // The displayed dependents count stays the WIDER total (production +
+    // test) -- that part is unchanged and correct.
+    expect(printed).toContain('8 files import this');
+    // But the risk verdict and its reasoning are scoped to PRODUCTION
+    // dependents only, matching get_dependents/lien api-delta.
+    expect(printed).toContain('risk: low');
+    expect(printed).toContain('2 production callers');
+    expect(printed).not.toContain('risk: medium');
+    expect(printed).not.toContain('8 callers');
+  });
+});
+
 describe('annotateCli (CLI exit-code contract, #978)', () => {
   let logSpy: ReturnType<typeof vi.spyOn>;
   let errSpy: ReturnType<typeof vi.spyOn>;

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -29,6 +29,7 @@ import {
   formatComplexityHeadroomWarning,
 } from '../mcp/handlers/get-files-context.js';
 import { findUnindexedPaths, formatUnindexedPathsNote } from '../mcp/utils/unindexed-paths.js';
+import { relabelCallerReasoning } from '../utils/blast-radius-reasoning.js';
 import { resolveProjectRoot } from './project-root.js';
 import { type AbsolutePath, type RelativePath, toAbsolutePath } from '../types/paths.js';
 import { canonicalizePath } from '../utils/canonicalize-path.js';
@@ -462,8 +463,22 @@ async function computeAnnotationData(
     allChunks,
     rootDir,
   );
+  // HOOKS-2: this used to feed `result.dependents.length` (production + test)
+  // in here while `uncoveredDependents` below was already production-only
+  // (`uncoveredProductionDependents`) -- an internal mismatch, and a
+  // cross-surface one too, since `get_dependents`/`api-delta` both feed
+  // `productionDependentCount` (a test file calling the target shouldn't
+  // weigh into blast-radius risk the same way a production caller does,
+  // #928). A file with many test-only importers and few/no production ones
+  // could come back a HIGHER risk here than `get_dependents` reported for
+  // the identical file at the identical moment. `productionDependentCount`
+  // matches the other two blast-radius surfaces; `relabelCallerReasoning`
+  // below then makes that scoping explicit in the printed reasoning, the
+  // same way `get_dependents` already does, since the displayed dependents
+  // list (`formatDependents`, below) intentionally stays the WIDER
+  // production+test total.
   const risk = computeBlastRadiusRisk({
-    dependentCount: result.dependents.length,
+    dependentCount: result.productionDependentCount,
     uncoveredDependents: result.uncoveredProductionDependents,
     // Dependents' max complexity feeds the blast-radius risk score. The
     // target file's own complexity (`complexity.max`) is reported
@@ -472,6 +487,10 @@ async function computeAnnotationData(
     hasHighComplexityUncovered,
     complexityRiskBoost: result.complexityMetrics.complexityRiskBoost,
   });
+  const relabeledRisk: BlastRadiusRisk = {
+    ...risk,
+    reasoning: relabelCallerReasoning(risk.reasoning),
+  };
 
   return {
     allChunks,
@@ -483,7 +502,7 @@ async function computeAnnotationData(
     csharpTypeReferenceTests,
     complexity,
     headroom,
-    risk,
+    risk: relabeledRisk,
   };
 }
 

--- a/packages/cli/src/mcp/handlers/get-complexity.ts
+++ b/packages/cli/src/mcp/handlers/get-complexity.ts
@@ -25,6 +25,20 @@ interface ProcessedViolations {
 
 /**
  * Transform a violation with file-level metadata for API response.
+ *
+ * `complexityRiskLevel` (renamed from `riskLevel` — CLI-4/REVIEW-6) is
+ * `FileComplexityData.riskLevel`: the file's own complexity severity, boosted
+ * (never downgraded) by dependent count/complexity — see that field's doc
+ * comment in `@liendev/parser`'s `insights/types.ts`. It is a DIFFERENT
+ * metric from `get_dependents`/`lien annotate`/`lien api-delta`'s
+ * `riskLevel` (blast-radius risk, `computeBlastRadiusRisk` in
+ * `@liendev/parser`'s `risk/blast-radius-risk.ts`), which weighs dependents'
+ * test coverage and applies a complexity floor instead of a ceiling-less
+ * boost. The two can disagree for the same file at the same moment by
+ * design — see docs/architecture/blast-radius-nudge.md's "Two risk
+ * concepts" section. Do not rename this back to `riskLevel`: that name
+ * collision, observed side-by-side across `get_complexity` and the other
+ * three surfaces, is the exact defect this rename fixes.
  */
 function transformViolation(v: ComplexityViolation, fileData: FileComplexityData) {
   return {
@@ -40,7 +54,7 @@ function transformViolation(v: ComplexityViolation, fileData: FileComplexityData
     language: v.language,
     message: v.message,
     dependentCount: fileData.dependentCount || 0,
-    riskLevel: fileData.riskLevel,
+    complexityRiskLevel: fileData.riskLevel,
     testAssociations: fileData.testAssociations,
     ...(v.halsteadDetails && { halsteadDetails: v.halsteadDetails }),
   };

--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -2,6 +2,7 @@ import type { z } from 'zod';
 import { wrapToolHandler } from '../utils/tool-wrapper.js';
 import { GetDependentsSchema } from '../schemas/index.js';
 import { findUnindexedPaths, formatUnindexedPathsNote } from '../utils/unindexed-paths.js';
+import { relabelCallerReasoning } from '../../utils/blast-radius-reasoning.js';
 import type { ToolContext, MCPToolResult } from '../types.js';
 import { computeBlastRadiusRisk, type BlastRadiusRisk } from '@liendev/parser';
 import type { AttributionCaveatReason } from '../attribution-caveat-reasons.js';
@@ -155,27 +156,7 @@ function computeRisk(analysis: DependencyAnalysisResult): BlastRadiusRisk {
     hasHighComplexityUncovered,
     complexityRiskBoost: complexityMetrics.complexityRiskBoost,
   });
-  return { ...risk, reasoning: clarifyCallerReasoning(risk.reasoning) };
-}
-
-/**
- * Relabel the shared primitive's generic "N callers"/"N caller" reasoning
- * entry to make explicit that it counts PRODUCTION dependents only (#928).
- * `computeRisk` above deliberately feeds `productionDependentCount` in — a
- * test file calling the target shouldn't weigh into risk the same way a
- * production caller does — but the response's own top-level `dependentCount`
- * field is the WIDER total (production + test). Left unrelabeled, a reader
- * sees two different numbers answering what looks like the same question
- * ("14 callers" next to `dependentCount: 80`) with nothing to indicate
- * they're deliberately scoped differently; this makes the scoping explicit
- * instead of changing either number. Scoped to this handler's own response
- * rather than the shared `blast-radius-risk.ts` primitive, which the review-
- * side blast-radius injection also consumes with its own (unrelated) scoping.
- */
-function clarifyCallerReasoning(reasoning: string[]): string[] {
-  return reasoning.map(entry =>
-    /^\d+ callers?$/.test(entry) ? entry.replace(/ callers?$/, m => ` production${m}`) : entry,
-  );
+  return { ...risk, reasoning: relabelCallerReasoning(risk.reasoning) };
 }
 
 /**

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -190,7 +190,15 @@ Examples:
 
 Returns:
 - summary: { filesAnalyzed, avgComplexity, maxComplexity, violationCount, bySeverity: { error, warning } }
-- violations[]: { filepath, symbolName, symbolType, complexity, metricType, threshold, severity, riskLevel, dependentCount, testAssociations }
+- violations[]: { filepath, symbolName, symbolType, complexity, metricType, threshold, severity, complexityRiskLevel, dependentCount, testAssociations }
+- complexityRiskLevel: "low" | "medium" | "high" | "critical" — the file's OWN complexity
+  severity (this violation plus any others in the same file), boosted (never downgraded)
+  by its dependent count/complexity. This is a DIFFERENT metric from \`get_dependents\`'/
+  \`lien annotate\`'s \`riskLevel\` (blast-radius risk): that one weighs dependents' TEST
+  COVERAGE and applies a complexity floor; this one has no test-coverage term at all.
+  The two can and do disagree for the same file at the same moment — see
+  docs/architecture/blast-radius-nudge.md's "Two risk concepts" section before assuming
+  they should match.
 - metricType: "cyclomatic" | "cognitive" | "halstead_effort" | "halstead_bugs"
 - severity: "error" | "warning"
 - note?: present and explicit when a requested \`files\` entry has no index entry at all — filesAnalyzed silently excludes it otherwise`,

--- a/packages/cli/src/utils/blast-radius-reasoning.test.ts
+++ b/packages/cli/src/utils/blast-radius-reasoning.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { relabelCallerReasoning } from './blast-radius-reasoning.js';
+
+describe('relabelCallerReasoning', () => {
+  it('relabels the plural "N callers" entry as "N production callers"', () => {
+    expect(relabelCallerReasoning(['8 callers', '2 untested'])).toEqual([
+      '8 production callers',
+      '2 untested',
+    ]);
+  });
+
+  it('relabels the singular "1 caller" entry as "1 production caller"', () => {
+    expect(relabelCallerReasoning(['1 caller'])).toEqual(['1 production caller']);
+  });
+
+  it('leaves unrelated reasoning entries untouched', () => {
+    const reasoning = ['max complexity 18', 'untested high-complexity dependent'];
+    expect(relabelCallerReasoning(reasoning)).toEqual(reasoning);
+  });
+
+  it('handles an empty reasoning list', () => {
+    expect(relabelCallerReasoning([])).toEqual([]);
+  });
+});

--- a/packages/cli/src/utils/blast-radius-reasoning.ts
+++ b/packages/cli/src/utils/blast-radius-reasoning.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared presentation helper for `computeBlastRadiusRisk`'s reasoning text.
+ *
+ * Every surface that computes blast-radius risk (`get_dependents`, `lien
+ * annotate`) deliberately feeds `productionDependentCount` into
+ * `computeBlastRadiusRisk`'s `dependentCount` -- a test file calling the
+ * target shouldn't weigh into risk the same way a production caller does
+ * (#928). But each surface's own top-level dependent count is the WIDER
+ * total (production + test), reported alongside the risk verdict. Left
+ * unrelabeled, a reader sees two different numbers answering what looks like
+ * the same question ("14 callers" next to a wider total) with nothing
+ * indicating they're deliberately scoped differently.
+ *
+ * `relabelCallerReasoning` makes that scoping explicit in the reasoning
+ * text itself, instead of changing either number. Originally added for
+ * `get_dependents` (#928); `lien annotate` fed the WIDER (production + test)
+ * count into `computeBlastRadiusRisk` instead of the production-only count
+ * until HOOKS-2 -- both surfaces now share this single relabeling
+ * implementation so the "N callers" -> "N production callers" wording can
+ * never drift out of sync between them the way the underlying population
+ * once did.
+ */
+export function relabelCallerReasoning(reasoning: string[]): string[] {
+  return reasoning.map(entry =>
+    /^\d+ callers?$/.test(entry) ? entry.replace(/ callers?$/, m => ` production${m}`) : entry,
+  );
+}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -144,6 +144,11 @@ interface FileComplexityData {
   violations: ComplexityViolation[];
   dependents: string[];        // Files that import this file
   testAssociations: string[];  // Test files covering this file
+  // Own complexity severity, boosted (never downgraded) by dependent
+  // count/complexity -- NOT the same concept as get_dependents'/`lien
+  // annotate`'s blast-radius `riskLevel` (no test-coverage term here at
+  // all). Serialized as `complexityRiskLevel` in `lien complexity
+  // --format json` / `get_complexity`'s MCP response.
   riskLevel: 'low' | 'medium' | 'high' | 'critical';
 }
 

--- a/packages/core/src/insights/formatters/json.test.ts
+++ b/packages/core/src/insights/formatters/json.test.ts
@@ -54,6 +54,17 @@ describe('formatJsonReport', () => {
     expect(parsed.files).not.toHaveProperty('src/simple.ts');
   });
 
+  // CLI-4/REVIEW-6: `lien complexity --format json`'s `riskLevel` collided
+  // with `lien annotate`/`get_dependents`/`lien api-delta`'s unrelated
+  // blast-radius `riskLevel` -- same name, different formula, disagreeing
+  // for the same file at the same moment. Renamed to `complexityRiskLevel`
+  // here; `riskLevel` must never reappear in this output.
+  it('renames riskLevel to complexityRiskLevel in the JSON output (CLI-4/REVIEW-6)', () => {
+    const parsed = JSON.parse(formatJsonReport(report));
+    expect(parsed.files['src/utils.ts'].complexityRiskLevel).toBe('low');
+    expect(parsed.files['src/utils.ts']).not.toHaveProperty('riskLevel');
+  });
+
   it('should handle empty report', () => {
     const empty: ComplexityReport = {
       summary: {

--- a/packages/core/src/insights/formatters/json.ts
+++ b/packages/core/src/insights/formatters/json.ts
@@ -1,4 +1,27 @@
-import type { ComplexityReport } from '@liendev/parser';
+import type { ComplexityReport, FileComplexityData } from '@liendev/parser';
+
+/**
+ * JSON-output shape for a file's complexity data: identical to
+ * `FileComplexityData` except `riskLevel` is renamed `complexityRiskLevel`
+ * (CLI-4/REVIEW-6). `FileComplexityData.riskLevel` is the file's OWN
+ * complexity severity, boosted (never downgraded) by dependent count/
+ * complexity -- see that field's doc comment in `@liendev/parser`'s
+ * `insights/types.ts`. It is a DIFFERENT metric from `get_dependents`/
+ * `lien annotate`/`lien api-delta`'s `riskLevel` (blast-radius risk, which
+ * weighs dependents' test coverage and applies a complexity floor instead
+ * of a boost) -- the two disagreed for the same file at the same moment
+ * under the shared name, which is the defect this rename fixes. See
+ * docs/architecture/blast-radius-nudge.md's "Two risk concepts" section.
+ * Do not rename this back to `riskLevel`.
+ */
+type JsonFileComplexityData = Omit<FileComplexityData, 'riskLevel'> & {
+  complexityRiskLevel: FileComplexityData['riskLevel'];
+};
+
+function toJsonFileData(data: FileComplexityData): JsonFileComplexityData {
+  const { riskLevel, ...rest } = data;
+  return { ...rest, complexityRiskLevel: riskLevel };
+}
 
 /**
  * Format complexity report as JSON for consumption by GitHub Action.
@@ -7,10 +30,12 @@ import type { ComplexityReport } from '@liendev/parser';
 export function formatJsonReport(report: ComplexityReport): string {
   // Filter to only files with violations - no point showing files with empty arrays
   const filesWithViolations = Object.fromEntries(
-    Object.entries(report.files).filter(([_, data]) => data.violations.length > 0),
+    Object.entries(report.files)
+      .filter(([_, data]) => data.violations.length > 0)
+      .map(([filepath, data]) => [filepath, toJsonFileData(data)]),
   );
 
-  const filteredReport: ComplexityReport = {
+  const filteredReport = {
     summary: report.summary,
     files: filesWithViolations,
   };

--- a/packages/core/src/insights/formatters/text.test.ts
+++ b/packages/core/src/insights/formatters/text.test.ts
@@ -111,7 +111,9 @@ describe('formatTextReport', () => {
 
   it('should show risk level, percentage over threshold, and dependency info', () => {
     const result = formatTextReport(createReport());
-    expect(result).toContain('Risk:');
+    // "Complexity risk" (not bare "Risk") -- disambiguates from
+    // `lien annotate`/`get_dependents`'s blast-radius risk (CLI-4/REVIEW-6).
+    expect(result).toContain('Complexity risk:');
     expect(result).toContain('HIGH');
     expect(result).toContain('133% over threshold'); // 35 over 15
     expect(result).toContain('Imported by 1 file');

--- a/packages/core/src/insights/formatters/text.ts
+++ b/packages/core/src/insights/formatters/text.ts
@@ -128,7 +128,12 @@ function formatViolation(
     chalk.dim(`    ⬆️  ${formatPercentageOver(violation.complexity, violation.threshold)}`),
     ...formatHalsteadDetails(violation),
     ...formatDependencyInfo(fileData),
-    chalk.dim(`    ⚠️  Risk: ${fileData.riskLevel.toUpperCase()}`),
+    // "Complexity risk" (not bare "Risk") -- this is the file's OWN
+    // complexity severity boosted by dependent count/complexity, a
+    // DIFFERENT metric from `lien annotate`/`get_dependents`/`lien
+    // api-delta`'s blast-radius risk (CLI-4/REVIEW-6). See
+    // docs/architecture/blast-radius-nudge.md's "Two risk concepts".
+    chalk.dim(`    ⚠️  Complexity risk: ${fileData.riskLevel.toUpperCase()}`),
     '',
   ];
 }

--- a/packages/parser/src/insights/complexity-vs-blast-radius-risk.test.ts
+++ b/packages/parser/src/insights/complexity-vs-blast-radius-risk.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { analyzeComplexityFromChunks } from './chunk-complexity.js';
+import { findDependents } from '../dependency-analyzer.js';
+import { computeBlastRadiusRisk } from '../risk/blast-radius-risk.js';
+import type { ChunkMetadata, CodeChunk } from '../types.js';
+
+/**
+ * PINS a deliberate, documented invariant (CLI-4/REVIEW-6, #1017): Lien
+ * computes two genuinely different "risk" concepts —
+ *
+ * - **Complexity risk** (`get_complexity`/`lien complexity`,
+ *   `analyzeComplexityFromChunks` -> `FileComplexityData.riskLevel`,
+ *   serialized externally as `complexityRiskLevel`): the file's OWN
+ *   complexity severity, boosted (never downgraded) by dependent count/
+ *   complexity. No test-coverage term anywhere in the formula.
+ * - **Blast-radius risk** (`get_dependents`/`lien annotate`/`lien
+ *   api-delta`, `computeBlastRadiusRisk` -> `riskLevel`): dependent breadth
+ *   plus untested-dependent count, with a complexity FLOOR instead of a
+ *   boost.
+ *
+ * Both fixtures below reproduce the exact shapes from the two bug reports
+ * that surfaced this (a `complexity-delta.ts`-shaped low/medium case, and a
+ * `gnarly.ts`-shaped high/low case) using the REAL production code paths —
+ * `analyzeComplexityFromChunks` (what `get_complexity` calls) and
+ * `findDependents` + `computeBlastRadiusRisk` (what `get_dependents`/`lien
+ * annotate`/`lien api-delta` call) — fed the identical chunk universe.
+ *
+ * See docs/architecture/blast-radius-nudge.md's "Two risk concepts" section
+ * for the full writeup. If a future change makes either formula start
+ * agreeing with the other on these fixtures, THIS TEST FAILS — that is the
+ * point: the two concepts converging silently is exactly the failure mode
+ * being guarded against, so any change that makes them agree here must be a
+ * conscious, disclosed decision (and this file, and the doc section above,
+ * re-read and updated), never an incidental side effect of touching one
+ * formula.
+ */
+
+/** Build a ChunkMetadata with sensible function defaults, override as needed. */
+function meta(overrides: Partial<ChunkMetadata> & { file: string }): ChunkMetadata {
+  return {
+    startLine: 1,
+    endLine: 10,
+    type: 'function',
+    language: 'typescript',
+    symbolType: 'function',
+    symbolName: 'fn',
+    imports: [],
+    ...overrides,
+  };
+}
+
+function chunk(overrides: Partial<ChunkMetadata> & { file: string }): CodeChunk {
+  return { content: '// stub', metadata: meta(overrides) };
+}
+
+const log = (): void => undefined;
+const ROOT = '/repo';
+
+describe('complexity risk vs blast-radius risk — documented divergence', () => {
+  // Reproduction A shape: a low-complexity file with 2 production
+  // dependents, one of which has no test coverage of its own.
+  it('diverges LOW (complexity risk) vs MEDIUM (blast-radius risk) for the same file, same moment', () => {
+    const target = chunk({ file: 'src/target.ts', complexity: 2, symbolName: 'target' });
+    const dep1 = chunk({
+      file: 'src/dep1.ts',
+      complexity: 3,
+      symbolName: 'dep1',
+      imports: ['src/target.ts'],
+    });
+    const dep2 = chunk({
+      file: 'src/dep2.ts',
+      complexity: 3,
+      symbolName: 'dep2',
+      imports: ['src/target.ts'],
+    });
+    // Gives dep1 (but not dep2) a test importer, so uncoveredProductionDependents == 1.
+    const dep1Test = chunk({
+      file: 'src/dep1.test.ts',
+      complexity: 1,
+      symbolName: 'testsDep1',
+      imports: ['src/dep1.ts'],
+    });
+    const allChunks = [target, dep1, dep2, dep1Test];
+
+    // --- Complexity risk: what get_complexity/lien complexity reports ---
+    const complexityReport = analyzeComplexityFromChunks(allChunks, ['src/target.ts']);
+    const complexityRiskLevel = complexityReport.files['src/target.ts'].riskLevel;
+    expect(complexityRiskLevel).toBe('low');
+
+    // --- Blast-radius risk: what get_dependents/lien annotate/lien api-delta report ---
+    const analysis = findDependents(allChunks, 'src/target.ts', log, ROOT);
+    expect(analysis.productionDependentCount).toBe(2);
+    expect(analysis.uncoveredProductionDependents).toBe(1);
+    const blastRadiusRisk = computeBlastRadiusRisk({
+      dependentCount: analysis.productionDependentCount,
+      uncoveredDependents: analysis.uncoveredProductionDependents,
+      maxDependentComplexity: analysis.complexityMetrics.maxComplexity,
+      complexityRiskBoost: analysis.complexityMetrics.complexityRiskBoost,
+    }).level;
+    expect(blastRadiusRisk).toBe('medium');
+
+    // The documented invariant: these disagree, by design.
+    expect(complexityRiskLevel).not.toBe(blastRadiusRisk);
+  });
+
+  // Reproduction B shape: a high-severity-violation file whose only
+  // dependent is its own test file (no production callers at all).
+  it('diverges HIGH (complexity risk) vs LOW (blast-radius risk) for the same file, same moment', () => {
+    const target = chunk({
+      file: 'src/gnarly.ts',
+      complexity: 35, // >= 2x the default cyclomatic threshold (15) -> an 'error' violation
+      symbolName: 'gnarly',
+    });
+    const targetTest = chunk({
+      file: 'src/gnarly.test.ts',
+      complexity: 2,
+      symbolName: 'testsGnarly',
+      imports: ['src/gnarly.ts'],
+    });
+    const allChunks = [target, targetTest];
+
+    // --- Complexity risk ---
+    const complexityReport = analyzeComplexityFromChunks(allChunks, ['src/gnarly.ts']);
+    const fileData = complexityReport.files['src/gnarly.ts'];
+    expect(fileData.violations.some(v => v.severity === 'error')).toBe(true);
+    const complexityRiskLevel = fileData.riskLevel;
+    expect(complexityRiskLevel).toBe('high');
+
+    // --- Blast-radius risk: the sole dependent is a test file, so
+    // productionDependentCount is 0 -- the file has no real callers at all. ---
+    const analysis = findDependents(allChunks, 'src/gnarly.ts', log, ROOT);
+    expect(analysis.productionDependentCount).toBe(0);
+    const blastRadiusRisk = computeBlastRadiusRisk({
+      dependentCount: analysis.productionDependentCount,
+      uncoveredDependents: analysis.uncoveredProductionDependents,
+      maxDependentComplexity: analysis.complexityMetrics.maxComplexity,
+      complexityRiskBoost: analysis.complexityMetrics.complexityRiskBoost,
+    }).level;
+    expect(blastRadiusRisk).toBe('low');
+
+    // The documented invariant: these disagree, by design -- in the
+    // OPPOSITE direction from the fixture above.
+    expect(complexityRiskLevel).not.toBe(blastRadiusRisk);
+  });
+});

--- a/packages/parser/src/insights/types.ts
+++ b/packages/parser/src/insights/types.ts
@@ -51,6 +51,25 @@ export interface FileComplexityData {
   dependentCount?: number;
   /** Test files associated with this source file. TODO: Populate when test-to-code mapping is implemented */
   testAssociations: string[];
+  /**
+   * Complexity risk: this file's OWN violation severity (`calculateRiskLevel`
+   * in `../chunk-complexity.ts`), boosted -- never downgraded -- by its
+   * dependent count/complexity (`enrichWithDependencies`, same file). There
+   * is no test-coverage term in this formula at all.
+   *
+   * This is a DIFFERENT concept from `get_dependents`/`lien annotate`/`lien
+   * api-delta`'s `riskLevel` (blast-radius risk, `computeBlastRadiusRisk` in
+   * `../risk/blast-radius-risk.ts`), which weighs dependents' test coverage
+   * and applies a complexity floor instead of a boost. The two can disagree
+   * for the same file at the same moment BY DESIGN (CLI-4/REVIEW-6) -- see
+   * `docs/architecture/blast-radius-nudge.md`'s "Two risk concepts" section,
+   * and `complexity-vs-blast-radius-risk.test.ts` for pinned examples of the
+   * divergence in both directions. Kept as `riskLevel` here (the internal,
+   * parser-package-only name); serialized as `complexityRiskLevel` at the
+   * `get_complexity`/`lien complexity --format json` output boundary, where
+   * the collision with the other three surfaces' `riskLevel` was actually
+   * observed.
+   */
   riskLevel: RiskLevel;
   dependentComplexityMetrics?: {
     averageComplexity: number;

--- a/packages/site/docs/guide/mcp-tools.md
+++ b/packages/site/docs/guide/mcp-tools.md
@@ -416,7 +416,7 @@ Analyze complexity of src/api/
       "language": "typescript",
       "message": "Cyclomatic complexity 23 exceeds threshold 15",
       "dependentCount": 5,
-      "riskLevel": "high"
+      "complexityRiskLevel": "high"
     },
     {
       "filepath": "src/parser/index.ts",
@@ -431,7 +431,7 @@ Analyze complexity of src/api/
       "language": "typescript",
       "message": "Time to understand ~1h 30m exceeds threshold 1h",
       "dependentCount": 5,
-      "riskLevel": "medium",
+      "complexityRiskLevel": "medium",
       "halsteadDetails": {
         "volume": 850.5,
         "difficulty": 45.2,
@@ -442,6 +442,16 @@ Analyze complexity of src/api/
   ]
 }
 ```
+
+::: tip `complexityRiskLevel` is not `get_dependents`' `riskLevel`
+`complexityRiskLevel` is this file's OWN complexity severity, boosted (never
+downgraded) by its dependent count/complexity — there's no test-coverage
+term in the formula at all. [`get_dependents`](#get_dependents)'s (and `lien
+annotate`'s, and `lien api-delta`'s) `riskLevel` is a different metric —
+blast-radius risk, which weighs dependents' test coverage and applies a
+complexity floor instead. The two can disagree for the same file at the
+same moment by design; don't assume they should match.
+:::
 
 ### Metric Types
 


### PR DESCRIPTION
## Summary

Fixes a confirmed defect that two independent verifiers found separately (CLI-4, REVIEW-6 — the same bug), plus a related-but-distinct bug found while investigating (HOOKS-2). References #1017.

**CLI-4/REVIEW-6 — `riskLevel` named two different concepts, and they disagreed for the same file at the same moment, in both directions.**

- `get_complexity`/`lien complexity`: the file's OWN complexity severity, boosted (never downgraded) by dependent count/complexity — no test-coverage term at all (`calculateRiskLevel` + `enrichWithDependencies` in `packages/parser/src/insights/chunk-complexity.ts`, `calculateRiskLevelFromCount`/`calculateComplexityRiskBoost` in `packages/parser/src/dependency-analyzer.ts`).
- `get_dependents`/`lien annotate`/`lien api-delta`: blast-radius risk — dependent breadth + untested-dependent count, with a complexity **floor** (`computeBlastRadiusRisk` in `packages/parser/src/risk/blast-radius-risk.ts`).

**The decision:** these are genuinely different concepts, not one concept computed two inconsistent ways — collapsing them into a single formula would lose information ("this function's complexity is already over threshold" and "3 of 5 callers have no tests" are both real, independent signals). The fix is the **name collision**, not the formula: `get_complexity`'s `violations[].riskLevel` → `complexityRiskLevel`, and `lien complexity --format json`'s per-file `riskLevel` → `complexityRiskLevel`. `get_dependents`/`lien annotate`/`lien api-delta` keep `riskLevel` for blast-radius risk, unchanged. The internal `FileComplexityData.riskLevel` type field (parser package) keeps its name — it's unambiguous within its own struct; the rename applies only at the CLI-JSON/MCP-tool output boundary where the two concepts were actually observed side by side.

Both concepts are now documented together, with the divergence pinned by a dedicated test, in `docs/architecture/blast-radius-nudge.md`'s new "Two risk concepts" section — so they can't silently re-converge (or re-diverge further) unnoticed.

**HOOKS-2 — found while investigating, a distinct bug in the SAME formula (not a naming issue): `lien annotate` fed the wrong population into `computeBlastRadiusRisk`.**

`get_dependents`/`lien api-delta` both feed `productionDependentCount` (test files calling the target don't weigh into risk the same way production callers do, #928). `lien annotate` fed the WIDER `result.dependents.length` (production + test) instead — an internal mismatch too, since it already used the narrower `uncoveredProductionDependents` for the untested count in the same call. Confirmed pre-existing (`git log -L` on the line shows it unchanged since #913; #941 fixed a *different* contradiction, #933, and never touched this). Fixed by feeding `productionDependentCount` in, and extracting the "N callers" → "N production callers" reasoning relabel (previously private to `get_dependents.ts`) into a shared `packages/cli/src/utils/blast-radius-reasoning.ts`, used by both surfaces — one implementation instead of two that can drift again.

## Verification — reproductions, before/after (this PR's own build, dogfooded against a scratch fixture project)

**Reproduction A** (own low complexity risk + medium blast-radius, from many dependents one of which is untested):

Before:
```
$ lien complexity --files src/target.ts --format json
"riskLevel": "low", "dependentCount": 2
$ lien annotate src/target.ts
• 2 files import this — src/dep2.ts, src/dep1.ts; risk: medium (2 callers, 1 untested, max complexity 1).
```
After:
```
$ lien complexity --files src/target.ts --format json
"complexityRiskLevel": "low", "dependentCount": 2
$ lien annotate src/target.ts
• 2 files import this — src/dep2.ts, src/dep1.ts; risk: medium (2 production callers, 1 untested, max complexity 1).
```

**Reproduction B** (own high complexity risk + low blast-radius, sole dependent is the file's own test):

Before and after are identical for this one (it's a formula/concept difference, not the population bug — confirms HOOKS-2 didn't regress it):
```
$ lien complexity --files src/gnarly.ts --format json
"complexityRiskLevel": "high" (was "riskLevel": "high"), "dependentCount": 1
$ lien annotate src/gnarly.ts
• 1 file imports this — src/gnarly.test.ts; risk: low.
```

**HOOKS-2 reproduction** (many test-only importers, few production ones):

Before:
```
$ lien annotate src/hookstarget.ts
• 8 files import this — src/prodCaller2.ts, src/prodCaller1.ts, ...; risk: medium (8 callers, max complexity 1).
```
After:
```
$ lien annotate src/hookstarget.ts
• 8 files import this — src/prodCaller2.ts, src/prodCaller1.ts, ...; risk: low (2 production callers, max complexity 1).
```
(2 production dependents, both individually test-covered; 6 dependents are themselves test files — `get_dependents` would report `productionDependentCount: 2` / `riskLevel: "low"` for the identical fixture, which `lien annotate` now matches.)

All commands were run against the actual built CLI (`node packages/cli/dist/index.js ...`) on a scratch fixture project, with "before" captured by temporarily reverting the touched behavioral files to `HEAD`, rebuilding, and re-running — not simulated.

## Every consumer of the renamed field, enumerated (grep across `packages/`, `plugins/`, `docs/`, `packages/site/`)

- `packages/cli/src/mcp/handlers/get-complexity.ts` — renamed (`transformViolation`).
- `packages/core/src/insights/formatters/json.ts` — renamed via a new `toJsonFileData` mapper (this is what `lien complexity --format json` actually serializes).
- `packages/core/src/insights/formatters/text.ts` — label changed from `Risk:` to `Complexity risk:` (field itself, `fileData.riskLevel`, stays internal/unrenamed).
- `packages/core/src/insights/formatters/sarif.ts` — does not reference `riskLevel` at all; unaffected.
- `packages/cli/src/mcp/tools.ts` — `get_complexity`'s tool description updated.
- `packages/site/docs/guide/mcp-tools.md` — both JSON examples updated, plus a new callout distinguishing the two concepts.
- `packages/core/README.md` — `FileComplexityData` doc block annotated (field name unchanged there, by design — see above).
- `packages/parser/src/insights/types.ts` — `FileComplexityData.riskLevel`'s doc comment now states the distinction and points at the external rename.
- `docs/architecture/blast-radius-nudge.md` — new "Two risk concepts" section.
- Checked and NOT touched (correctly): `packages/review/src/*` (its `ComplexityReport.files[x].riskLevel` usage in `prompt.ts`/`dependent-context.ts`/`plugins/complexity.ts` reads the *internal* field, which is unrenamed — no change needed there); `plugins/claude/hooks/api-delta-write.sh` (reads `lien api-delta`'s own `riskLevel`, a different, already-correctly-named field); `CLAUDE.md`/`AGENTS.md`/`cross-editor-setup.md` (their `riskLevel` mentions are all scoped to `get_dependents`, unaffected).

## The other three surfaces

- **`get_dependents`**: behavior unchanged. Its `clarifyCallerReasoning` helper was moved verbatim (same implementation) into the new shared `packages/cli/src/utils/blast-radius-reasoning.ts` as `relabelCallerReasoning` — a pure code-motion, confirmed by its existing 47-test suite passing unchanged.
- **`lien api-delta`** (`api-delta-cmd.ts`): zero lines changed (confirmed via `git diff`); its own 17-test suite passes unchanged.
- **`lien annotate`**: DOES change (that's the HOOKS-2 fix) — its risk verdict now matches `get_dependents`/`api-delta`'s population semantics; its displayed dependents list/count stays the wider production+test total (unchanged, by design).

## Tests added

- `packages/parser/src/insights/complexity-vs-blast-radius-risk.test.ts` — pins the two-concepts divergence using the real production code paths (`analyzeComplexityFromChunks` + `findDependents`/`computeBlastRadiusRisk`) against both reproduction shapes; fails loudly if either formula ever starts agreeing with the other on these fixtures.
- `packages/cli/src/utils/blast-radius-reasoning.test.ts` — the shared relabeling helper.
- `packages/cli/src/cli/annotate-cmd.test.ts` — HOOKS-2 regression: 2 production dependents (0 uncovered) + 6 test-only importers must read `risk: low` / `2 production callers`, not `risk: medium` / `8 callers`.
- `packages/core/src/insights/formatters/{json,text}.test.ts` — updated for the rename.

## Unrelated pre-existing bug found + fixed while rebasing

Rebasing onto latest `main` (past #1034/#1031/#1028) surfaced `packages/cli/src/cli/annotate-cmd.test.ts`'s `annotateCommand (integration) > never opens or creates the structural store on a never-indexed root` failing — **confirmed already broken on `main` itself** (real CI on `main`, run `30704209723`, is currently red on this exact test; also reproduces locally with zero code changes of mine, verified by reverting to the pristine upstream file and re-running).

Root cause: `getLienHome()` is `process.env.LIEN_HOME || os.homedir()`. Vitest's `global-setup.ts` sets `LIEN_HOME` to one shared temp dir for the whole test run; that wins over this describe block's `os.homedir()` mock, so its "pristine, never-indexed home" isolation was silently a no-op — any other test in the same run that legitimately indexes this repo's real root under the shared home leaves a real `structural.db` this test then misreads as "already indexed." Fixed by also redirecting `process.env.LIEN_HOME` per-test (separate commit, `0928d29a`). Verified: the full `packages/cli` suite (1572 tests) now passes consistently across repeated runs.

Not part of CLI-4/REVIEW-6/HOOKS-2 — flagging explicitly since it was blocking green CI for any PR based on current `main`, not just this one.

## Gates (all six pass)

```
npm run format:check   ✓
npm run lint            ✓ (0 errors, 40 pre-existing warnings, none touched by this PR)
npm run typecheck        ✓
npm run build            ✓
npm test                 ✓ 27 + 1673 + 407 + 1748 + 1572 + 41 = 5468 tests passed, 0 failed
lien delta                ✓ exit 0 (informational "worsened" time deltas well under threshold — no new-over-threshold crossing)
```

`npm run docs:build` also run (touched `packages/site`); rendered HTML checked directly for both the JSON examples and the new callout.

## Changeset

`.changeset/two-risk-concepts-and-population-parity.md` — patch bump for `@liendev/core` and `@liendev/lien` (both touched behaviorally). `@liendev/parser` only gained a new test file and a doc comment — no behavior/API change, no changeset needed. The test-isolation fix is test-only, no changeset needed.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR cleanly disambiguates two risk concepts that were previously exposed under the same `riskLevel` name, and fixes a population-parity bug in `lien annotate`. The rename from `riskLevel` to `complexityRiskLevel` is applied consistently at the CLI/MCP output boundaries (`get_complexity`, `lien complexity --format json`) while the internal `FileComplexityData.riskLevel` field is left unchanged. The HOOKS-2 fix switches `lien annotate`'s blast-radius computation from the wider `dependents.length` to `productionDependentCount`, matching `get_dependents`/`lien api-delta`, with reasoning relabeled to "N production callers" via a new shared helper. Tests cover the rename, the shared relabeling helper, the population-parity regression, and the conceptual divergence itself.
>
> - Renamed complexity-risk output field to `complexityRiskLevel` in `get_complexity` and `lien complexity --format json`
> - Fixed `lien annotate` to use `productionDependentCount` for blast-radius risk instead of `dependents.length`
> - Extracted `relabelCallerReasoning` into a shared utility used by both `get_dependents` and `lien annotate`

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 0928d29. Updates automatically on new commits.</sup>
<!-- /lien-stats -->