### PR TITLE
fix(cli): build the index-state honesty detector (#1029 W1)

### DIFF
--- a/.changeset/index-state-honesty-detector.md
+++ b/.changeset/index-state-honesty-detector.md
@@ -1,0 +1,17 @@
+---
+"@liendev/lien": patch
+---
+
+Fix three more instances of the fail-quiet defect class (#1029 Workstream 1) and build the detector that stops the class from recurring.
+
+**New instances fixed** (same disposition as #1031/#1034: a confident answer where the honest answer is "I don't know"):
+
+- **`get_complexity` (MCP tool)**: a whole-repo scan (no `files` filter) over a structural store with zero rows reported "0 files analyzed, 0 violations" with no indication the store was empty — indistinguishable from a genuinely clean, fully-indexed codebase. Now adds the same `⚠ Lien: ... no data` note `search_code`/`list_functions` already give.
+- **`find_similar` (MCP tool)**: 0 results on an empty structural store got the generic "ensure your snippet is representative" note — the same one a healthy index gives for a real 0-match query. Now escalates to the unmissable no-data note when `hasData()` is false.
+- **`lien api-delta`**: an index directory that exists but has zero rows (cleared, moved aside, mid-rebuild) sailed past the existing `hasStructuralIndex` check and reported a real-looking `enriched: true, dependentCount: 0` instead of degrading like a never-indexed project does.
+- **`lien annotate`**: `reportUnresolvedPath` (a typo'd/nonexistent path) skipped the `hasStructuralIndex` pre-check the file's other two call sites already have, silently materializing an empty `structural.db` as a side effect on a virgin project.
+- **`lien complexity`**: extended to catch S1 (index directory exists, store has 0 rows) as a hard error — previously only S0 (no index at all) was caught.
+
+**The detector**: `packages/cli/utils/index-freshness.ts` (from #1031) gains a `classifyIndexState` function consolidating the S0 (no index) / S1 (empty store) / S2 (stale vs. HEAD) ladder in one place. `packages/cli/test/integration/index-state-matrix.test.ts` is a new table test asserting every read-only, index-backed entry point's actual response against a real `SqliteBackend` (no mocking) across every state that applies to it, with a completeness guard that fails the build if a new `createVectorDB` call site or MCP tool handler isn't accounted for.
+
+Policy documented in CLAUDE.md and `docs/architecture/index-state-honesty.md`: the right response differs by command disposition (gate-shaped commands hard-error on S0/S1; advisory nudges warn loudly but stay exit-0; MCP tools use an explicit `note`/`attributionCaveat`) — never a blanket rule.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,42 @@ Lien provides lexical (FTS5) code search and dependency analysis via MCP. These 
 
 ---
 
+## Index-State Honesty — MANDATORY for New Commands/Tools
+
+**A read-only, index-backed command MUST NEVER produce a confident answer
+when it has no data, or the wrong data, to answer from.** An empty scan
+that formats as "0 violations, clean!" and a genuinely clean codebase are
+the same shape unless the command checks which one it actually has —
+checking is not optional.
+
+Classify the index state via `classifyIndexState`
+(`packages/cli/src/utils/index-freshness.ts`) for whole-index states, and
+`findUnindexedPaths` (`packages/cli/src/mcp/utils/unindexed-paths.ts`) for a
+specific requested path. **Do not hand-roll this check again** — every
+existing read-only entry point already goes through one of these two.
+
+The response required differs by what kind of command it is — **never a
+blanket "always error"**:
+
+| Disposition | No index / empty store (S0/S1) | Stale vs. HEAD (S2) | Requested path not indexed (S3) |
+|---|---|---|---|
+| Gate-shaped (`lien complexity --fail-on`) | **Hard error, non-zero exit** | Loud warning, still runs | — |
+| Advisory nudge (`lien annotate`, `lien api-delta`) | Loud, un-suppressible warning or degraded marker (`enriched: false`) — exit 0 is fine | n/a for these two | Explicit "not found in the index" |
+| MCP tool | S0 is structurally impossible (`lien serve` initializes the store before registering tools); S1 → explicit `note`/`attributionCaveat`, never a bare empty result | n/a — `lien serve`'s git-detection keeps it fresh | Explicit `note`/`attributionCaveat` naming the path |
+
+**Hard constraint: never turn a genuinely clean, freshly-indexed result into
+a false alarm.** Gate on the actual state (`hasData()`, `getIndexedFiles()`),
+never on the shape of the result — see #1014 for what over-firing costs
+(a false caveat that fires every session gets trained out as noise).
+
+**Before shipping a new command or MCP tool that reads the structural
+index**, add it to `packages/cli/test/integration/index-state-matrix.test.ts`
+— its completeness guard fails the build if a new `createVectorDB` call site
+or MCP tool handler isn't accounted for there. Full policy, the four-state
+vocabulary, and worked examples: `docs/architecture/index-state-honesty.md`.
+
+---
+
 ## Agent-Review Rule Development — Use the Test Harness
 
 Adding or tweaking a rule in `packages/review/src/plugins/agent/` MUST go

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -167,6 +167,19 @@ Read this before adding or changing a plugin hook.
 
 ---
 
+### [Index-State Honesty](./index-state-honesty.md)
+The policy + detector behind never producing a confident answer on missing/stale data.
+
+Explains:
+- The four whole-index/per-path states (S0/S1/S2/S3) and `classifyIndexState`
+- Why the right response differs by command disposition (gate-shaped, advisory, MCP tool) — never a blanket rule
+- The table test (`packages/cli/test/integration/index-state-matrix.test.ts`) and its completeness guard
+- How to wire a new read-only, index-backed command correctly
+
+Read this before adding any command or MCP tool that reads from the structural index.
+
+---
+
 ### [Agent-Review Pass Architecture](./review-pass-architecture.md)
 `ReviewPassSpec` and the extra-pass executor (Lien Review).
 
@@ -210,6 +223,7 @@ For the history behind these designs, see the [Architectural Decision Records in
 | Session risk-ledger recap (`lien recap`) | [Session Risk-Ledger Recap](./session-risk-recap.md) |
 | Plugin hook design (what reaches the model) | [Claude Code Hook Output Channels](./claude-code-hook-channels.md) |
 | Lien Review's extra LLM passes (doc-truth, candidate loops) | [Agent-Review Pass Architecture](./review-pass-architecture.md) |
+| Never a confident answer on missing/stale data (S0-S3) | [Index-State Honesty](./index-state-honesty.md) |
 
 ### For debugging
 

--- a/docs/architecture/index-state-honesty.md
+++ b/docs/architecture/index-state-honesty.md
@@ -1,0 +1,165 @@
+# Index-State Honesty
+
+The policy and detector behind #1029 Workstream 1: when Lien has no data, or
+the wrong data, it must say so — never produce a confident answer that
+happens to be indistinguishable from a real one.
+
+## Why this exists
+
+The #1017 sweep confirmed 28 defects. Roughly 11 of them were the same
+disposition: a read-only command or MCP tool answered a question it had no
+data to answer, and the answer came back looking exactly like a genuine
+clean result.
+
+- `lien complexity` on a never-indexed repo → `✓ No violations found!`, exit 0.
+- …on an indexed-but-empty store (same bug, one layer deeper) → the same
+  false clean.
+- `get_complexity({ files: [...] })` on an unindexed path → the path silently
+  dropped, a whole-repo answer returned in its place.
+- `lien annotate <nonexistent>` → nothing printed, exit 0.
+- `lien status` → "Index files: 7" when 11 files are actually indexed.
+
+Each individual case was a defensible *local* default — Zod strips unknown
+keys by default, SQLite's `CREATE TABLE IF NOT EXISTS` materializes a store
+where none existed, an empty scan formats as a valid, clean report — that
+composed into a lie. Nothing in the codebase said otherwise, so the next
+command added the same way would repeat it. This document is that "otherwise."
+
+## The four states
+
+A read-only, index-backed command or tool can find itself in one of four
+states, classified by `packages/cli/src/utils/index-freshness.ts`'s
+`classifyIndexState` (whole-index states) plus a per-path check
+(`findUnindexedPaths`, `packages/cli/src/mcp/utils/unindexed-paths.ts`) for
+the fourth:
+
+| State | Meaning | Whole-index or per-path? |
+|-------|---------|---------------------------|
+| **S0** | No index directory exists at all — the project has never been indexed. | Whole-index |
+| **S1** | The index directory exists, but the structural store has zero rows (cleared, moved aside, or indexed against an all-ignored tree). | Whole-index |
+| **S2** | The store has real data, but it's stale vs. the working tree's current git HEAD. | Whole-index |
+| **S3** | The index is fine, but the specific path the caller asked about isn't in it. | Per-path |
+
+A fifth state exists in the codebase but is explicitly **out of scope** here:
+the mechanism itself can be structurally blind to a real usage (Java/Kotlin
+same-package access, Ruby class names referenced without an import, C#
+`global using`, a type symbol referenced by constructor call rather than by
+name). That is #1026's `attributionCaveat` vocabulary
+(`AttributionCaveatReason` in `packages/cli/src/mcp/attribution-caveat-reasons.ts`)
+— a different axis (import-graph visibility, not index freshness). Don't
+build a competing vocabulary for it; if you find yourself wanting a state
+that means "the analysis couldn't see it," that's `attributionCaveat`'s job.
+
+## The policy
+
+The bar is **never a confident answer when the honest answer is "I don't
+know."** But "never silent" does not mean "always a hard process error" —
+the right response depends on what kind of command this is:
+
+- **Gate-shaped commands** (their whole purpose is a pass/fail verdict fed
+  to CI or a commit hook — `lien complexity --fail-on`): **S0/S1 is a hard
+  error, non-zero exit.** A confident "0 violations" here is a false "safe
+  to merge." **S2 is a loud warning, never silent** — print it and still run
+  the analysis (don't block; the caller asked for an answer and staleness is
+  a caveat on it, not a reason to refuse one).
+- **Advisory/nudge commands** (`lien annotate`, `lien api-delta` — see
+  [Blast-Radius Nudge](./blast-radius-nudge.md)): these are explicitly
+  designed to degrade rather than fail the process — shell hooks depend on
+  their exit-code contract for unrelated signals (`lien annotate`'s exit 2
+  is the habituation "never-suppress" signal, not a general error channel).
+  For these, **S0/S1 must produce a loud, unmissable, un-suppressible
+  warning or degraded-result marker** (`enriched: false`, never a bare
+  `dependentCount: 0`) — but the process may still exit 0. Silence is the
+  bug, not the exit code.
+- **MCP tools**: same idea, translated to the protocol — **S0 is
+  structurally impossible** (`lien serve` always initializes the structural
+  store before registering tool handlers; see `mcp/server.ts`'s
+  `startMCPServer` → `initializeComponents` → `setupAndConnectServer` →
+  `registerMCPHandlers` ordering). **S1 and S3 must produce an explicit
+  `note` (or, for `get_dependents`, `attributionCaveat`) — never a bare empty
+  result indistinguishable from a real "not found."** Never `isError` for
+  these — a healthy client should still be able to act (run `lien index` and
+  retry), not have the whole call blow up. **S2 does not apply to MCP
+  tools** — `lien serve`'s git-detection machinery (`git-detection.ts`)
+  keeps the index reconciled continuously; staleness is a one-shot-CLI
+  problem only.
+- **`lien status`**: report the true state textually. Already correct
+  (`✗ Not indexed` for S0; `✓ Exists` + a real, possibly-zero file count for
+  S1; `⚠️ Git state changed` for S2) — the reference implementation the
+  other commands' S2 warning text was factored out of
+  (`getIndexStalenessWarning`).
+- **Index-independent commands** (`lien path`, `lien delta`, `lien config
+  get`): none of the above applies — they never call `createVectorDB` and
+  must stay that way. This is enforced structurally, not just documented
+  (see "The detector" below).
+- **Writers** (`lien index`, `lien serve`): legitimately create the index.
+  Unchanged by this policy.
+
+**The one hard constraint that cuts across all of the above: never turn a
+genuinely clean, freshly-indexed result into a false alarm.** A state check
+that fires on real data because it merely *shares a shape* with S1/S3 (a
+real 0-violations report; a real 0-results search) destroys the signal's
+value — see #1014, where a false "not found in the index" caveat fired on
+every worktree session and trained everyone to ignore it. Every check in
+this codebase gates on the actual state (`hasData()`, `getIndexedFiles()`),
+never on the shape of the result alone.
+
+## The detector
+
+`packages/cli/test/integration/index-state-matrix.test.ts` is the table
+test: every read-only entry point in the surface below, crossed with every
+state that applies to it, asserting the actual response against a real
+`SqliteBackend` — no `createVectorDB` mocking, so a regression has to
+actually reproduce rather than merely fail to satisfy a mock's expectation.
+
+### The surface (as of #1029 W1)
+
+Only five non-test files under `packages/cli/src` call `createVectorDB`:
+
+| File | Role |
+|------|------|
+| `mcp/server.ts` | Writer (`lien serve`) — exempt |
+| `cli/index-cmd.ts` | Writer (`lien index`) — exempt |
+| `cli/complexity.ts` | Read-only, gate-shaped |
+| `cli/annotate-cmd.ts` | Read-only, advisory |
+| `cli/api-delta-cmd.ts` | Read-only, advisory |
+
+Plus the six MCP tools dispatched through `mcp/handlers/index.ts`'s
+`toolHandlers` registry: `search_code`, `find_similar`, `get_files_context`,
+`list_functions`, `get_dependents`, `get_complexity`.
+
+Plus three CLI commands that are read-only and index-**independent** —
+`lien status` (has its own, already-correct index-state handling — not in
+the `createVectorDB`-caller set because it reads the store's on-disk
+presence/manifest directly, never opens the backend), `lien path`, `lien
+delta`, `lien config get`.
+
+### The completeness guard
+
+The table above is only a detector as long as it can't silently go stale.
+Rather than trust a hand-maintained list, the test derives the real surface
+two ways and cross-checks both against the table:
+
+1. **A source scan** for every non-test file under `packages/cli/src` that
+   calls `createVectorDB(` (stripping comment-only lines first, so a doc
+   comment that merely *mentions* the call isn't mistaken for a real call
+   site). If a new file starts calling it — including one of the
+   index-independent commands quietly growing an index dependency — the
+   discovered set diverges from the known one and the guard fails until a
+   human adds a table row (or a writer exemption).
+2. **`Object.keys(toolHandlers)`** — the MCP server's own dispatch registry
+   — cross-checked against the table's MCP rows the same way.
+
+This is the mechanism that stops the table itself from becoming the next
+"one decision, applied at fewer than N sites" — the exact pattern this
+whole campaign exists to close.
+
+## Adding a new read-only, index-backed command
+
+1. Decide which disposition it is: gate-shaped, advisory, or an MCP tool.
+2. Call `classifyIndexState` (whole-index) and/or `findUnindexedPaths`
+   (per-path) — don't hand-roll the S0/S1/S2 ladder again.
+3. Wire the response per the policy table above for that disposition.
+4. Add the file to `index-state-matrix.test.ts`'s known-callers set (or
+   `toolHandlers`, for an MCP tool) and add its row(s) to `TABLE`. The
+   completeness guard will fail until you do — that's the point.

--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -659,18 +659,38 @@ describe('annotateCommand (integration)', () => {
   // "no index found" warning a real, resolvable path gets against an
   // unindexed root (see 'warns loudly instead of silently analyzing an
   // unindexed root' below) — NOT silence.
-  it('warns instead of silently exiting for a non-existent file (unindexed root)', async () => {
+  //
+  // #1029 W1: `reportUnresolvedPath` used to skip straight to
+  // `createVectorDB(rootDir).initialize()` before checking
+  // `hasStructuralIndex` — since `createVectorDB` here is the REAL
+  // implementation (only mocked per-test via `mockResolvedValueOnce`
+  // elsewhere in this describe block), that silently materialized an empty
+  // `structural.db` in tmpHome as a side effect of asking about a typo'd
+  // path on a virgin project. The printed warning was already correct; only
+  // the side effect was wrong.
+  it('warns instead of silently exiting for a non-existent file (unindexed root), without creating a structural.db', async () => {
     await annotateCommand('this/path/does/not/exist.ts');
     expect(errSpy).not.toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy.mock.calls[0][0]).toContain('Lien: no index found at the resolved project root');
+    expect(coreModule.createVectorDB).not.toHaveBeenCalled();
   });
 
   // HOOKS-9's actual reported shape: an INDEXED repo given a path the index
   // has never heard of. Mocks createVectorDB directly (rather than building
   // a real index in tmpHome) so `hasData()` reports true without an actual
-  // indexing pass.
+  // indexing pass — but `reportUnresolvedPath`'s `hasStructuralIndex`
+  // pre-check (#1029 W1) is a REAL filesystem check in this describe block,
+  // so a real (content-irrelevant) `structural.db` stub must exist too, or
+  // that check reads this as an unindexed root instead.
   it('says the path is not found in the index for a non-existent path in an INDEXED repo', async () => {
+    const fs = await import('fs/promises');
+    const { getIndexDir } = await import('@liendev/core');
+    const rootDir = resolveProjectRoot(toAbsolutePath(process.cwd()));
+    const idxDir = getIndexDir(rootDir);
+    await fs.mkdir(idxDir, { recursive: true });
+    await fs.writeFile(path.join(idxDir, 'structural.db'), '', 'utf-8');
+
     vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
       initialize: vi.fn().mockResolvedValue(undefined),
       hasData: vi.fn().mockResolvedValue(true),

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -526,12 +526,25 @@ async function reportUnresolvedPath(file: string): Promise<boolean> {
   if (!file.trim()) return false;
 
   const rootDir = resolveProjectRoot(toAbsolutePath(process.cwd()));
+
+  // #1029 W1: check existence BEFORE createVectorDB/initialize() — same
+  // reason as `run()`'s own pre-check just below (see `hasStructuralIndex`'s
+  // doc comment). This call site used to skip straight to `createVectorDB`,
+  // which silently materializes an empty structural.db as a side effect on a
+  // never-indexed project — the printed warning text was already correct
+  // (via the `hasData()` check below), but a virgin project shouldn't gain a
+  // stray store just because someone ran `lien annotate` on a typo'd path.
+  if (!(await hasStructuralIndex(rootDir))) {
+    console.log(formatNoIndexWarning(rootDir));
+    return false;
+  }
+
   const vectorDB = await createVectorDB(rootDir);
   await vectorDB.initialize();
 
-  // #894: same "index never built" check `run()` makes for a resolvable
-  // path — a stray/typo'd path against a never-indexed root should say so,
-  // not "not found in the index" (which implies indexing exists to check).
+  // #894: defense-in-depth for the rarer case where the store file exists
+  // but genuinely has zero rows — the `hasStructuralIndex` check above only
+  // catches "never indexed at all".
   if (!(await vectorDB.hasData())) {
     console.log(formatNoIndexWarning(rootDir));
     return false;

--- a/packages/cli/src/cli/api-delta-cmd.test.ts
+++ b/packages/cli/src/cli/api-delta-cmd.test.ts
@@ -450,6 +450,7 @@ describe('apiDeltaCommand — enrichment when an index is present', () => {
     };
     vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
       initialize: vi.fn().mockResolvedValue(undefined),
+      hasData: vi.fn().mockResolvedValue(true),
       getCurrentVersion: vi.fn().mockReturnValue(1),
       scanAll: vi.fn().mockResolvedValue([targetChunk, callerChunk]),
     } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
@@ -476,6 +477,46 @@ describe('apiDeltaCommand — enrichment when an index is present', () => {
     expect(errSpy).not.toHaveBeenCalled();
   });
 
+  // #1029 W1: the index DIRECTORY existing (structural.db on disk) is not
+  // the same as the store having usable data — a cleared/moved-aside/
+  // mid-rebuild store must degrade exactly like "no index at all" (S0),
+  // never report a real-looking `enriched: true, dependentCount: 0`.
+  it('degrades to signature-only when the index directory exists but the store has 0 rows', async () => {
+    await write('a.ts', 'export function formatUser(user) { return user.name; }');
+    await git('add', '-A');
+    await git('-c', 'commit.gpgsign=false', 'commit', '-q', '-m', 'init');
+    await write('a.ts', 'export function formatUser(user, opts) { return user.name; }');
+
+    const { getIndexDir } = await import('@liendev/core');
+    const realIndexDir = getIndexDir(dir);
+    await fs.mkdir(realIndexDir, { recursive: true });
+    await fs.writeFile(path.join(realIndexDir, 'structural.db'), '', 'utf-8');
+
+    vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      hasData: vi.fn().mockResolvedValue(false),
+      getCurrentVersion: vi.fn().mockReturnValue(1),
+      scanAll: vi.fn().mockResolvedValue([]),
+    } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
+
+    await expect(apiDeltaCommand({ format: 'json', file: 'a.ts' })).rejects.toThrow('__exit__:0');
+
+    const result = lastJsonLog() as {
+      changes: Array<{
+        symbol: string;
+        enriched: boolean;
+        dependentCount: number | null;
+        untestedDependentCount: number | null;
+      }>;
+    };
+    expect(result.changes[0]).toMatchObject({
+      symbol: 'formatUser',
+      enriched: false,
+      dependentCount: null,
+      untestedDependentCount: null,
+    });
+  });
+
   it('reports docRefCount/docRefPaths for a REMOVED symbol referenced by doc chunks in the stub index', async () => {
     await write('a.ts', 'export function oldHelper() { return 1; }');
     await git('add', '-A');
@@ -495,6 +536,7 @@ describe('apiDeltaCommand — enrichment when an index is present', () => {
     };
     vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
       initialize: vi.fn().mockResolvedValue(undefined),
+      hasData: vi.fn().mockResolvedValue(true),
       getCurrentVersion: vi.fn().mockReturnValue(1),
       scanAll: vi.fn().mockResolvedValue([docChunk]),
     } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);
@@ -532,6 +574,7 @@ describe('apiDeltaCommand — enrichment when an index is present', () => {
 
     vi.mocked(coreModule.createVectorDB).mockResolvedValueOnce({
       initialize: vi.fn().mockResolvedValue(undefined),
+      hasData: vi.fn().mockResolvedValue(true),
       getCurrentVersion: vi.fn().mockReturnValue(1),
       scanAll: vi.fn().mockResolvedValue([]),
     } as unknown as Awaited<ReturnType<typeof coreModule.createVectorDB>>);

--- a/packages/cli/src/cli/api-delta-cmd.ts
+++ b/packages/cli/src/cli/api-delta-cmd.ts
@@ -21,7 +21,7 @@ import {
 } from '../utils/signature-delta.js';
 import { recordBlastEvent, type BlastEvent } from '../utils/blast-events.js';
 import { findDocReferences } from '../utils/doc-references.js';
-import { hasStructuralIndex } from '../utils/index-freshness.js';
+import { classifyIndexState } from '../utils/index-freshness.js';
 
 export interface ApiDeltaOptions {
   format: 'text' | 'json';
@@ -149,9 +149,18 @@ async function enrichOneChange(
  * Enrich every change with dependent counts + risk, best-effort. Only runs
  * index-touching work when there is at least one change (the rare event) —
  * the common edit pays only the cheap content-based detection. Degrades to
- * signature-only (whole batch) when no index exists or the vectorDB itself
- * fails to open; degrades per-change when `findDependents` throws for that
- * one symbol. Never throws.
+ * signature-only (whole batch) when no index exists (S0), the index exists
+ * but has zero rows (S1 — cleared, moved aside, or mid-rebuild; without this
+ * check `findDependents` would return a real-looking `dependentCount: 0`
+ * marked `enriched: true`, indistinguishable from a verified empty result),
+ * or the vectorDB itself fails to open; degrades per-change when
+ * `findDependents` throws for that one symbol. Never throws.
+ *
+ * Deliberately does not surface S2 (stale index) here — this command is
+ * advisory-only (see the module doc comment) and its core signal (which
+ * exported symbols changed/were removed) comes from the git diff content,
+ * not the index; only the enrichment counts could be mildly stale, which
+ * doesn't warrant interrupting a nudge with a warning.
  */
 async function enrichDeltas(
   rootDir: string,
@@ -159,13 +168,18 @@ async function enrichDeltas(
 ): Promise<EnrichedSignatureDelta[]> {
   if (deltas.length === 0) return [];
 
-  if (!(await hasStructuralIndex(rootDir))) {
-    return deltas.map(d => ({ filepath: d.filepath, changes: d.changes.map(degradedChange) }));
-  }
-
   try {
-    const vectorDB = await createVectorDB(rootDir);
-    await vectorDB.initialize();
+    const result = await classifyIndexState(rootDir, async () => {
+      const vectorDB = await createVectorDB(rootDir);
+      await vectorDB.initialize();
+      return vectorDB;
+    });
+
+    if (result.state === 'S0' || result.state === 'S1' || !result.vectorDB) {
+      return deltas.map(d => ({ filepath: d.filepath, changes: d.changes.map(degradedChange) }));
+    }
+
+    const vectorDB = result.vectorDB;
     // Captured once so every symbol in this run shares the scan cache inside
     // findDependents — only the first symbol in the batch pays the scanAll.
     const indexVersion = vectorDB.getCurrentVersion();

--- a/packages/cli/src/cli/complexity.test.ts
+++ b/packages/cli/src/cli/complexity.test.ts
@@ -65,6 +65,9 @@ describe('complexityCommand', () => {
     mockVectorDB = {
       initialize: vi.fn().mockResolvedValue(undefined),
       scanAll: vi.fn(), // Used for actual analysis
+      // Healthy-index default; the "indexed-but-empty" test below overrides
+      // this to `false` to exercise `classifyIndexState`'s S1 branch.
+      hasData: vi.fn().mockResolvedValue(true),
     };
 
     // The factory hands back our mock instance
@@ -367,6 +370,24 @@ describe('complexityCommand', () => {
     // project that has never been indexed.
     expect(coreModule.createVectorDB).not.toHaveBeenCalled();
     await expect(fs.access(path.join(await indexDir(), 'structural.db'))).rejects.toThrow();
+  });
+
+  // Regression test for the sibling false-clean bug the "never-indexed" test
+  // above doesn't cover: an index DIRECTORY that exists (structural.db is on
+  // disk) but whose store has zero rows — e.g. cleared, moved aside, or
+  // indexed against an all-ignored tree. Before this fix, `ensureIndexExists`
+  // only checked file existence, so this state sailed straight through to
+  // `ComplexityAnalyzer` and reported "0 violations, exit 0" indistinguishable
+  // from a genuinely clean, fully-indexed codebase.
+  it('should error loudly on an indexed-but-empty project (store has 0 rows), without proceeding to analysis', async () => {
+    mockVectorDB.hasData.mockResolvedValue(false);
+
+    await complexityCommand({ format: 'text' });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Index is empty'));
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    // Never even ran the analyzer over the empty store.
+    expect(mockVectorDB.scanAll).not.toHaveBeenCalled();
   });
 
   it('should handle a thrown error from the database gracefully once the index exists', async () => {

--- a/packages/cli/src/cli/complexity.ts
+++ b/packages/cli/src/cli/complexity.ts
@@ -4,8 +4,8 @@ import path from 'path';
 import { createVectorDB } from '@liendev/core';
 import { ComplexityAnalyzer } from '@liendev/core';
 import { formatReport } from '@liendev/core';
-import type { OutputFormat } from '@liendev/core';
-import { hasStructuralIndex, getIndexStalenessWarning } from '../utils/index-freshness.js';
+import type { OutputFormat, VectorDBInterface } from '@liendev/core';
+import { classifyIndexState } from '../utils/index-freshness.js';
 
 interface ComplexityOptions {
   files?: string[];
@@ -53,34 +53,56 @@ function validateFilesExist(files: string[] | undefined, rootDir: string): void 
 }
 
 /**
- * Check if the project has ever been indexed, and exit loudly if not.
+ * Resolve `rootDir`'s whole-index state via the shared classifier
+ * (`classifyIndexState`, `../utils/index-freshness.js`) and exit loudly for
+ * either "never indexed" (S0) or "indexed, but the store has 0 rows" (S1) —
+ * `lien complexity` is a gate-shaped command (`--fail-on`), so a project
+ * with no usable data is always a hard error here, independent of
+ * `--fail-on`. A confident "0 violations, exit 0" on either state would be
+ * exactly the false-clean bug this command exists to never repeat.
  *
- * Deliberately a plain filesystem existence check (`hasStructuralIndex`)
- * rather than opening the database and probing for rows: `createVectorDB(
- * rootDir).initialize()` unconditionally creates the index directory and an
- * empty-but-valid `structural.db` (see `schema.ts`'s `openDatabase`), so
- * calling it first — then discovering there's no data — is too late to
- * distinguish "never indexed" from "empty index," and leaves behind exactly
- * the store this command has no business creating. `lien complexity` is a
- * gate-shaped command (`--fail-on`), so a missing index is always a hard
- * error here, independent of `--fail-on`.
+ * `classifyIndexState` itself guarantees `createVectorDB(...).initialize()`
+ * — which unconditionally creates the index directory and an empty-but-
+ * valid `structural.db` (see `schema.ts`'s `openDatabase`) — is never even
+ * invoked for S0, so a never-indexed project is never left with a stray
+ * store as a side effect of this check.
  *
- * Returns whether the index exists. `process.exit(1)` terminates the process
- * for real in production, but the boolean return (checked by the caller) is
- * what actually stops this function's caller from proceeding to
- * `createVectorDB` in a test environment where `process.exit` is mocked —
- * belt-and-suspenders against ever opening the database on a missing index.
+ * Returns the ready-to-use `vectorDB` for `ok`/`S2`, or `undefined` after
+ * already exiting for `S0`/`S1`. `process.exit(1)` terminates the process
+ * for real in production, but the `undefined` return (checked by the
+ * caller) is what actually stops this function's caller from proceeding to
+ * `ComplexityAnalyzer` in a test environment where `process.exit` is
+ * mocked — belt-and-suspenders against ever analyzing 0 rows as a clean
+ * report.
  */
-async function ensureIndexExists(rootDir: string): Promise<boolean> {
-  if (await hasStructuralIndex(rootDir)) return true;
-  console.error(chalk.red('Error: Index not found'));
-  console.log(
-    chalk.yellow('\nRun'),
-    chalk.bold('lien index'),
-    chalk.yellow('to index your codebase first'),
-  );
-  process.exit(1);
-  return false;
+async function resolveIndexOrExit(rootDir: string): Promise<VectorDBInterface | undefined> {
+  const result = await classifyIndexState(rootDir, async () => {
+    const vectorDB = await createVectorDB(rootDir);
+    await vectorDB.initialize();
+    return vectorDB;
+  });
+
+  if (result.state === 'S0' || result.state === 'S1') {
+    const reason = result.state === 'S0' ? 'Index not found' : 'Index is empty (0 indexed files)';
+    console.error(chalk.red(`Error: ${reason}`));
+    console.log(
+      chalk.yellow('\nRun'),
+      chalk.bold('lien index'),
+      chalk.yellow('to index your codebase first'),
+    );
+    process.exit(1);
+    return undefined;
+  }
+
+  // `lien serve`'s auto-reindex machinery (git-detection.ts) doesn't run for
+  // this one-shot command, so a repo whose working tree has moved on since
+  // the last `lien index`/`lien serve` reindex would otherwise report a
+  // silent false clean. Warn, don't block or auto-reindex.
+  if (result.state === 'S2' && result.warning) {
+    console.warn(chalk.yellow(result.warning));
+  }
+
+  return result.vectorDB;
 }
 
 /**
@@ -95,22 +117,10 @@ export async function complexityCommand(options: ComplexityOptions) {
     validateFormat(options.format);
     validateFilesExist(options.files, rootDir);
 
-    // Cheap existence check BEFORE ever opening the database — see
-    // `ensureIndexExists`'s doc comment for why this must come first.
-    if (!(await ensureIndexExists(rootDir))) return;
-
-    // `lien serve`'s auto-reindex machinery (git-detection.ts) doesn't run
-    // for this one-shot command, so a repo whose working tree has moved on
-    // since the last `lien index`/`lien serve` reindex would otherwise
-    // report a silent false clean. Warn, don't block or auto-reindex —
-    // reuses the same staleness check `lien status` already computes.
-    const stalenessWarning = await getIndexStalenessWarning(rootDir);
-    if (stalenessWarning) console.warn(chalk.yellow(stalenessWarning));
-
-    // Initialize database via the factory so reads hit the same backend
-    // `lien index` wrote
-    const vectorDB = await createVectorDB(rootDir);
-    await vectorDB.initialize();
+    // Classify the index state and exit loudly for S0/S1 — see
+    // `resolveIndexOrExit`'s doc comment.
+    const vectorDB = await resolveIndexOrExit(rootDir);
+    if (!vectorDB) return;
 
     // Run analysis and output (uses default thresholds)
     const analyzer = new ComplexityAnalyzer(vectorDB);

--- a/packages/cli/src/mcp/handlers/find-similar.test.ts
+++ b/packages/cli/src/mcp/handlers/find-similar.test.ts
@@ -13,6 +13,7 @@ describe('handleFindSimilar', () => {
 
   let mockVectorDB: {
     search: ReturnType<typeof vi.fn>;
+    hasData: ReturnType<typeof vi.fn>;
   };
 
   let mockCtx: ToolContext;
@@ -53,6 +54,9 @@ describe('handleFindSimilar', () => {
 
     mockVectorDB = {
       search: vi.fn(),
+      // Healthy-index default; the "no data at all" test below overrides
+      // this to `false` to exercise the `hasData()`-gated note.
+      hasData: vi.fn().mockResolvedValue(true),
     };
 
     mockCtx = {
@@ -454,6 +458,33 @@ describe('handleFindSimilar', () => {
       expect(parsed.note).toContain('0 results');
       expect(parsed.note).toContain('24 characters');
       expect(parsed.note).toContain('grep');
+    });
+
+    // #1029 W1: 0 results on a structural store with no data at all (never
+    // indexed, cleared, or mid-rebuild) used to get the exact same "ensure
+    // the snippet is representative" note as a genuinely healthy index that
+    // just found nothing similar — indistinguishable from "confirmed absent"
+    // when it should read as "unknown".
+    it('escalates to the unmissable no-index note when the structural store has no data at all', async () => {
+      mockVectorDB.search.mockResolvedValue([]);
+      mockVectorDB.hasData.mockResolvedValue(false);
+
+      const result = await handleFindSimilar({ code: 'async function fetchData() {}' }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(0);
+      expect(parsed.note).toContain('⚠ Lien:');
+      expect(parsed.note).toContain('no data');
+    });
+
+    it('does not call hasData() when results are already non-empty', async () => {
+      mockVectorDB.search.mockResolvedValue([
+        createMockResult({ content: 'function fetchUser() {}' }),
+      ]);
+
+      await handleFindSimilar({ code: 'async function fetchData() {}' }, mockCtx);
+
+      expect(mockVectorDB.hasData).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/cli/src/mcp/handlers/find-similar.ts
+++ b/packages/cli/src/mcp/handlers/find-similar.ts
@@ -1,6 +1,7 @@
 import { wrapToolHandler } from '../utils/tool-wrapper.js';
 import { FindSimilarSchema } from '../schemas/index.js';
 import { shapeResults, deduplicateResults } from '../utils/metadata-shaper.js';
+import { formatNoIndexNote } from '../utils/unindexed-paths.js';
 import type { ToolContext, MCPToolResult } from '../types.js';
 import type { SearchResult, VectorDBInterface } from '@liendev/core';
 
@@ -39,9 +40,17 @@ async function fetchCandidates(
 /**
  * Build the diagnostic note, if any. Never states a specific total — only
  * what's actually known (empty, or capped with more possibly available).
+ *
+ * On 0 results, only assert the harder "no index at all" fact (`hasData`)
+ * when it's actually established — same reasoning as search_code/
+ * list_functions's own `hasData()` gate: a structural store with zero rows
+ * (never indexed, cleared, or mid-rebuild) produces the exact same "0
+ * results" as a genuinely healthy index that just found nothing similar,
+ * which is exactly backwards for a tool an agent is told to trust.
  */
-function buildNote(finalCount: number, hasMore: boolean): string | undefined {
+function buildNote(finalCount: number, hasMore: boolean, hasData: boolean): string | undefined {
   if (finalCount === 0) {
+    if (!hasData) return formatNoIndexNote();
     return '0 results. Ensure the code snippet is at least 24 characters and representative of the pattern. Try grep for exact string matches.';
   }
   if (hasMore) {
@@ -150,7 +159,11 @@ export async function handleFindSimilar(args: unknown, ctx: ToolContext): Promis
     // have more filtered candidates than `limit` shows, OR the underlying
     // fetch window wasn't proven exhausted (see fetchCandidates).
     const hasMore = filtered.length > limit || !fetchWindowExhausted;
-    const note = buildNote(finalResults.length, hasMore);
+    // Only pay for the extra hasData() round-trip when it would actually
+    // change the note (0 results) — same "only ask when it matters" pattern
+    // as get_complexity/list_functions.
+    const hasData = finalResults.length > 0 || (await vectorDB.hasData());
+    const note = buildNote(finalResults.length, hasMore, hasData);
 
     return {
       indexInfo: getIndexMetadata(),

--- a/packages/cli/src/mcp/handlers/get-complexity.test.ts
+++ b/packages/cli/src/mcp/handlers/get-complexity.test.ts
@@ -42,6 +42,7 @@ describe('handleGetComplexity', () => {
     scanWithFilter: vi.fn(),
     getCurrentVersion: vi.fn(() => 1234567890),
     getVersionDate: vi.fn(() => '2025-12-19'),
+    hasData: vi.fn(),
   };
 
   // Config no longer needed - ComplexityAnalyzer uses defaults
@@ -74,6 +75,9 @@ describe('handleGetComplexity', () => {
       mockAnalyzeFn.mockClear();
     }
     vi.mocked(findUnindexedPaths).mockResolvedValue([]);
+    // Healthy-index default; the "empty structural store" tests below
+    // override this to `false` to exercise the `hasData()`-gated note.
+    mockVectorDB.hasData.mockResolvedValue(true);
   });
 
   const getMockAnalyze = () => (globalThis as any).__mockAnalyze;
@@ -620,6 +624,34 @@ describe('handleGetComplexity', () => {
       const result = await handleGetComplexity({ top: 10 }, mockCtx);
 
       expect(findUnindexedPaths).not.toHaveBeenCalled();
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed).not.toHaveProperty('note');
+    });
+
+    // #1029 W1: a whole-codebase sweep (no `files` filter) over a structural
+    // store with zero rows (never indexed, cleared, or mid-rebuild) used to
+    // report "0 files analyzed, 0 violations" with no note at all —
+    // structurally indistinguishable from a genuinely clean, fully-indexed
+    // codebase. `findUnindexedPaths` never even runs in this no-`files`
+    // path (see the test above), so it can't be the thing that catches this.
+    it('adds the unmissable no-index note on a whole-codebase sweep when the structural store has no data at all', async () => {
+      mockVectorDB.hasData.mockResolvedValue(false);
+      getMockAnalyze().mockResolvedValue(emptyReport);
+
+      const result = await handleGetComplexity({ top: 10 }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.note).toContain('⚠ Lien:');
+      expect(parsed.note).toContain('no data');
+      expect(parsed.summary.filesAnalyzed).toBe(0);
+    });
+
+    it('does not add the no-index note when a whole-codebase sweep genuinely finds 0 violations on a healthy index', async () => {
+      mockVectorDB.hasData.mockResolvedValue(true);
+      getMockAnalyze().mockResolvedValue(emptyReport);
+
+      const result = await handleGetComplexity({ top: 10 }, mockCtx);
+
       const parsed = JSON.parse(result.content![0].text);
       expect(parsed).not.toHaveProperty('note');
     });

--- a/packages/cli/src/mcp/handlers/get-complexity.ts
+++ b/packages/cli/src/mcp/handlers/get-complexity.ts
@@ -2,7 +2,11 @@ import collect from 'collect.js';
 import { wrapToolHandler } from '../utils/tool-wrapper.js';
 import { GetComplexitySchema } from '../schemas/index.js';
 import type { GetComplexityInput } from '../schemas/index.js';
-import { findUnindexedPaths, formatUnindexedPathsNote } from '../utils/unindexed-paths.js';
+import {
+  findUnindexedPaths,
+  formatUnindexedPathsNote,
+  formatNoIndexNote,
+} from '../utils/unindexed-paths.js';
 import { ComplexityAnalyzer } from '@liendev/core';
 import type { ComplexityViolation, FileComplexityData, ComplexityReport } from '@liendev/parser';
 import type { ToolContext, MCPToolResult } from '../types.js';
@@ -140,6 +144,22 @@ export async function handleGetComplexity(args: unknown, ctx: ToolContext): Prom
       metricType,
     );
 
+    // A whole-repo scan (no `files` filter) over a structural store that has
+    // no data at all (never indexed, cleared, or mid-rebuild) produces
+    // exactly the same "0 files analyzed, 0 violations" shape as a
+    // genuinely clean, fully-indexed codebase — that's backwards for a tool
+    // whose entire purpose is a confidence check before relying on the
+    // answer. `unindexedNote` above already covers the scoped-`files` case
+    // (every requested path already reads as unknown-to-the-index when the
+    // whole store is empty); this only fires the ADDITIONAL "the index
+    // itself is empty" fact when `files` was omitted, mirroring
+    // search_code/list_functions's own `hasData()` gate for the identical
+    // 0-results ambiguity.
+    let note = unindexedNote;
+    if (!note && report.summary.filesAnalyzed === 0 && !(await vectorDB.hasData())) {
+      note = formatNoIndexNote();
+    }
+
     return {
       indexInfo: getIndexMetadata(),
       summary: {
@@ -150,7 +170,7 @@ export async function handleGetComplexity(args: unknown, ctx: ToolContext): Prom
         bySeverity,
       },
       violations: topViolations,
-      ...(unindexedNote && { note: unindexedNote }),
+      ...(note && { note }),
     };
   })(args);
 }

--- a/packages/cli/src/utils/index-freshness.ts
+++ b/packages/cli/src/utils/index-freshness.ts
@@ -1,5 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
+import type { VectorDBInterface } from '@liendev/core';
 import { getIndexDir, isGitRepo, getCurrentBranch, getCurrentCommit } from '@liendev/core';
 
 /**
@@ -100,4 +101,84 @@ export async function getIndexStalenessWarning(rootDir: string): Promise<string 
   } catch {
     return null;
   }
+}
+
+/**
+ * The whole-index states a read-only, index-backed command can find itself
+ * in (see #1029 W1 — this is the shared classifier that replaces every call
+ * site re-deriving its own version of this ladder):
+ *
+ * - `S0` — no index directory at all (never indexed).
+ * - `S1` — the index directory exists, but the structural store has zero
+ *   rows (cleared, moved aside, or indexed against an all-ignored tree).
+ * - `S2` — the store has data, but it's stale vs the working tree's current
+ *   git HEAD (the one-shot CLI path has no auto-reindex machinery — that
+ *   only lives in `lien serve`'s `git-detection.ts` — so this is the only
+ *   place staleness gets caught).
+ * - `ok` — none of the above; safe to answer normally.
+ *
+ * Deliberately NOT covering "the requested path isn't in the index" (S3 in
+ * the issue's vocabulary) — that's a per-path question, answered by
+ * `findUnindexedPaths` (`../mcp/utils/unindexed-paths.js`) against a
+ * specific filepath, not a whole-index state this classifier can decide in
+ * isolation. Nor does it cover "the analysis mechanism structurally cannot
+ * see an answer" (Java same-package, Ruby class names, type symbols) — that
+ * is #1026's `attributionCaveat` vocabulary (`get_dependents`'s
+ * `AttributionCaveatReason`), a different axis entirely: this classifier is
+ * about the INDEX's state, not about a language's import-graph visibility.
+ */
+export type IndexState = 'S0' | 'S1' | 'S2' | 'ok';
+
+export interface IndexStateResult {
+  state: IndexState;
+  /** Populated only for `S2` — the human-readable staleness warning. */
+  warning?: string;
+  /**
+   * The opened, initialized `VectorDBInterface` — present for every state
+   * except `S0`, where it is deliberately never constructed at all (see
+   * `hasStructuralIndex`'s doc comment: `createVectorDB(rootDir).initialize()`
+   * itself materializes an empty store as a side effect, which is exactly
+   * the bug this classifier exists to prevent).
+   */
+  vectorDB?: VectorDBInterface;
+}
+
+/**
+ * Classify `rootDir`'s whole-index state in one call, composing the three
+ * checks above in the only safe order: the cheap on-disk existence check
+ * FIRST (so an `S0` project is never opened at all), then — only once that
+ * has ruled out S0 — open the store and check `hasData()` for `S1`, then
+ * the git-state comparison for `S2`.
+ *
+ * `openVectorDB` is a thunk (not a plain `VectorDBInterface`) specifically
+ * so this function — not each call site — owns the decision of whether to
+ * ever invoke `createVectorDB(...).initialize()` at all. Callers that
+ * already need an initialized `vectorDB` for their real work get it back on
+ * the result (`ok`/`S1`/`S2`) rather than opening it a second time; callers
+ * that only need the verdict can ignore the field.
+ *
+ * This is the single place new read-only, index-backed commands should call
+ * into — see CLAUDE.md's "Index-state honesty" policy and
+ * `docs/architecture/index-state-honesty.md`.
+ */
+export async function classifyIndexState(
+  rootDir: string,
+  openVectorDB: () => Promise<VectorDBInterface>,
+): Promise<IndexStateResult> {
+  if (!(await hasStructuralIndex(rootDir))) {
+    return { state: 'S0' };
+  }
+
+  const vectorDB = await openVectorDB();
+
+  if (!(await vectorDB.hasData())) {
+    return { state: 'S1', vectorDB };
+  }
+
+  const warning = await getIndexStalenessWarning(rootDir);
+  if (warning) {
+    return { state: 'S2', warning, vectorDB };
+  }
+
+  return { state: 'ok', vectorDB };
 }

--- a/packages/cli/test/integration/index-state-matrix.test.ts
+++ b/packages/cli/test/integration/index-state-matrix.test.ts
@@ -1,0 +1,984 @@
+/**
+ * #1029 Workstream 1 — the index-state × entry-point detector.
+ *
+ * Every read-only, index-backed entry point Lien exposes, exercised against
+ * every whole-index state it can find itself in (S0/S1/S2/S3/ok — see
+ * `../../src/utils/index-freshness.ts`'s `IndexState` doc comment and
+ * `docs/architecture/index-state-honesty.md`), asserting the ACTUAL response
+ * — not just "a response exists". This is the detector for the largest
+ * defect class in #1017's sweep: a confident answer where the honest answer
+ * is "I don't know."
+ *
+ * Two things make this a detector rather than a snapshot:
+ *
+ * 1. Every assertion is on real behavior against a REAL `SqliteBackend` (no
+ *    `createVectorDB` mocking) — a regression has to actually reproduce, not
+ *    just fail to satisfy a mock expectation.
+ * 2. The completeness guard at the bottom fails the build the moment a new
+ *    read-only, index-touching entry point exists that isn't accounted for
+ *    here — derived from a source scan + the MCP tool registry, not a
+ *    hand-maintained list anyone could forget to update.
+ *
+ * Test isolation: every test gets its own project directory AND its own
+ * `LIEN_HOME` (via `process.env.LIEN_HOME`, restored in `afterEach`) — never
+ * `os.homedir()` mocking, which `getLienHome()` doesn't even consult once
+ * `LIEN_HOME` is set (see #1037's incident: mocking `os.homedir()` alone is
+ * silently a no-op once vitest's `global-setup.ts` has already set
+ * `LIEN_HOME` for the whole run).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { fileURLToPath } from 'url';
+import { createVectorDB, indexCodebase, type VectorDBInterface } from '@liendev/core';
+import { complexityCommand } from '../../src/cli/complexity.js';
+import { apiDeltaCommand } from '../../src/cli/api-delta-cmd.js';
+import { annotateCommand } from '../../src/cli/annotate-cmd.js';
+import { statusCommand } from '../../src/cli/status.js';
+import { pathCommand } from '../../src/cli/path-cmd.js';
+import { deltaCommand } from '../../src/cli/delta-cmd.js';
+import { configGetCommand } from '../../src/cli/config.js';
+import { handleSearchCode } from '../../src/mcp/handlers/search-code.js';
+import { handleGetFilesContext } from '../../src/mcp/handlers/get-files-context.js';
+import { handleGetDependents } from '../../src/mcp/handlers/get-dependents.js';
+import { handleGetComplexity } from '../../src/mcp/handlers/get-complexity.js';
+import { handleListFunctions } from '../../src/mcp/handlers/list-functions.js';
+import { handleFindSimilar } from '../../src/mcp/handlers/find-similar.js';
+import { toolHandlers } from '../../src/mcp/handlers/index.js';
+import type { ToolContext } from '../../src/mcp/types.js';
+
+const execFileAsync = promisify(execFile);
+
+// ============================================================================
+// The table (deliverable #3) — one row per (entry point, state). Rendered
+// verbatim in the PR body. `state: 'n/a'` rows document why a state doesn't
+// apply (never a silent omission) rather than being skipped.
+// ============================================================================
+
+type EntryPointState = 'S0' | 'S1' | 'S2' | 'S3' | 'ok' | 'n/a';
+
+interface TableRow {
+  entryPoint: string;
+  state: EntryPointState;
+  expected: string;
+}
+
+const TABLE: TableRow[] = [
+  // --- CLI, index-touching (gate-shaped: hard error on S0/S1) ---
+  { entryPoint: 'lien complexity', state: 'S0', expected: 'error, exit 1, "Index not found"' },
+  {
+    entryPoint: 'lien complexity',
+    state: 'S1',
+    expected: 'error, exit 1, "Index is empty (0 indexed files)"',
+  },
+  {
+    entryPoint: 'lien complexity',
+    state: 'S2',
+    expected: 'loud stderr staleness warning, still analyzes (never silent, never blocks)',
+  },
+  {
+    entryPoint: 'lien complexity',
+    state: 'ok',
+    expected: 'real report; exit 0 on a genuinely clean fixture (no over-firing)',
+  },
+  // --- CLI, index-touching (advisory nudge: loud warning, exit 0 by design) ---
+  {
+    entryPoint: 'lien annotate',
+    state: 'S0',
+    expected: 'loud "no index found" warning printed, exit 0 (advisory — see policy nuance)',
+  },
+  {
+    entryPoint: 'lien annotate',
+    state: 'S1',
+    expected: 'same loud warning as S0 (indistinguishable to this advisory tool)',
+  },
+  {
+    entryPoint: 'lien annotate',
+    state: 'S3',
+    expected: '"not found in the index" note for the unresolved path, exit 0',
+  },
+  {
+    entryPoint: 'lien annotate',
+    state: 'ok',
+    expected: 'real dependents/tests/complexity annotation printed',
+  },
+  {
+    entryPoint: 'lien api-delta',
+    state: 'S0',
+    expected: 'degrades: enriched:false, dependentCount:null (never a fabricated 0), exit 0',
+  },
+  {
+    entryPoint: 'lien api-delta',
+    state: 'S1',
+    expected: 'degrades identically to S0 (#1029 W1 fix — previously a false enriched:true/0)',
+  },
+  {
+    entryPoint: 'lien api-delta',
+    state: 'ok',
+    expected: 'enriched:true with real dependentCount',
+  },
+  // --- CLI, index-independent (never touch the structural store at all) ---
+  {
+    entryPoint: 'lien status',
+    state: 'S0',
+    expected: '"✗ Not indexed" (already honest — reference implementation)',
+  },
+  {
+    entryPoint: 'lien status',
+    state: 'S1',
+    expected: '"✓ Exists" + "Index files: 0" — a true zero, not a lie',
+  },
+  {
+    entryPoint: 'lien status',
+    state: 'S2',
+    expected: '"⚠️ Git state changed" warning',
+  },
+  { entryPoint: 'lien status', state: 'ok', expected: 'real indexed-file count, no warning' },
+  {
+    entryPoint: 'lien path',
+    state: 'n/a',
+    expected: 'never touches the index — output identical regardless of index state',
+  },
+  {
+    entryPoint: 'lien delta',
+    state: 'n/a',
+    expected: 'git-diff/AST only, never touches the index — output identical regardless',
+  },
+  {
+    entryPoint: 'lien config get',
+    state: 'n/a',
+    expected: 'global config only, never touches the index — output identical regardless',
+  },
+  // --- MCP tools (S0 is structurally impossible: `lien serve` always
+  //     initializes the store before registering tool handlers) ---
+  {
+    entryPoint: 'search_code',
+    state: 'S1',
+    expected: 'note: "⚠ Lien: ... no data" (never a bare confident 0 results)',
+  },
+  { entryPoint: 'search_code', state: 'ok', expected: 'real hit, no note' },
+  {
+    entryPoint: 'list_functions',
+    state: 'S1',
+    expected: 'note: "⚠ Lien: ... no data"',
+  },
+  { entryPoint: 'list_functions', state: 'ok', expected: 'real hit, no note' },
+  {
+    entryPoint: 'find_similar',
+    state: 'S1',
+    expected: 'note: "⚠ Lien: ... no data" (#1029 W1 fix — previously the generic 0-results note)',
+  },
+  { entryPoint: 'find_similar', state: 'ok', expected: 'real hit, no note' },
+  {
+    entryPoint: 'get_complexity',
+    state: 'S1',
+    expected: 'note: "⚠ Lien: ... no data" on a whole-repo scan (#1029 W1 fix — previously silent)',
+  },
+  {
+    entryPoint: 'get_complexity',
+    state: 'S3',
+    expected: 'unindexed-path note naming the requested file',
+  },
+  { entryPoint: 'get_complexity', state: 'ok', expected: 'real violation reported, no note' },
+  {
+    entryPoint: 'get_dependents',
+    state: 'S1',
+    expected: 'attributionCaveat: unresolved-target + unindexed-path note (S1 ⊆ S3 here)',
+  },
+  {
+    entryPoint: 'get_dependents',
+    state: 'S3',
+    expected: 'attributionCaveat: unresolved-target + unindexed-path note',
+  },
+  {
+    entryPoint: 'get_dependents',
+    state: 'ok',
+    expected: 'real dependent found, no attributionCaveat',
+  },
+  {
+    entryPoint: 'get_files_context',
+    state: 'S1',
+    expected: 'unindexed-path note (S1 ⊆ S3 here — filepath is mandatory)',
+  },
+  { entryPoint: 'get_files_context', state: 'S3', expected: 'unindexed-path note' },
+  { entryPoint: 'get_files_context', state: 'ok', expected: 'real chunks returned, no note' },
+];
+
+// ============================================================================
+// Fixture helpers
+// ============================================================================
+
+async function git(dir: string, ...args: string[]): Promise<void> {
+  await execFileAsync('git', args, { cwd: dir });
+}
+
+async function initRepo(dir: string): Promise<void> {
+  await git(dir, 'init', '-q');
+  await git(dir, 'config', 'user.email', 'test@example.com');
+  await git(dir, 'config', 'user.name', 'Test');
+  await git(dir, 'config', 'commit.gpgsign', 'false');
+}
+
+async function commitAll(dir: string, message: string): Promise<void> {
+  await git(dir, 'add', '-A');
+  await git(dir, '-c', 'commit.gpgsign=false', 'commit', '-q', '-m', message);
+}
+
+/**
+ * Real fixture: a tiny git repo with a high-complexity function (crosses the
+ * default cyclomatic warn threshold of 15 — `DEFAULT_COMPLEXITY_THRESHOLDS`
+ * in `@liendev/parser`), a real cross-file dependent, and a real
+ * import-associated test file. Indexed for real via `indexCodebase` — no
+ * hand-built chunk metadata — so every entry point below reads genuinely
+ * indexed data, not a mock's approximation of it.
+ */
+async function writeHealthyFixture(dir: string): Promise<void> {
+  const manyIfs = Array.from({ length: 20 }, (_, i) => `  if (x === ${i}) r += ${i};`).join('\n');
+  await fs.writeFile(
+    path.join(dir, 'math.ts'),
+    [
+      'export function add(a: number, b: number): number {',
+      '  return a + b;',
+      '}',
+      '',
+      'export function manyBranches(x: number): number {',
+      '  let r = x;',
+      manyIfs,
+      '  return r;',
+      '}',
+      '',
+    ].join('\n'),
+  );
+  await fs.writeFile(
+    path.join(dir, 'caller.ts'),
+    [
+      "import { add } from './math';",
+      '',
+      'export function useAdd(a: number, b: number) {',
+      '  return add(a, b);',
+      '}',
+      '',
+    ].join('\n'),
+  );
+  await fs.writeFile(
+    path.join(dir, 'math.test.ts'),
+    [
+      "import { add } from './math';",
+      '',
+      "test('adds', () => {",
+      '  expect(add(1, 2)).toBe(3);',
+      '});',
+      '',
+    ].join('\n'),
+  );
+}
+
+async function buildHealthyIndex(dir: string): Promise<void> {
+  await initRepo(dir);
+  await writeHealthyFixture(dir);
+  await commitAll(dir, 'init');
+  const result = await indexCodebase({ rootDir: dir, verbose: false });
+  if (!result.success || result.filesIndexed < 3) {
+    throw new Error(`fixture indexing failed: ${JSON.stringify(result)}`);
+  }
+}
+
+function makeCtx(vectorDB: VectorDBInterface): ToolContext {
+  return {
+    vectorDB,
+    rootDir: process.cwd(),
+    log: () => undefined,
+    checkAndReconnect: async () => undefined,
+    getIndexMetadata: () => ({
+      indexVersion: vectorDB.getCurrentVersion(),
+      indexDate: vectorDB.getVersionDate(),
+    }),
+    getReindexState: () => ({
+      inProgress: false,
+      pendingFiles: [],
+      lastReindexTimestamp: null,
+      lastReindexDurationMs: null,
+    }),
+  };
+}
+
+// ============================================================================
+// Shared per-test isolation
+// ============================================================================
+
+describe('index-state × entry-point matrix (#1029 W1)', () => {
+  let dir: string;
+  let home: string;
+  let originalCwd: string;
+  let originalHome: string | undefined;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-ism-'));
+    dir = await fs.realpath(dir); // resolve macOS /var -> /private/var
+    originalCwd = process.cwd();
+    process.chdir(dir);
+
+    // Redirect LIEN_HOME (not os.homedir()) per test, restored in afterEach —
+    // see this file's module doc comment for why the distinction matters.
+    originalHome = process.env.LIEN_HOME;
+    home = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-ism-home-'));
+    process.env.LIEN_HOME = home;
+
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    // Never throws — several commands under test (`api-delta`, `delta`) call
+    // `process.exit` unconditionally as their last statement even on a clean
+    // run (by design: both are one-shot CLI processes in production). Let
+    // execution fall off the end of the function normally instead.
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    if (originalHome === undefined) delete process.env.LIEN_HOME;
+    else process.env.LIEN_HOME = originalHome;
+    vi.restoreAllMocks();
+    await fs.rm(dir, { recursive: true, force: true });
+    await fs.rm(home, { recursive: true, force: true });
+  });
+
+  // Several commands (`lien status` chief among them) call `console.log`
+  // with multiple positional args (e.g. `console.log(chalk.dim('Index
+  // files:'), count)`) rather than one pre-joined string — join every arg
+  // of every call, not just the first, or half the printed line goes
+  // missing from assertions.
+  /** Strip chalk's ANSI color codes so assertions match on plain text, not raw escape sequences. */
+  function stripAnsi(s: string): string {
+    return s.replace(/\x1b\[[0-9;]*m/g, '');
+  }
+
+  function allLogged(): string {
+    return stripAnsi(
+      [...logSpy.mock.calls, ...errSpy.mock.calls, ...warnSpy.mock.calls]
+        .map(call => call.map(String).join(' '))
+        .join('\n'),
+    );
+  }
+
+  function clearLogs(): void {
+    logSpy.mockClear();
+    errSpy.mockClear();
+    warnSpy.mockClear();
+    exitSpy.mockClear();
+  }
+
+  // ==========================================================================
+  // CLI, index-touching, gate-shaped: S0/S1 must be a hard error.
+  // ==========================================================================
+
+  describe('lien complexity', () => {
+    it('S0: errors loudly, exit 1, never opens the database', async () => {
+      await complexityCommand({ format: 'text' });
+
+      expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('Index not found'));
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('S1: errors loudly, exit 1 (index directory exists, store has 0 rows)', async () => {
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      await complexityCommand({ format: 'text' });
+
+      expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('Index is empty'));
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('S2: warns loudly but still analyzes (stale git state, never silent)', async () => {
+      await buildHealthyIndex(dir);
+      await fs.writeFile(path.join(dir, 'extra.ts'), 'export const z = 1;\n');
+      await commitAll(dir, 'second commit');
+
+      await complexityCommand({ format: 'text' });
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('stale'));
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Complexity Analysis'));
+    });
+
+    it('ok: reports the real violation on a genuinely clean, freshly-indexed fixture — no over-firing', async () => {
+      await buildHealthyIndex(dir);
+
+      await complexityCommand({ format: 'json' });
+
+      const output = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+      expect(output.summary.filesAnalyzed).toBeGreaterThan(0);
+      expect(output.summary.totalViolations).toBeGreaterThan(0);
+      expect(errSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // CLI, index-touching, advisory nudge: loud warning is the bar, not exit
+  // code — see docs/architecture/index-state-honesty.md's policy nuance.
+  // ==========================================================================
+
+  describe('lien annotate', () => {
+    it('S0: prints a loud "no index found" warning, exit 0', async () => {
+      await fs.writeFile(
+        path.join(dir, 'math.ts'),
+        'export function add(a, b) { return a + b; }\n',
+      );
+
+      await annotateCommand('math.ts');
+
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Lien: no index found'));
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it('S1: prints the same loud warning as S0 (index directory exists, store has 0 rows)', async () => {
+      await fs.writeFile(
+        path.join(dir, 'math.ts'),
+        'export function add(a, b) { return a + b; }\n',
+      );
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      await annotateCommand('math.ts');
+
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Lien: no index found'));
+    });
+
+    it('S3: reports "not found in the index" for an unresolvable path in an indexed repo', async () => {
+      await buildHealthyIndex(dir);
+
+      await annotateCommand('does/not/exist.ts');
+
+      expect(allLogged()).toContain('not found in the index');
+    });
+
+    it('ok: prints the real annotation (dependents/tests/complexity)', async () => {
+      await buildHealthyIndex(dir);
+
+      await annotateCommand('math.ts');
+
+      expect(allLogged()).toContain('Lien impact for math.ts');
+    });
+  });
+
+  describe('lien api-delta', () => {
+    async function writeSignatureChange(before: string, after: string): Promise<void> {
+      await initRepo(dir);
+      await fs.writeFile(path.join(dir, 'a.ts'), before);
+      await commitAll(dir, 'init');
+      await fs.writeFile(path.join(dir, 'a.ts'), after);
+    }
+
+    it('S0: degrades to signature-only — never a fabricated dependentCount:0', async () => {
+      await writeSignatureChange(
+        'export function formatUser(user) { return user.name; }\n',
+        'export function formatUser(user, opts) { return user.name; }\n',
+      );
+
+      await apiDeltaCommand({ format: 'json', file: 'a.ts' });
+
+      const printed = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+      expect(printed.changes[0]).toMatchObject({ enriched: false, dependentCount: null });
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('S1: degrades identically to S0 (index directory exists, store has 0 rows)', async () => {
+      await writeSignatureChange(
+        'export function formatUser(user) { return user.name; }\n',
+        'export function formatUser(user, opts) { return user.name; }\n',
+      );
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      await apiDeltaCommand({ format: 'json', file: 'a.ts' });
+
+      const printed = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+      expect(printed.changes[0]).toMatchObject({ enriched: false, dependentCount: null });
+    });
+
+    it('ok: enriches with the real dependent count', async () => {
+      await buildHealthyIndex(dir);
+      // Uncommitted signature change on top of the real indexed state —
+      // `caller.ts` is a real, already-indexed dependent of `add`.
+      await fs.writeFile(
+        path.join(dir, 'math.ts'),
+        [
+          'export function add(a: number, b: number, c: number): number {',
+          '  return a + b + c;',
+          '}',
+          '',
+          'export function manyBranches(x: number): number { return x; }',
+          '',
+        ].join('\n'),
+      );
+
+      await apiDeltaCommand({ format: 'json', file: 'math.ts' });
+
+      const printed = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+      const addChange = printed.changes.find((c: { symbol: string }) => c.symbol === 'add');
+      // Real dependents: caller.ts (production) and math.test.ts (both
+      // import `add`) — assert real enrichment ran, not an exact count that
+      // would make this test brittle to fixture changes.
+      expect(addChange.enriched).toBe(true);
+      expect(addChange.dependentCount).toBeGreaterThan(0);
+    });
+  });
+
+  // ==========================================================================
+  // CLI, index-touching, but a plain descriptive report — `lien status`
+  // already gets this right (reference implementation, unchanged by W1).
+  // ==========================================================================
+
+  describe('lien status', () => {
+    it('S0: reports "Not indexed"', async () => {
+      await statusCommand({ format: 'text' });
+
+      expect(allLogged()).toContain('Not indexed');
+    });
+
+    it('S1: reports "Exists" + a true zero indexed-file count (not a lie)', async () => {
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      await statusCommand({ format: 'text' });
+
+      const printed = allLogged();
+      expect(printed).toContain('Exists');
+      expect(/Index files:\s*0\b/.test(printed)).toBe(true);
+    });
+
+    it('S2: warns about stale git state', async () => {
+      await buildHealthyIndex(dir);
+      await fs.writeFile(path.join(dir, 'extra.ts'), 'export const z = 1;\n');
+      await commitAll(dir, 'second commit');
+
+      await statusCommand({ format: 'text' });
+
+      expect(allLogged()).toContain('Git state changed');
+    });
+
+    it('ok: reports the real indexed-file count, no staleness warning', async () => {
+      await buildHealthyIndex(dir);
+
+      await statusCommand({ format: 'text' });
+
+      const printed = allLogged();
+      expect(printed).not.toContain('Git state changed');
+      expect(/Index files:\s*3\b/.test(printed)).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // CLI, index-INDEPENDENT: never touch the structural store at all, so
+  // their output must never vary with index state — proven behaviorally,
+  // not just asserted by comment.
+  // ==========================================================================
+
+  describe('lien path (index-independent)', () => {
+    it('produces identical output whether or not an index exists', async () => {
+      pathCommand({ root: true });
+      const withoutIndex = allLogged();
+      clearLogs();
+
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      pathCommand({ root: true });
+      const withIndex = allLogged();
+
+      expect(withIndex).toBe(withoutIndex);
+      expect(withoutIndex.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('lien delta (index-independent)', () => {
+    it('produces identical output whether or not an index exists', async () => {
+      await initRepo(dir);
+      await fs.writeFile(path.join(dir, 'a.ts'), 'export const a = 1;\n');
+      await commitAll(dir, 'init');
+
+      // `lien delta` reports its own elapsed ms in the text — strip that one
+      // genuinely-nondeterministic number before comparing, or this test
+      // would flake on timing noise alone.
+      const stripTiming = (s: string): string => s.replace(/\(\d+ ms\)/g, '(N ms)');
+
+      await deltaCommand({ format: 'text' });
+      const withoutIndex = stripTiming(allLogged());
+      clearLogs();
+
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      await deltaCommand({ format: 'text' });
+      const withIndex = stripTiming(allLogged());
+
+      expect(withIndex).toBe(withoutIndex);
+    });
+  });
+
+  describe('lien config get (index-independent)', () => {
+    it('produces identical output whether or not an index exists', async () => {
+      await configGetCommand('backend');
+      const withoutIndex = allLogged();
+      clearLogs();
+
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      await configGetCommand('backend');
+      const withIndex = allLogged();
+
+      expect(withIndex).toBe(withoutIndex);
+      expect(withoutIndex.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ==========================================================================
+  // MCP tools. S0 is structurally impossible here: `lien serve` always
+  // initializes the structural store (`createVectorDB(...).initialize()`)
+  // before ever registering tool handlers — see mcp/server.ts's
+  // `startMCPServer` -> `initializeComponents` -> `setupAndConnectServer` ->
+  // `registerMCPHandlers` ordering. The earliest state a tool call can ever
+  // observe is S1.
+  // ==========================================================================
+
+  describe('search_code', () => {
+    it('S1: notes the whole-index-empty fact instead of a bare 0 results', async () => {
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      const result = await handleSearchCode({ query: 'manyBranches' }, makeCtx(vectorDB));
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(0);
+      expect(parsed.note).toContain('⚠ Lien:');
+      expect(parsed.note).toContain('no data');
+    });
+
+    it('ok: finds the real hit, no note', async () => {
+      await buildHealthyIndex(dir);
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      const result = await handleSearchCode({ query: 'manyBranches' }, makeCtx(vectorDB));
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results.length).toBeGreaterThan(0);
+      expect(parsed.note).toBeUndefined();
+    });
+  });
+
+  describe('list_functions', () => {
+    it('S1: notes the whole-index-empty fact instead of a bare 0 results', async () => {
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      const result = await handleListFunctions({ pattern: '.*' }, makeCtx(vectorDB));
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(0);
+      expect(parsed.note).toContain('no data');
+    });
+
+    it('ok: finds the real symbol, no note', async () => {
+      await buildHealthyIndex(dir);
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      const result = await handleListFunctions({ pattern: 'manyBranches' }, makeCtx(vectorDB));
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('find_similar', () => {
+    const snippet = 'export function manyBranches(x: number): number { let r = x; return r; }';
+
+    it('S1: notes the whole-index-empty fact instead of the generic 0-results note (#1029 W1 fix)', async () => {
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      const result = await handleFindSimilar({ code: snippet }, makeCtx(vectorDB));
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results).toHaveLength(0);
+      expect(parsed.note).toContain('⚠ Lien:');
+      expect(parsed.note).toContain('no data');
+    });
+
+    it('ok: finds the real hit, no note', async () => {
+      await buildHealthyIndex(dir);
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      const result = await handleFindSimilar({ code: snippet }, makeCtx(vectorDB));
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.results.length).toBeGreaterThan(0);
+      expect(parsed.note).toBeUndefined();
+    });
+  });
+
+  describe('get_complexity', () => {
+    it('S1: notes the whole-index-empty fact on a whole-repo scan (#1029 W1 fix)', async () => {
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      const result = await handleGetComplexity({ top: 10 }, makeCtx(vectorDB));
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.summary.filesAnalyzed).toBe(0);
+      expect(parsed.note).toContain('⚠ Lien:');
+      expect(parsed.note).toContain('no data');
+    });
+
+    it('S3: names the unindexed path instead of a silent 0', async () => {
+      await buildHealthyIndex(dir);
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      const result = await handleGetComplexity({ files: ['does/not/exist.ts'] }, makeCtx(vectorDB));
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.note).toContain('does/not/exist.ts');
+    });
+
+    it('ok: reports the real violation, no note', async () => {
+      await buildHealthyIndex(dir);
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      const result = await handleGetComplexity({ top: 10 }, makeCtx(vectorDB));
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.summary.violationCount).toBeGreaterThan(0);
+      expect(parsed.note).toBeUndefined();
+    });
+  });
+
+  describe('get_dependents', () => {
+    it('S1: attributionCaveat unresolved-target + unindexed note (S1 ⊆ S3 here)', async () => {
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      const result = await handleGetDependents({ filepath: 'math.ts' }, makeCtx(vectorDB));
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.attributionCaveat?.reason).toBe('unresolved-target');
+      expect(parsed.dependentCount).toBe(0);
+    });
+
+    it('S3: attributionCaveat unresolved-target for a specific unindexed path', async () => {
+      await buildHealthyIndex(dir);
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      const result = await handleGetDependents(
+        { filepath: 'does/not/exist.ts' },
+        makeCtx(vectorDB),
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.attributionCaveat?.reason).toBe('unresolved-target');
+    });
+
+    it('ok: finds the real dependent, no attributionCaveat', async () => {
+      await buildHealthyIndex(dir);
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      const result = await handleGetDependents({ filepath: 'math.ts' }, makeCtx(vectorDB));
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.dependentCount).toBeGreaterThan(0);
+      expect(parsed.attributionCaveat).toBeUndefined();
+    });
+  });
+
+  describe('get_files_context', () => {
+    it('S1: unindexed-path note (S1 ⊆ S3 here — filepath is mandatory)', async () => {
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      const result = await handleGetFilesContext({ filepaths: 'math.ts' }, makeCtx(vectorDB));
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.note).toContain('⚠ Lien:');
+      expect(parsed.note).toContain('not found in the index');
+    });
+
+    it('S3: unindexed-path note for a specific unindexed path', async () => {
+      await buildHealthyIndex(dir);
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      const result = await handleGetFilesContext(
+        { filepaths: 'does/not/exist.ts' },
+        makeCtx(vectorDB),
+      );
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.note).toContain('not found in the index');
+    });
+
+    it('ok: returns the real chunks, no note', async () => {
+      await buildHealthyIndex(dir);
+      const vectorDB = await createVectorDB(dir);
+      await vectorDB.initialize();
+
+      const result = await handleGetFilesContext({ filepaths: 'math.ts' }, makeCtx(vectorDB));
+
+      const parsed = JSON.parse(result.content![0].text);
+      expect(parsed.chunks.length).toBeGreaterThan(0);
+      expect(parsed.note).toBeUndefined();
+    });
+  });
+});
+
+// ============================================================================
+// Deliverable #4 — the completeness guard.
+//
+// The table above is only a detector as long as it can't silently go stale.
+// Rather than trust a hand-maintained list of "every read-only entry point",
+// this derives the REAL surface two ways and cross-checks both against the
+// known set this file's TABLE was written against:
+//
+//   (a) a source scan for every non-test file under packages/cli/src that
+//       calls `createVectorDB(` — the issue's own framing: "only five
+//       non-test files call createVectorDB ... so the surface is genuinely
+//       enumerable." Two of the five are legitimate WRITERS (`lien index`,
+//       `lien serve`) and stay exempt; the other three are the CLI rows in
+//       TABLE. If a new file starts calling `createVectorDB`, the discovered
+//       set grows past the known one and this fails — forcing whoever added
+//       it to add a TABLE row (or the writer exemption) before the guard is
+//       green again. This is also what would catch `lien path`/`lien delta`/
+//       `lien config get` quietly growing an index dependency: those three
+//       are ABSENT from the known-callers set specifically because they
+//       don't call it, so a stray call site added to any of them makes the
+//       discovered set diverge from the known one just the same.
+//   (b) `Object.keys(toolHandlers)` — the MCP server's own dispatch registry
+//       (`mcp/handlers/index.ts`) — cross-checked against TABLE's MCP rows.
+//       A new tool handler registered there without a TABLE entry fails this
+//       the same way.
+// ============================================================================
+
+describe('completeness guard (#1029 W1) — table vs. real source', () => {
+  const thisFile = fileURLToPath(import.meta.url);
+  const CLI_SRC_DIR = path.resolve(path.dirname(thisFile), '../../src');
+
+  /** Files legitimately allowed to call `createVectorDB` without a TABLE row: they CREATE the index, not just read it. */
+  const WRITER_EXEMPT = new Set(['mcp/server.ts', 'cli/index-cmd.ts']);
+
+  /** Strip comment-only lines so a doc comment that merely MENTIONS `createVectorDB(` in prose isn't mistaken for a real call site. */
+  function stripCommentLines(content: string): string {
+    return content
+      .split('\n')
+      .filter(line => !/^\s*(\*|\/\/)/.test(line))
+      .join('\n');
+  }
+
+  async function findCreateVectorDbCallers(): Promise<Set<string>> {
+    const found = new Set<string>();
+
+    async function walk(dir: string): Promise<void> {
+      const entries = await fs.readdir(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          await walk(full);
+          continue;
+        }
+        if (!entry.name.endsWith('.ts') || entry.name.endsWith('.test.ts')) continue;
+        const content = await fs.readFile(full, 'utf-8');
+        if (/createVectorDB\s*\(/.test(stripCommentLines(content))) {
+          found.add(path.relative(CLI_SRC_DIR, full).replace(/\\/g, '/'));
+        }
+      }
+    }
+
+    await walk(CLI_SRC_DIR);
+    return found;
+  }
+
+  /** Every entryPoint name TABLE documents for the CLI, index-touching (non-writer) rows. */
+  const TABLE_CLI_INDEX_TOUCHING = new Set(
+    TABLE.filter(row =>
+      ['lien complexity', 'lien annotate', 'lien api-delta'].includes(row.entryPoint),
+    ).map(row => row.entryPoint),
+  );
+
+  /** Every entryPoint name TABLE documents as explicitly index-independent. */
+  const TABLE_CLI_INDEX_INDEPENDENT = new Set(
+    TABLE.filter(row => row.state === 'n/a').map(row => row.entryPoint),
+  );
+
+  it('every file that calls createVectorDB is either a known writer or a CLI row in TABLE', async () => {
+    const discovered = await findCreateVectorDbCallers();
+    const readOnlyDiscovered = new Set([...discovered].filter(file => !WRITER_EXEMPT.has(file)));
+    const expectedReadOnlyFiles = new Set([
+      'cli/annotate-cmd.ts',
+      'cli/api-delta-cmd.ts',
+      'cli/complexity.ts',
+    ]);
+
+    expect(readOnlyDiscovered).toEqual(expectedReadOnlyFiles);
+    // Every discovered writer really is on the exemption list (catches a
+    // WRITER_EXEMPT entry that's gone stale in the other direction too).
+    for (const file of discovered) {
+      if (!readOnlyDiscovered.has(file)) expect(WRITER_EXEMPT.has(file)).toBe(true);
+    }
+    // And TABLE actually has a row for each of the three read-only callers —
+    // the other half of "the table must fail when an entry point isn't in
+    // it": a discovered file with zero TABLE rows would pass the set
+    // equality above but still leave the class undocumented.
+    expect(TABLE_CLI_INDEX_TOUCHING).toEqual(
+      new Set(['lien complexity', 'lien annotate', 'lien api-delta']),
+    );
+  });
+
+  it('the three index-independent CLI commands (status is index-touching, not independent) stay off the createVectorDB caller list', async () => {
+    const discovered = await findCreateVectorDbCallers();
+    expect(discovered.has('cli/path-cmd.ts')).toBe(false);
+    expect(discovered.has('cli/delta-cmd.ts')).toBe(false);
+    expect(discovered.has('cli/config.ts')).toBe(false);
+    expect(TABLE_CLI_INDEX_INDEPENDENT).toEqual(
+      new Set(['lien path', 'lien delta', 'lien config get']),
+    );
+  });
+
+  it('every registered MCP tool handler has a TABLE row, and vice versa', () => {
+    const registered = new Set(Object.keys(toolHandlers));
+    const tabled = new Set(
+      TABLE.filter(row =>
+        [
+          'search_code',
+          'get_files_context',
+          'get_dependents',
+          'get_complexity',
+          'list_functions',
+          'find_similar',
+        ].includes(row.entryPoint),
+      ).map(row => row.entryPoint),
+    );
+
+    expect(registered).toEqual(
+      new Set([
+        'search_code',
+        'find_similar',
+        'get_files_context',
+        'list_functions',
+        'get_dependents',
+        'get_complexity',
+      ]),
+    );
+    expect(tabled).toEqual(registered);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Workstream 1 of #1029**: the detector for the largest defect class from #1017's sweep (~11 of 28 confirmed defects) — a confident answer where the honest answer is "I don't know."

### 1. Shared classifier

`packages/cli/src/utils/index-freshness.ts` (from #1031) gains `classifyIndexState`, composing the existing `hasStructuralIndex`/`getIndexStalenessWarning` primitives into one call:

- **S0** no index directory at all
- **S1** index exists, store has 0 rows
- **S2** store has data but is stale vs git HEAD
- (S3 — "path not in the index" — is a separate per-path concern, already served by `findUnindexedPaths`; not folded into this whole-index classifier)

Explicitly does **not** duplicate #1026's `attributionCaveat` vocabulary (the mechanism-blind-to-a-real-usage case) — different axis.

### 2. Policy

`CLAUDE.md` ("Index-State Honesty — MANDATORY for New Commands/Tools") + `docs/architecture/index-state-honesty.md`. The response required differs by command disposition — **never a blanket rule**:

| Disposition | S0/S1 | S2 | S3 |
|---|---|---|---|
| Gate-shaped (`lien complexity --fail-on`) | Hard error, non-zero exit | Loud warning, still runs | — |
| Advisory nudge (`lien annotate`, `lien api-delta`) | Loud warning/degraded marker, exit 0 is fine | n/a | "not found in the index" |
| MCP tool | S0 structurally impossible; S1 → explicit `note`/`attributionCaveat` | n/a (serve's git-detection keeps it fresh) | explicit `note`/`attributionCaveat` |

I pushed back on the issue's literal "S0/S1 → error, non-zero exit" for `lien annotate`/`lien api-delta`: both are explicitly advisory-only by design (exit 0 always; `lien annotate`'s exit 2 is a *different*, pre-existing habituation signal shell hooks depend on). Forcing a hard nonzero exit there would collide with that contract and risk breaking hook plumbing outside my lane. The bar for these is "never silent," not "never exit 0" — documented explicitly as the policy nuance.

### 3. The detector (table test)

`packages/cli/test/integration/index-state-matrix.test.ts` — every read-only entry point × every state that applies to it, asserted against a **real `SqliteBackend`** (no `createVectorDB` mocking):

- CLI: `complexity`, `annotate`, `api-delta` (index-touching); `status` (already correct); `path`, `delta`, `config get` (index-independent — proven behaviorally identical with/without an index)
- MCP: `search_code`, `get_files_context`, `get_dependents`, `get_complexity`, `list_functions`, `find_similar`

36 tests, ~1.9s, stable across repeated runs.

### 4. Completeness guard

Two structural checks, not a hand-maintained list:
- A source scan for every non-test file under `packages/cli/src` calling `createVectorDB(` (comment-stripped first), cross-checked against the known 3 read-only callers + 2 writer exemptions (`mcp/server.ts`, `cli/index-cmd.ts`).
- `Object.keys(toolHandlers)` cross-checked against the table's MCP rows.

### Bugs found and fixed along the way (same class, previously unfixed)

Building the table's "ok" cells surfaced 3 real gaps in already-shipped code (#1031/#1034 only fixed the CLI-side S0 case, not these):

- **`get_complexity` (MCP)**: whole-repo scan (no `files`) on an empty store → `filesAnalyzed: 0, violations: []`, no note at all. Now mirrors `search_code`/`list_functions`'s `hasData()` gate.
- **`find_similar` (MCP)**: 0 results on an empty store got the generic "make your snippet more representative" note, same as a healthy 0-match query. Now escalates to the no-data note.
- **`lien api-delta`**: index directory exists but 0 rows → real-looking `enriched: true, dependentCount: 0` instead of degrading.
- **`lien annotate`**: `reportUnresolvedPath` (typo'd path) skipped the `hasStructuralIndex` guard its sibling call sites already have, silently creating a stray empty `structural.db` on a virgin project.
- **`lien complexity`**: only caught S0, not S1 (index dir exists, 0 rows) — extended.

## Verification (dogfooded per CLAUDE.md's mandatory policy)

**Completeness guard catches a new unaccounted-for entry point** — added a dummy file calling `createVectorDB`, guard failed:
```
- Set { 'cli/annotate-cmd.ts', 'cli/api-delta-cmd.ts', 'cli/complexity.ts' }
+ Set { 'cli/annotate-cmd.ts', 'cli/api-delta-cmd.ts', 'cli/complexity.ts', 'cli/scratch-dummy-cmd.ts' }
```
Removed the file, guard green again.

**Detector catches the real #1031 shape** — temporarily reverted `complexity.ts`'s guard to the old unconditional-open pattern:
```
FAIL lien complexity > S0: errors loudly, exit 1, never opens the database
FAIL lien complexity > S1: errors loudly, exit 1 (index directory exists, store has 0 rows)
FAIL lien complexity > S2: warns loudly but still analyzes (stale git state, never silent)
```
Reverted the revert; all green.

**Every new fix's own test fails when the fix is reverted** (not just "never observed failing"): temporarily disabled the `get_complexity`, `find_similar`, and `api-delta` fixes one at a time — all 3 corresponding table cells failed for the right reason, e.g.:
```
FAIL get_complexity > S1: notes the whole-index-empty fact on a whole-repo scan
FAIL find_similar > S1: notes the whole-index-empty fact instead of the generic 0-results note
FAIL lien api-delta > S1: degrades identically to S0
  - { "dependentCount": null, "enriched": false }
  + { "dependentCount": 0, "enriched": true }
```
Restored; all 36 tests green again.

**No over-firing** — real CLI dogfood, virgin dir → `lien index` → clean fixture:
```
$ lien complexity --fail-on error
Complexity Analysis
  Files analyzed: 1
  Violations: 0 (0 errors, 0 warnings)
No violations found!
EXIT: 0
```

**S0/S1 real dogfood** (built CLI, not just tests):
```
$ lien complexity --fail-on error   # virgin dir, never indexed
Error: Index not found
EXIT: 1

$ lien complexity --fail-on error   # index dir exists, store empty
Error: Index is empty (0 indexed files)
EXIT: 1
```

**`lien index` on a virgin directory still works**: confirmed via the dogfood above (`Indexing complete (1/1)`, exit 0).

**Gates**: `format:check`, `lint` (0 errors), `typecheck`, `build`, `npm test` (full monorepo, 1629+ cli tests + all other packages), `lien delta` (exit 0, no new-over-threshold or crossed functions) — all green, re-verified after rebasing onto main post-#1041 (W3).

## Test plan
- [x] `packages/cli/test/integration/index-state-matrix.test.ts` — 36 new tests, real backend, no mocking
- [x] Updated existing tests in `complexity.test.ts`, `annotate-cmd.test.ts`, `api-delta-cmd.test.ts`, `get-complexity.test.ts`, `find-similar.test.ts` for the new S1 checks
- [x] Completeness guard verified to fail on a dummy entry point (see above)
- [x] Regression shape verified to fail when reintroduced (see above)
- [x] Real CLI dogfood: virgin dir, empty-store dir, clean fixture — all correct

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR implements Workstream 1 of #1029: a shared index-state classifier (`classifyIndexState`) and a detector test matrix that prevents read-only, index-backed commands from producing confident answers when no usable index data exists. The changes are well-scoped, thoroughly tested (36 integration tests plus updated unit tests), and the policy is documented in CLAUDE.md and a new architecture doc. The classifier correctly orders checks (filesystem existence before opening the store), and every touched call site handles S0/S1/S2/ok appropriately for its disposition (gate-shaped CLI hard-errors, advisory commands degrade/warn, MCP tools emit explicit notes).
>
> - Added `classifyIndexState` in `packages/cli/src/utils/index-freshness.ts` to consolidate S0/S1/S2 detection.
> - Extended `lien complexity` to hard-error on S1 (empty store), not just S0.
> - Fixed `lien api-delta`, `lien annotate`, `get_complexity`, and `find_similar` to degrade or warn instead of returning confident empty results on missing/empty indexes.
> - Added `packages/cli/test/integration/index-state-matrix.test.ts` with a completeness guard that fails when new `createVectorDB` call sites or MCP tool handlers are unaccounted for.

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 0518dcc. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 659K/783K tokens
<!-- /lien:attestation -->