### PR TITLE
fix(parser): make matcher-path LanguageDefinition fields required (ADR-015, #1038)

### DIFF
--- a/.changeset/adr-015-required-matcher-fields.md
+++ b/.changeset/adr-015-required-matcher-fields.md
@@ -1,0 +1,36 @@
+---
+"@liendev/parser": patch
+---
+
+Make `LanguageDefinition`'s three matcher-path fields (`wholeModuleImports`,
+`singleFileImports`, `namespaceStyleImports`) required instead of optional,
+per ADR-015 (#1038). Previously a language declaring nothing silently
+inherited the shared matcher's permissive defaults — 7 of 11 languages
+(TypeScript, JavaScript, Python, Rust, Go, Java, Kotlin) declared none of
+these three fields, so nobody had ever had to state whether that permissive
+default was correct-by-design or correct-by-accident for them. This is the
+mechanism behind #1028: a leniency added for Swift/Go/Ruby silently applied
+to Rust too, which had never opted into anything.
+
+All 11 language definitions now declare all three fields explicitly,
+verified against a real corpus per language (requests, zod, express,
+monolog, anyhow, chi, javapoet, mediatr, sinatra, klaxon, swiftyjson) — see
+each definition file's own citation. Only Swift (`wholeModuleImports`),
+Ruby (`singleFileImports`), and PHP (`namespaceStyleImports`) are `true`;
+every other cell is an explicit, evidence-backed `false`. This corrects one
+factual error surfaced during verification: C# was previously believed to
+already set `wholeModuleImports` (per issue #1038's own "current state"
+table) — it does not, and never has; it only sets the separate,
+out-of-scope `enclosingNamespaceAccess` flag. Rust's `singleFileImports`
+stays `false` per #1021/#1024's own established reasoning (`mod`-derived
+specifiers bypass these flags entirely via `rust-mod-marker.ts`).
+
+Behavior-preserving by construction: every declared value matches the
+language's current effective default, confirmed via full before/after
+per-file dependency-edge dumps across all 11 corpora (byte-identical, modulo
+one pre-existing, code-independent non-determinism in zod's re-export
+transitive resolution — filed separately as #1044, unrelated to this
+change). Adding a 12th language definition without declaring all three
+fields is now a compile error. A new cross-language policy table asserts
+these fields stay sparse and mutually exclusive per language, so future
+additions don't quietly relocate the same drift.

--- a/docs/architecture/decisions/0015-required-matcher-path-language-fields.md
+++ b/docs/architecture/decisions/0015-required-matcher-path-language-fields.md
@@ -1,0 +1,203 @@
+# ADR-015: Make Per-Language Matching Policy Mandatory and Declarative
+
+**Status**: Accepted
+**Date**: 2026-08-01
+**Deciders**: Core Team
+**Related**: #1038 (proposal, adversarial critique, and revised decision),
+PR #1045 (implementation) · #883, #884, #887, #928, #929, #1005, #1017,
+#1021, #1024, #1028, #1029, #1032
+
+## Context and Problem Statement
+
+`matchesFile` (`packages/parser/src/utils/path-matching.ts`) resolves
+imports for 11 languages via five strategies. Per-language behaviour is
+configured through optional flags on `LanguageDefinition`
+(`packages/parser/src/ast/languages/types.ts`) that the matcher reads via
+`=== true`. Because the flags are optional, a language declaring nothing
+silently inherits the shared matcher's permissive defaults — measured on
+`main` before this ADR, only 3 of 11 languages (PHP, Ruby, Swift) declared
+any of the three matcher-path fields (`wholeModuleImports`,
+`singleFileImports`, `namespaceStyleImports`); the other 8, including Rust
+and Go, whose module semantics are anything but default, declared none.
+
+At runtime, `unset` and `false` are identical — `hasWholeModuleImports` and
+its siblings compare with `=== true`. The gap is purely epistemic: nobody
+had ever had to state whether the permissive default was correct-by-design
+or correct-by-accident for the 8 silent languages. This is the mechanism
+behind #1028: a leniency added for Swift/Go/Ruby's real conventions (#883)
+silently applied to Rust too, which had never opted into anything, and
+fabricated self-edges on a real `dtolnay/anyhow` clone before #1032 fixed
+it reactively.
+
+An earlier version of this issue proposed migrating matching *policy*
+itself into per-language matcher objects, arguing this had decayed over
+months. An adversarial critique found the timeline claim was wrong by a
+factor of ~34 (the five escape hatches in question landed over eight days
+during an intensive measurement campaign, not months of silent drift), and
+that the migration's stated benefit — structural impossibility of
+cross-language leakage — was not delivered by the option chosen: the
+shared matching primitives (`matchesAtBoundaryPrecise` et al.) would stay
+shared either way, and several of the cited incidents lived *inside* those
+primitives, not at the per-language dispatch layer. That proposal was
+rejected; this ADR records the revised decision instead. The critique and
+the concession are preserved verbatim in #1038's comment history.
+
+## Decision Drivers
+
+- New languages must not silently inherit permissive defaults nobody
+  examined.
+- The fix must not require restructuring the hottest matching function in
+  the repo for a behaviourally-neutral migration.
+- Every declared value must be verifiable against real code, not asserted
+  from theory.
+- Runtime behaviour must not change as a side effect of closing the gap —
+  a wrong declared value is a regression, not a refactor.
+
+## Considered Options
+
+1. **Status quo** — cheapest per individual incident, and the 8-day #883→
+   #1032 record shows the reactive loop converging quickly. Rejected only
+   because the 8 silent languages remain undiagnosed and language #12 would
+   inherit the same defaults with nobody deciding so.
+2. **Migrate matching policy into per-language matcher objects** (the
+   original proposal) — rejected. Does not deliver structural leak-proofing
+   (see Context); converges on today's architecture, restructured, for a
+   byte-identical behavioural no-op.
+3. **Make the matcher-path fields on `LanguageDefinition` required, keep
+   the shared matching engine, add a cross-language policy table.**
+   Selected.
+
+## Decision Outcome
+
+Chosen option: **3 — required fields, shared engine, no migration**,
+because it delivers the one benefit that survives scrutiny (new languages
+get opt-in semantics instead of inherited defaults) at day-scale effort
+with zero behavioural change, while leaving `matchesFile`'s battle-tested
+shared primitives untouched.
+
+Scope is exactly the three fields that sit on `importMatchesTarget`'s
+matcher path: `wholeModuleImports` (`registry.ts`'s
+`hasWholeModuleImports`), `singleFileImports`
+(`hasSingleFileImportSemantics`), and `namespaceStyleImports`
+(`hasNamespaceMatchingSemantics`). `enclosingNamespaceAccess`,
+`sameDirectoryTestConvention`, `samePackageTestConvention`, and
+`sameUnitAccessWithoutImport` are a different mechanism (test-association
+and `get_dependents` honesty-caveat policy, consulted outside
+`path-matching.ts` entirely) and are out of scope — changing `?:` to `:`
+for those is a separate decision this ADR does not make.
+
+1. **Required fields.** `?: boolean` → `: boolean` for the three fields, so
+   a 12th language definition omitting any of them is a compile error
+   (`TS2739`), and all 11 existing languages had to state intent
+   explicitly.
+2. **Declare all 11 languages' real value for all three fields**, each
+   verified against a real corpus (PR #1045's evidence table). Net result:
+   exactly 3 of 33 cells are `true` (Swift/`wholeModuleImports`,
+   Ruby/`singleFileImports`, PHP/`namespaceStyleImports` — all pre-existing
+   and re-verified, not newly introduced); every other cell, including all
+   21 for the 8 previously-silent languages, is an evidence-backed `false`
+   matching the pre-existing effective default.
+3. **Cross-language policy table** (`registry.test.ts`) asserting what's
+   genuinely establishable as universal across languages: every language
+   declares a real boolean (never `undefined`) for all three fields; at
+   most one of the three flags is `true` per language (they are
+   alternative, largely mutually-exclusive bare-specifier resolution
+   strategies); and the three escape hatches stay sparse (at most one
+   language sets each field `true` — a tripwire that forces a conscious
+   decision before a third or fourth escape hatch accumulates unnoticed,
+   rather than a hard architectural ceiling).
+4. **Keep extraction-time form-tagging (`rust-mod-marker.ts`) as the
+   established pattern** for per-import-form dispatch within a single
+   language — it already works inside the current architecture and this
+   ADR does not change it. Rust's `singleFileImports` stays `false`
+   precisely because of this: `mod`-derived specifiers bypass these flags
+   entirely via the marker, so the flag continues to govern only `use`/
+   `self::`/`super::` specifiers, exactly as before #1021/#1024.
+
+## Consequences
+
+### Positive
+
+- Opt-in rather than inherited semantics: a 13th language cannot be added
+  without a compiler-enforced decision on all three fields.
+- The 8 previously-silent languages were examined once, each against real
+  code, closing a real diagnostic gap (#1028's root cause) without waiting
+  for another reactive incident.
+- Zero behavioural migration: PR #1045's full before/after per-file
+  dependency-edge dump across all 11 real-project corpora is byte-identical
+  in 10 of 11 (the eleventh's one file-pair diff was tracked to a
+  pre-existing, code-independent non-determinism in re-export resolution,
+  filed separately as #1044 — not caused by this change).
+- One factual error surfaced and was corrected during verification: C# was
+  believed (per #1038's own "current state" table) to already set
+  `wholeModuleImports`. It did not — only the separate,
+  out-of-scope `enclosingNamespaceAccess` — confirmed by a pre-existing
+  passing test assertion and the field's own prior comment arguing against
+  setting it.
+
+### Negative / Risks
+
+- The cross-language policy table's "sparse" assertion is a tripwire, not a
+  proof of correctness: a future PR can still set a flag `true` for a wrong
+  reason, it will just have to do so consciously (bump the count) rather
+  than by accident.
+- Two of the four previously-partial languages (PHP, Ruby) had their other
+  two fields newly declared `false` on the basis of "no confirmed
+  regression case today" rather than an exhaustive proof of every possible
+  input shape — an honest, deliberately conservative call documented per
+  language in PR #1045, not a claim of completeness.
+
+### Neutral
+
+- No published API change: `matchesFile` stays exported from
+  `@liendev/parser` and re-exported by `@liendev/core`, unaffected by this
+  ADR (the published-API question raised in #1038's discussion is a
+  separate, still-open concern this ADR does not resolve).
+- `LanguageDefinition`'s other optional fields
+  (`enclosingNamespaceAccess`, `sameDirectoryTestConvention`,
+  `samePackageTestConvention`, `sameUnitAccessWithoutImport`,
+  `importExtractor`, `symbolExtractor`) are untouched.
+
+## Validation
+
+Per #1038's own validation criteria, all satisfied by PR #1045:
+
+1. **Behaviour-preserving**: full before/after per-file dependency-edge
+   dumps across all 11 corpora (requests, zod, express, monolog, anyhow,
+   chi, javapoet, mediatr, sinatra, klaxon, swiftyjson), isolated by
+   reverting only the touched files and rebuilding. 10/11 byte-identical;
+   the zod exception is a pre-existing non-determinism unrelated to this
+   change (#1044).
+2. Every language's declared value that differs from a pre-existing value
+   (there were none — see Consequences/Positive) would have been filed as
+   a finding rather than silently shipped; none was needed.
+3. The cross-language policy table (`registry.test.ts`) fails if a
+   universal rule is violated, and passes today.
+4. A temporary 12th language definition omitting all three fields produced
+   a `TS2739` compile error citing all three missing properties; removed
+   after capturing the proof.
+
+## Alternatives Considered
+
+See Considered Options above; the rejected per-language-matcher migration
+and its critique are preserved verbatim in #1038's comment history rather
+than summarized lossily here.
+
+## References
+
+- `packages/parser/src/utils/path-matching.ts`: `matchesFile`,
+  `importMatchesTarget`, and the three per-language guards
+- `packages/parser/src/ast/languages/types.ts`: `LanguageDefinition`'s
+  three required fields, each with a per-language rationale in its own doc
+  comment
+- `packages/parser/src/ast/languages/registry.ts`: `hasWholeModuleImports`,
+  `hasSingleFileImports`, `hasNamespaceStyleImports`
+- `packages/parser/src/utils/rust-mod-marker.ts`: the established
+  per-import-form tagging pattern this ADR keeps rather than migrates away
+  from
+- #1038: the original proposal, the adversarial critique that killed it,
+  and the revised decision this ADR records
+- #1044: the pre-existing zod re-export non-determinism found during this
+  ADR's own verification, filed separately as out of scope
+- PR #1045: the implementation, full per-language evidence table, and
+  before/after corpus diffs

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -20,6 +20,7 @@ This directory contains Architectural Decision Records (ADRs) documenting signif
 | [ADR-012](0012-self-hostable-review-action.md) | Self-Hostable GitHub Action for PR Review | 2026-06-27 | Accepted |
 | [ADR-013](0013-prebuilt-native-parser-napi-rs.md) | Prebuilt Native Parser via napi-rs (`@liendev/parser-native`) | 2026-07-08 | Accepted |
 | [ADR-014](0014-per-rule-candidate-loop-passes.md) | Per-Rule Candidate-Loop Passes for Agent Review | 2026-07-16 | Accepted |
+| [ADR-015](0015-required-matcher-path-language-fields.md) | Make Per-Language Matching Policy Mandatory and Declarative | 2026-08-01 | Accepted |
 
 ## Conventions
 

--- a/packages/parser/src/ast/languages/csharp.ts
+++ b/packages/parser/src/ast/languages/csharp.ts
@@ -737,6 +737,34 @@ export const csharpDefinition: LanguageDefinition = {
   // `wholeModuleImports` here would discard all of them and regress #866.
   enclosingNamespaceAccess: true,
 
+  // ADR-015 (#1038): verified against a real corpus (mediatr). Note for the
+  // record: issue #1038's own "current state" table listed C# as already
+  // setting `wholeModuleImports` -- that was incorrect. C# has only ever set
+  // `enclosingNamespaceAccess` (above, a DIFFERENT, out-of-scope flag); this
+  // is confirmed both by `registry.test.ts`'s pre-existing
+  // `hasWholeModuleImports('csharp')).toBe(false)` assertion and by this
+  // very file's own comment two lines up arguing against it. All three
+  // matcher-path fields below are being declared for C# for the first time.
+  // `wholeModuleImports: false`: per the comment above, C#'s dotted
+  // `using` directives resolve correctly today via ordinary per-file
+  // matching (`test/MediatR.DependencyInjectionTests/MicrosoftDependencyInjectionTests.cs:1-2`'s
+  // `using MediatR.DependencyInjectionTests.Abstractions;` is a real, precise,
+  // working per-file reference, not a whole-module-unresolvable one).
+  wholeModuleImports: false,
+  // `singleFileImports: false`: inapplicable, not merely unconfirmed --
+  // `CSharpImportExtractor.getImportPath` returns the qualified name text
+  // verbatim (dotted, e.g. `MediatR.Pipeline`), never converted to `/`, so a
+  // C# import never reaches `matchesAtBoundaryPrecise`'s slash-based
+  // multi-segment branch this flag gates.
+  singleFileImports: false,
+  // `namespaceStyleImports: false`: C# namespace/folder mirroring is
+  // case-sensitive in practice -- confirmed exact-case in this corpus
+  // (`namespace MediatR.Pipeline;` in `src/MediatR/Pipeline/RequestExceptionActionProcessorBehavior.cs`
+  // matches `src/MediatR/Pipeline/` exactly, no case divergence the way
+  // PHP's PSR-4 has). Setting this would risk the same case-insensitive
+  // false-hub class #1028 fixed for Rust, for no confirmed benefit here.
+  namespaceStyleImports: false,
+
   complexity: {
     decisionPoints: [
       'if_statement',

--- a/packages/parser/src/ast/languages/go.ts
+++ b/packages/parser/src/ast/languages/go.ts
@@ -539,6 +539,27 @@ export const goDefinition: LanguageDefinition = {
   importExtractor: new GoImportExtractor(),
   symbolExtractor: new GoSymbolExtractor(),
 
+  // ADR-015 (#1038): verified against a real corpus (chi).
+  // `wholeModuleImports: false`: a Go import like `"github.com/go-chi/chi/v5/middleware"`
+  // (`middleware/client_ip_example_test.go:9`) names a package directory, not
+  // a single file, but that's ALREADY handled correctly and permissively by
+  // Strategy 2's package-directory matching (see `singleFileImports` below)
+  // -- it's resolvable, not structurally unresolvable the way Swift's
+  // whole-module imports are, so this stays false.
+  wholeModuleImports: false,
+  // `singleFileImports: false`: THE canonical non-example this flag's own
+  // doc comment cites. `middleware/` has 49 `.go` files
+  // (`clean_path.go`, `compress_test.go`, `client_ip_test.go`, ...), and a
+  // single bare import of the directory (`"github.com/go-chi/chi/v5/middleware"`,
+  // normalized after module-prefix stripping to `middleware`) legitimately
+  // matches every one of them as a package member -- confirmed via this PR's
+  // own before/after corpus dump (chi is byte-identical).
+  singleFileImports: false,
+  // `namespaceStyleImports: false`: Go import paths are case-sensitive and
+  // mirror directory case exactly (`middleware` -> `middleware/`, never a
+  // differently-cased directory); no PSR-4-style convention exists.
+  namespaceStyleImports: false,
+
   complexity: {
     decisionPoints: [
       'if_statement',

--- a/packages/parser/src/ast/languages/go.ts
+++ b/packages/parser/src/ast/languages/go.ts
@@ -539,21 +539,43 @@ export const goDefinition: LanguageDefinition = {
   importExtractor: new GoImportExtractor(),
   symbolExtractor: new GoSymbolExtractor(),
 
-  // ADR-015 (#1038): verified against a real corpus (chi).
-  // `wholeModuleImports: false`: a Go import like `"github.com/go-chi/chi/v5/middleware"`
-  // (`middleware/client_ip_example_test.go:9`) names a package directory, not
-  // a single file, but that's ALREADY handled correctly and permissively by
-  // Strategy 2's package-directory matching (see `singleFileImports` below)
-  // -- it's resolvable, not structurally unresolvable the way Swift's
-  // whole-module imports are, so this stays false.
+  // ADR-015 (#1038): verified against a real corpus (chi), and against the
+  // real, language-gated `importMatchesTarget` -- not the lower-level
+  // `matchesFile` called directly, which defaults Strategy 5 (Python module
+  // matching) ON and can produce a false positive for an unrelated reason if
+  // probed without the language guard (a real mistake caught during this
+  // verification, corrected here rather than left in).
+  // `wholeModuleImports: false`: a Go import like
+  // `"github.com/go-chi/chi/v5/_examples/versions/data"` (`main.go:14`)
+  // names a package directory, not a single file, but that's ALREADY
+  // resolvable -- not structurally unresolvable the way Swift's whole-module
+  // imports are -- so this stays false; see `singleFileImports` below for
+  // the confirmed-working mechanism.
   wholeModuleImports: false,
   // `singleFileImports: false`: THE canonical non-example this flag's own
-  // doc comment cites. `middleware/` has 49 `.go` files
-  // (`clean_path.go`, `compress_test.go`, `client_ip_test.go`, ...), and a
-  // single bare import of the directory (`"github.com/go-chi/chi/v5/middleware"`,
-  // normalized after module-prefix stripping to `middleware`) legitimately
-  // matches every one of them as a package member -- confirmed via this PR's
-  // own before/after corpus dump (chi is byte-identical).
+  // doc comment cites, and this one is LOAD-BEARING, not just a safe
+  // default -- confirmed by directly toggling it against the real
+  // `importMatchesTarget` path. `main.go:14`'s
+  // `"github.com/go-chi/chi/v5/_examples/versions/data"` normalizes (after
+  // module-prefix stripping) to the multi-segment bare specifier
+  // `_examples/versions/data`, which today correctly matches
+  // `_examples/versions/data/article.go` and `.../data/errors.go` via
+  // Strategy 2's interior-hit leniency (`requireExactTailForMultiSegment:
+  // false`) -- confirmed in this PR's own before/after corpus dump. Setting
+  // this flag `true` measurably DELETES both of those real edges (verified
+  // by toggling it and re-running `importMatchesTarget` against the same
+  // pair): the multi-segment specifier would then require its match to
+  // reach the exact end of the target string, which it doesn't (the target
+  // continues with `/article`/`/errors` past the shared `data` segment).
+  // Correction from an earlier draft of this comment: a BARE
+  // SINGLE-segment package import in this same corpus -- `main.go:19`'s
+  // `"github.com/go-chi/chi/v5/middleware"`, stripping to the single word
+  // `middleware` -- does NOT currently resolve to any of `middleware/`'s 49
+  // files (confirmed directly: `matchesSingleSegmentTail` requires the
+  // match to reach the end of the target, and a directory prefix never
+  // does). That's a real, pre-existing gap, but it's independent of all
+  // three fields this ADR covers -- it doesn't change with this flag either
+  // way, so it's left as a separate observation, not fixed here.
   singleFileImports: false,
   // `namespaceStyleImports: false`: Go import paths are case-sensitive and
   // mirror directory case exactly (`middleware` -> `middleware/`, never a

--- a/packages/parser/src/ast/languages/java.ts
+++ b/packages/parser/src/ast/languages/java.ts
@@ -603,6 +603,32 @@ export const javaDefinition: LanguageDefinition = {
   // for the full rationale (and why this needs no directory bounding).
   samePackageTestConvention: true,
 
+  // ADR-015 (#1038): verified against a real corpus (javapoet).
+  // `wholeModuleImports: false`: Java's `import com.example.Foo;` names a
+  // precise class, not a whole, per-file-unresolvable module -- confirmed:
+  // every non-stdlib symbol javapoet's own code needs is either same-package
+  // (no import at all, `samePackageTestConvention` above) or an ordinary
+  // `java.*`/`javax.*` stdlib import (`TypeSpec.java:18-25`). javapoet's own
+  // package (`com/squareup/javapoet`) is a single flat directory with no
+  // sub-packages, so this corpus has no genuine cross-package internal
+  // import to independently exercise -- noted as a real limitation of this
+  // corpus, not papered over; the `false` value rests on the import
+  // extractor's own dotted (never-unresolvable) shape (`JavaImportExtractor`
+  // never emits a bare, per-file-ambiguous specifier) rather than a
+  // same-repo cross-package repro.
+  wholeModuleImports: false,
+  // `singleFileImports: false`: inapplicable, not merely unconfirmed --
+  // `JavaImportExtractor.getImportPath` stores the raw DOTTED path
+  // (`path.split('.')`, never converted to `/`), so a Java import never
+  // reaches `matchesAtBoundaryPrecise`'s slash-based multi-segment branch
+  // this flag gates at all.
+  singleFileImports: false,
+  // `namespaceStyleImports: false`: Java package/directory mirroring
+  // (`com.squareup.javapoet` -> `com/squareup/javapoet/`) is case-sensitive
+  // in both the language spec and idiomatic tooling, confirmed exact-case
+  // in this corpus -- no PSR-4-style case-insensitive convention.
+  namespaceStyleImports: false,
+
   complexity: {
     decisionPoints: [
       'if_statement',

--- a/packages/parser/src/ast/languages/javascript.ts
+++ b/packages/parser/src/ast/languages/javascript.ts
@@ -932,6 +932,26 @@ export const javascriptDefinition: LanguageDefinition = {
   importExtractor: new JavaScriptImportExtractor(),
   symbolExtractor: new JavaScriptSymbolExtractor(),
 
+  // ADR-015 (#1038): verified against a real corpus (express), not
+  // inherited from TypeScript's identical reasoning above (`typescript.ts`).
+  // `express.js:15-21` shows the real distinction clearly: internal modules
+  // use relative requires (`require('./application')`, `require('./request')`
+  // -- resolved to a concrete file before `matchesFile` ever runs), while
+  // every bare, slash-free require (`require('body-parser')`,
+  // `require('router')`, `require('merge-descriptors')`) is a genuinely
+  // external npm package with no corresponding local file.
+  wholeModuleImports: false,
+  // `singleFileImports: false`: preserves the permissive default; no bare
+  // multi-segment CommonJS require in this corpus names a package directory
+  // vs. a single file in a way this flag would need to disambiguate (deep
+  // requires like `require('mime/lite')`-shaped specifiers, if present,
+  // resolve into node_modules, outside this corpus's own dependency graph).
+  singleFileImports: false,
+  // `namespaceStyleImports: false`: CommonJS/ESM specifiers are relative
+  // paths or npm package names, never a case-insensitive directory-mirroring
+  // namespace.
+  namespaceStyleImports: false,
+
   complexity: jsTsComplexityConfig,
 
   symbols: {

--- a/packages/parser/src/ast/languages/kotlin.ts
+++ b/packages/parser/src/ast/languages/kotlin.ts
@@ -547,6 +547,33 @@ export const kotlinDefinition: LanguageDefinition = {
   importExtractor: new KotlinImportExtractor(),
   symbolExtractor: new KotlinSymbolExtractor(),
 
+  // ADR-015 (#1038): verified against a real corpus (klaxon).
+  // `wholeModuleImports: false`: Kotlin's cross-package imports name a
+  // precise class or sub-package, never a whole-module-only shape --
+  // confirmed with real cross-package imports (unlike javapoet's flat
+  // layout, klaxon genuinely has sub-packages): `JsonObjectConverter.kt:3`'s
+  // `import com.beust.klaxon.internal.firstNotNullResult` and
+  // `StateMachine.kt:3-4`'s `import com.beust.klaxon.token.Token` both
+  // resolve to real directories (`com/beust/klaxon/internal/`,
+  // `com/beust/klaxon/token/`, confirmed on disk). Note this is orthogonal to
+  // #1005's separate, already-documented zero-edge gap
+  // (`KNOWN_ZERO_EDGE_LANGUAGES` in the E2E suite) -- Kotlin's dotted
+  // specifiers never get slash-converted, so they don't reach `matchesFile`'s
+  // slash-oriented strategies at all today regardless of this flag; that gap
+  // is `sameUnitAccessWithoutImport`'s territory (out of scope here), not
+  // these three matcher-path fields.
+  wholeModuleImports: false,
+  // `singleFileImports: false`: inapplicable, not merely unconfirmed --
+  // `KotlinImportExtractor` stores the raw DOTTED path (mirrors Java's
+  // `JavaImportExtractor`), never converted to `/`, so it never reaches this
+  // flag's slash-based multi-segment branch.
+  singleFileImports: false,
+  // `namespaceStyleImports: false`: Kotlin package/directory mirroring is
+  // case-sensitive, confirmed exact-case in this corpus
+  // (`com.beust.klaxon.token` -> `com/beust/klaxon/token/`); no PSR-4-style
+  // convention.
+  namespaceStyleImports: false,
+
   complexity: {
     decisionPoints: [
       'if_expression',

--- a/packages/parser/src/ast/languages/php.ts
+++ b/packages/parser/src/ast/languages/php.ts
@@ -530,7 +530,31 @@ export const phpDefinition: LanguageDefinition = {
   // language `matchesFile`'s Strategy 4 (`matchesPHPNamespace`) is a real
   // semantic for, not an incidental leniency. See `LanguageDefinition.namespaceStyleImports`'s
   // doc comment (#1028) for the Rust false-positive this flag now excludes.
+  // Re-verified (ADR-015, #1038) against monolog: `composer.json:57` maps
+  // `"Monolog\\": "src/Monolog"` and `Logger.php:12` declares
+  // `namespace Monolog;` -- this particular corpus's own case happens to
+  // match exactly (unlike the canonical Laravel `App\` vs. `app/` example
+  // this flag's doc comment cites), but PSR-4 is case-insensitive BY SPEC
+  // regardless of whether any one corpus's names happen to collide, so this
+  // stays `true`.
   namespaceStyleImports: true,
+  // ADR-015 (#1038): the other two matcher-path fields, declared for PHP for
+  // the first time (previously silently unset, i.e. effectively false).
+  // `wholeModuleImports: false`: PHP's `use` statements resolve to a precise
+  // file via Strategy 4's own dedicated namespace-to-path mapping (above),
+  // not a whole-module-unresolvable shape.
+  wholeModuleImports: false,
+  // `singleFileImports: false`: preserves the permissive default. PHP's
+  // normalized (backslash to forward-slash) `use` specifiers usually end in
+  // a class name (`use Monolog\Handler\HandlerInterface;`, `Logger.php:17`,
+  // mapping to exactly one file), which would arguably also satisfy a
+  // single-file semantic if Strategies 1/2 were ever reached for a
+  // case-matching PHP import -- but Strategy 4 is PHP's real, primary
+  // resolution mechanism, and there is no confirmed case today where
+  // Strategies 1/2's interior-hit leniency produces a wrong match for PHP,
+  // so this is left `false` (no behavior change) rather than speculatively
+  // tightened.
+  singleFileImports: false,
 
   complexity: {
     decisionPoints: [

--- a/packages/parser/src/ast/languages/php.ts
+++ b/packages/parser/src/ast/languages/php.ts
@@ -534,9 +534,16 @@ export const phpDefinition: LanguageDefinition = {
   // `"Monolog\\": "src/Monolog"` and `Logger.php:12` declares
   // `namespace Monolog;` -- this particular corpus's own case happens to
   // match exactly (unlike the canonical Laravel `App\` vs. `app/` example
-  // this flag's doc comment cites), but PSR-4 is case-insensitive BY SPEC
-  // regardless of whether any one corpus's names happen to collide, so this
-  // stays `true`.
+  // this flag's doc comment cites). Correction: PSR-4 the autoloading SPEC
+  // actually mandates exact-case file/directory matching -- it is PHP's own
+  // namespace name resolution that's case-insensitive at the language level
+  // (`\App` and `\app` are the same namespace to the parser), and real-world
+  // autoloading tolerates the mismatch anyway on case-insensitive
+  // filesystems (macOS/Windows) even though a strict PSR-4 implementation
+  // on Linux would not. `matchesPHPNamespace`'s case-insensitive leniency
+  // models that real-world tolerance, not a literal PSR-4 spec requirement --
+  // this stays `true` on that basis, independent of whether any one
+  // corpus's names happen to already match case.
   namespaceStyleImports: true,
   // ADR-015 (#1038): the other two matcher-path fields, declared for PHP for
   // the first time (previously silently unset, i.e. effectively false).

--- a/packages/parser/src/ast/languages/python.ts
+++ b/packages/parser/src/ast/languages/python.ts
@@ -572,6 +572,31 @@ export const pythonDefinition: LanguageDefinition = {
   importExtractor: new PythonImportExtractor(),
   symbolExtractor: new PythonSymbolExtractor(),
 
+  // ADR-015 (#1038): verified against a real corpus (requests).
+  // `wholeModuleImports: false` -- MUST stay false, not merely "no evidence
+  // for true": `tests/test_requests.py:19-20` has `import requests` (bare)
+  // and `from requests.adapters import HTTPAdapter` (dotted), both resolved
+  // TODAY via `matchesFile`'s Strategy 5 (`matchesPythonModule`,
+  // `../../utils/path-matching.ts`) to `src/requests/__init__.py` and
+  // `src/requests/adapters.py` respectively. `isUnresolvableWholeModuleImport`
+  // runs unconditionally BEFORE Strategy 5 in `importMatchesTarget` -- setting
+  // this to `true` would short-circuit every bare Python import and silently
+  // regress this real, currently-working resolution (confirmed via this PR's
+  // own before/after corpus dump: `src/requests/__init__.py` has 9+
+  // dependents today, including both test files above).
+  wholeModuleImports: false,
+  // `singleFileImports: false`: inapplicable, not merely unconfirmed --
+  // Python's dotted specifiers (`requests.adapters`) never contain a literal
+  // `/`, so they never reach `matchesAtBoundaryPrecise`'s multi-segment
+  // branch this flag gates; only an already-relative-resolved import (a real
+  // file path by the time it gets here) would, and that's not what this flag
+  // is about.
+  singleFileImports: false,
+  // `namespaceStyleImports: false`: Python's dotted module paths are
+  // case-sensitive and resolved by Strategy 5's own dedicated matcher, never
+  // Strategy 4's PSR-4-style case-insensitive namespace mirroring.
+  namespaceStyleImports: false,
+
   complexity: {
     decisionPoints: [
       'if_statement',

--- a/packages/parser/src/ast/languages/registry.test.ts
+++ b/packages/parser/src/ast/languages/registry.test.ts
@@ -7,6 +7,7 @@ import {
   hasWholeModuleImports,
   hasEnclosingNamespaceAccess,
   hasSingleFileImports,
+  hasNamespaceStyleImports,
   hasSameDirectoryTestConvention,
   hasSamePackageTestConvention,
   hasDependentAttributionBlindSpot,
@@ -209,6 +210,95 @@ describe('Language Registry', () => {
     it('is independent of hasWholeModuleImports/hasEnclosingNamespaceAccess', () => {
       expect(hasWholeModuleImports('ruby')).toBe(false);
       expect(hasEnclosingNamespaceAccess('ruby')).toBe(false);
+    });
+  });
+
+  describe('hasNamespaceStyleImports (#1028, made required by ADR-015/#1038)', () => {
+    it('is true for PHP (PSR-4 case-insensitive, directory-mirroring namespaces)', () => {
+      expect(hasNamespaceStyleImports('php')).toBe(true);
+    });
+
+    it('is false for every other registered language, notably C#/Java/Kotlin despite their own directory-mirroring package/namespace conventions', () => {
+      expect(hasNamespaceStyleImports('csharp')).toBe(false);
+      expect(hasNamespaceStyleImports('java')).toBe(false);
+      expect(hasNamespaceStyleImports('kotlin')).toBe(false);
+      const others = getAllLanguages()
+        .map(d => d.id)
+        .filter(id => id !== 'php');
+      expect(others.length).toBeGreaterThan(0);
+      others.forEach(id => {
+        expect(hasNamespaceStyleImports(id)).toBe(false);
+      });
+    });
+
+    it('is independent of hasWholeModuleImports/hasSingleFileImports', () => {
+      expect(hasWholeModuleImports('php')).toBe(false);
+      expect(hasSingleFileImports('php')).toBe(false);
+    });
+  });
+
+  describe('ADR-015 (#1038): matcher-path fields are required and declared for all 11 languages', () => {
+    const MATCHER_PATH_FLAGS = [
+      'wholeModuleImports',
+      'singleFileImports',
+      'namespaceStyleImports',
+    ] as const;
+
+    it('every language declares a real boolean (never undefined) for all three fields', () => {
+      // Runtime defense-in-depth for the compile-time `LanguageDefinition`
+      // contract: this stays green even if some future refactor constructs a
+      // definition dynamically (object spread, `Object.assign`, a JS
+      // consumer bypassing TS) in a way that could silently smuggle an
+      // `undefined` back in past `tsc`.
+      getAllLanguages().forEach(def => {
+        MATCHER_PATH_FLAGS.forEach(flag => {
+          expect(typeof def[flag]).toBe('boolean');
+        });
+      });
+    });
+
+    it('cross-language policy: at most one of the three matcher-path flags is true per language', () => {
+      // These three fields are alternative, largely mutually-exclusive
+      // resolution strategies for a language's BARE import specifiers --
+      // whole-module-only (Swift), single-file (Ruby), or case-insensitive
+      // namespace-mirroring (PHP). A language genuinely needing two at once
+      // would be a surprising enough finding to warrant its own discussion,
+      // not a silent combination, so this is asserted as a policy, not
+      // merely observed per-language.
+      getAllLanguages().forEach(def => {
+        const trueCount = MATCHER_PATH_FLAGS.filter(flag => def[flag] === true).length;
+        expect(trueCount).toBeLessThanOrEqual(1);
+      });
+    });
+
+    it('cross-language policy: these three escape hatches stay sparse -- at most one language sets each one', () => {
+      // A tripwire, not a hard architectural limit: these flags exist
+      // because a language's bare-import convention diverges from the
+      // shared matcher's default. If a review ever needs to set a SECOND
+      // language's flag true for the same field, that's a fine, deliberate
+      // outcome -- but this test should fail loudly when it happens, forcing
+      // a conscious bump here rather than a silent third/fourth escape hatch
+      // accumulating unnoticed (the exact failure mode ADR-015/#1038 was
+      // written to close off).
+      MATCHER_PATH_FLAGS.forEach(flag => {
+        const languagesSettingTrue = getAllLanguages().filter(def => def[flag] === true);
+        expect(languagesSettingTrue.length).toBeLessThanOrEqual(1);
+      });
+      expect(
+        getAllLanguages()
+          .filter(d => d.wholeModuleImports)
+          .map(d => d.id),
+      ).toEqual(['swift']);
+      expect(
+        getAllLanguages()
+          .filter(d => d.singleFileImports)
+          .map(d => d.id),
+      ).toEqual(['ruby']);
+      expect(
+        getAllLanguages()
+          .filter(d => d.namespaceStyleImports)
+          .map(d => d.id),
+      ).toEqual(['php']);
     });
   });
 

--- a/packages/parser/src/ast/languages/registry.ts
+++ b/packages/parser/src/ast/languages/registry.ts
@@ -144,8 +144,8 @@ export function hasEnclosingNamespaceAccess(language: SupportedLanguage): boolea
  * True when `language`'s bare, potentially multi-segment import specifiers
  * always name a single file rather than a package directory whose files are
  * all implicitly members (see `LanguageDefinition.singleFileImports`, #887).
- * Only Ruby sets this today; every other language (notably Go, whose
- * `import "pkg/sub"` names a directory) leaves it unset and keeps the
+ * Only Ruby sets this `true` today; every other language (notably Go, whose
+ * `import "pkg/sub"` names a directory) sets it `false`, keeping the
  * permissive package-directory matching `matchesFile` has always done.
  */
 export function hasSingleFileImports(language: SupportedLanguage): boolean {

--- a/packages/parser/src/ast/languages/ruby.ts
+++ b/packages/parser/src/ast/languages/ruby.ts
@@ -355,8 +355,23 @@ export const rubyDefinition: LanguageDefinition = {
   // to share the same directory (`rack/protection/base.rb`) is a distinct,
   // unrelated module, not an implicit member of the required specifier
   // (#887). See `LanguageDefinition.singleFileImports`'s doc comment for the
-  // contrast with Go's package-directory semantics.
+  // contrast with Go's package-directory semantics. Re-verified (ADR-015,
+  // #1038) against sinatra, with a stronger, fully-INTERNAL example than the
+  // external-gem one above: `lib/sinatra/base.rb:22`'s
+  // `require 'sinatra/indifferent_hash'` resolves to exactly
+  // `lib/sinatra/indifferent_hash.rb` -- a single file, confirmed on disk,
+  // not a directory of implicit siblings.
   singleFileImports: true,
+  // ADR-015 (#1038): the other two matcher-path fields, declared for Ruby for
+  // the first time (previously silently unset, i.e. effectively false).
+  // `wholeModuleImports: false`: Ruby's `require`/`require_relative` always
+  // names a specific file (via $LOAD_PATH or a relative path) -- there is no
+  // Ruby equivalent of Swift's whole-module-only import shape.
+  wholeModuleImports: false,
+  // `namespaceStyleImports: false`: Ruby's require paths are case-sensitive
+  // file paths, not a PSR-4-style case-insensitive directory-mirroring
+  // namespace convention.
+  namespaceStyleImports: false,
 
   complexity: {
     // Structural control-flow branch points. NOTE: Ruby's logical operators

--- a/packages/parser/src/ast/languages/rust.ts
+++ b/packages/parser/src/ast/languages/rust.ts
@@ -1120,6 +1120,45 @@ export const rustDefinition: LanguageDefinition = {
   importExtractor: new RustImportExtractor(),
   symbolExtractor: new RustSymbolExtractor(),
 
+  // ADR-015 (#1038): verified against a real corpus (anyhow == dtolnay/anyhow,
+  // the exact repo #1028's bug was found on).
+  // `wholeModuleImports: false`: Rust has no whole-crate-only import shape --
+  // `mod x;` (`src/lib.rs:252-263`: `mod backtrace;`, `mod chain;`, ...) names
+  // exactly one file via the #1021 mod-marker system (bypasses these flags
+  // entirely, see `rust-mod-marker.ts`), and `use crate::...` resolves via
+  // ordinary `matchesFile` strategies (`use crate::error::ErrorImpl;` at
+  // `src/lib.rs:265` resolves to `src/error.rs` today via Strategy 2's
+  // one-leading-segment convention).
+  wholeModuleImports: false,
+  // `singleFileImports: false` -- MUST stay false, not just unconfirmed: this
+  // is `LanguageDefinition.singleFileImports`'s own documented "DELIBERATE
+  // non-example". A `mod x;` declaration does name exactly one file, but a
+  // single Rust file routinely has BOTH a `mod x;` and a `use crate::y;`
+  // among its own imports (`src/lib.rs` has both), and this flag can't
+  // disambiguate between two entries in one file's import list the way it
+  // disambiguates between two languages -- `mod`-derived specifiers carry
+  // their own per-specifier marker (#1021) straight past this flag instead
+  // (see `rust-mod-marker.ts`). Rust's `use`/`self::`/`super::` specifiers
+  // (e.g. `use crate::ptr::Own;`, `src/lib.rs:266`) still need `matchesFile`'s
+  // permissive, Go-style package-directory leniency to resolve at all, since
+  // a `crate::`-relative path is missing its real `src/`-style directory
+  // prefix -- setting this to `true` would apply Ruby's exact-tail semantics
+  // to those specifiers too and regress #1024's own fix. This corpus's own
+  // `use` statements are all single-segment after `crate::`-stripping (no
+  // nested `a::b::c` module path exists in anyhow's flat module layout), so
+  // this flag's multi-segment branch isn't independently exercised here --
+  // the reasoning above is #1021/#1024's own, not re-derived from this
+  // corpus, per the ADR's explicit instruction not to re-litigate it.
+  singleFileImports: false,
+  // `namespaceStyleImports: false` -- MUST stay false, actively bug-preventing,
+  // not just unconfirmed: `src/error.rs:8` has `use crate::{Error, StdError};`
+  // and `src/context.rs:2` has `use crate::{Context, Error, StdError};` --
+  // exactly the grouped-use shape whose first-wins bare specifier `"Error"`
+  // case-insensitively self-matched `src/error.rs` before #1028/#1032 gated
+  // Strategy 4 to PHP only. Setting this to `true` would reintroduce that
+  // exact self-edge on this exact file.
+  namespaceStyleImports: false,
+
   complexity: {
     decisionPoints: [
       'if_expression',

--- a/packages/parser/src/ast/languages/swift.ts
+++ b/packages/parser/src/ast/languages/swift.ts
@@ -505,7 +505,23 @@ export const swiftDefinition: LanguageDefinition = {
   // the bare module path (`import Alamofire` -> `"Alamofire"`), never a
   // per-file specifier, so import-based test-association can structurally
   // never resolve a Swift test file to the specific source file it covers.
+  // Re-verified (ADR-015, #1038) against swiftyjson:
+  // `Tests/SwiftJSONTests/SubscriptTests.swift:24` has plain
+  // `import SwiftyJSON` -- bare module name, no file-level signal at all.
   wholeModuleImports: true,
+  // ADR-015 (#1038): the other two matcher-path fields, declared for Swift
+  // for the first time (previously silently unset, i.e. effectively false).
+  // `singleFileImports: false`: moot in practice -- `SwiftImportExtractor`
+  // only ever extracts a single bare identifier (`childByType(node,
+  // 'identifier')`), never a multi-segment specifier, so this flag's
+  // multi-segment branch is unreachable for Swift either way; `false`
+  // preserves the permissive default with no behavior change.
+  singleFileImports: false,
+  // `namespaceStyleImports: false`: Swift's bare module imports are
+  // case-sensitive and carry no directory-mirroring namespace convention;
+  // confirmed no `App\`-vs-`app/`-style case divergence exists for Swift
+  // module names.
+  namespaceStyleImports: false,
 
   complexity: {
     decisionPoints: [

--- a/packages/parser/src/ast/languages/types.ts
+++ b/packages/parser/src/ast/languages/types.ts
@@ -69,13 +69,17 @@ export interface LanguageDefinition {
    * `chunk.metadata.imports` carries no per-file signal an import-based
    * test-association matcher (`matchesFile`) can ever resolve to a specific
    * source file. This is a structural gap, not a matching bug (#869) — no
-   * heuristic recovers it here. Absent/false (the default for every
-   * language except Swift) means the existing per-file import matching
-   * applies as before; unset is NOT the same as "confirmed false", it's just
-   * unconfirmed, so only set this where the whole-module convention has
-   * been verified against real code.
+   * heuristic recovers it here. `false` means the existing per-file import
+   * matching applies as before.
+   *
+   * REQUIRED (ADR-015, #1038): every `LanguageDefinition` must set this
+   * explicitly, verified against real code, one way or the other -- there is
+   * no permissive default to silently inherit. `false` is not "nobody
+   * looked", it is "this was checked against a real corpus and the
+   * whole-module convention does not apply". See each language's own
+   * definition file for its citation. Only Swift is `true` today.
    */
-  wholeModuleImports?: boolean;
+  wholeModuleImports: boolean;
 
   /**
    * True when this language lets a nested namespace body reference an
@@ -109,17 +113,22 @@ export interface LanguageDefinition {
    * stripping) to the bare `internal/fs`, which names a PACKAGE — every
    * `.go` file inside that directory is a member of the package, so
    * `internal/fs` legitimately matches `internal/fs/fs.go`,
-   * `internal/fs/utils.go`, etc. Absent/false (the default for every
-   * language except Ruby) preserves that permissive package-directory
-   * matching. Every other currently-supported language is unaffected either
-   * way and leaves this unset too: TypeScript/JavaScript resolve specifiers
-   * to a concrete file before `matchesFile` ever runs, and Python/PHP use
-   * their own dedicated matching strategies (`matchesPythonModule`/
-   * `matchesPHPNamespace`). See `matchesFile`'s `requireExactTailForMultiSegment`
-   * parameter for how this flag is consumed (only `importMatchesTarget`
-   * derives it from the importer's language; the two build-side sites and
-   * the two stay-raw `matchesFile` call sites don't have a specific target
-   * to disambiguate against).
+   * `internal/fs/utils.go`, etc. `false` preserves that permissive
+   * package-directory matching. Every other language is `false` too, each
+   * for its own reason -- see each definition file's own citation. Notably:
+   * TypeScript/JavaScript resolve specifiers to a concrete file before
+   * `matchesFile` ever runs (relative imports and workspace packages are
+   * resolved upstream; a genuinely unresolved bare specifier is an external
+   * package with no local file to disambiguate against), and Python/PHP/
+   * Java/Kotlin/C# route their bare/qualified specifiers through their own
+   * dedicated per-language matching (`matchesPythonModule`/
+   * `matchesPHPNamespace`) or a dotted (never slash-converted) form this
+   * flag's slash-based multi-segment check never reaches at all. See
+   * `matchesFile`'s `requireExactTailForMultiSegment` parameter for how this
+   * flag is consumed (only `importMatchesTarget` derives it from the
+   * importer's language; the two build-side sites and the two stay-raw
+   * `matchesFile` call sites don't have a specific target to disambiguate
+   * against).
    *
    * Rust is a DELIBERATE non-example, not an oversight: its `mod x;`
    * declarations do name an exact file (never a package directory), but
@@ -133,9 +142,13 @@ export interface LanguageDefinition {
    * (#1021) straight past this flag entirely -- see `rust-mod-marker.ts`
    * and `matchesRustModSpecifier` in `../../utils/path-matching.ts`. Rust's
    * `use`/`self::`/`super::` specifiers are unaffected by that marker and
-   * keep relying on this flag staying unset for Rust, exactly as before.
+   * keep relying on this flag staying `false` for Rust, exactly as before
+   * (#1021/#1024) -- see `rust.ts`'s own citation.
+   *
+   * REQUIRED (ADR-015, #1038): every `LanguageDefinition` must set this
+   * explicitly, verified against real code. Only Ruby is `true` today.
    */
-  singleFileImports?: boolean;
+  singleFileImports: boolean;
 
   /**
    * True when this language's dominant test convention colocates a test file
@@ -241,15 +254,22 @@ export interface LanguageDefinition {
    * bare specifier happens to share a target's basename modulo case, within
    * the same one-leading-directory window — not just the self-edge shape.
    *
-   * Absent/false (the default for every language except PHP) means
-   * `matchesFile` skips Strategy 4 entirely for that language's imports —
-   * see `allowNamespaceMatching` in `../../utils/path-matching.ts` and
-   * `hasNamespaceMatchingSemantics`, the one place this flag is consulted
-   * (mirroring the established `singleFileImports`/#887 and Python/#929
-   * per-language-gate pattern, rather than adding an eighteenth patch to the
-   * shared matcher itself, per #1028's own recommendation). Only set this
-   * where the case-insensitive-namespace-to-directory convention has been
-   * verified against real code.
+   * `false` means `matchesFile` skips Strategy 4 entirely for that
+   * language's imports — see `allowNamespaceMatching` in
+   * `../../utils/path-matching.ts` and `hasNamespaceMatchingSemantics`, the
+   * one place this flag is consulted (mirroring the established
+   * `singleFileImports`/#887 and Python/#929 per-language-gate pattern,
+   * rather than adding an eighteenth patch to the shared matcher itself, per
+   * #1028's own recommendation).
+   *
+   * REQUIRED (ADR-015, #1038): every `LanguageDefinition` must set this
+   * explicitly, verified against real code — a case-insensitive,
+   * directory-mirroring namespace convention is exactly the kind of thing
+   * that looks superficially plausible for a dotted-path language (C#,
+   * Java, Kotlin all have directory-mirroring namespace/package
+   * conventions) but is actually case-SENSITIVE in every one of them —
+   * setting this without checking would silently reintroduce the Rust
+   * self-edge bug (#1028) for a new language. Only PHP is `true` today.
    */
-  namespaceStyleImports?: boolean;
+  namespaceStyleImports: boolean;
 }

--- a/packages/parser/src/ast/languages/types.ts
+++ b/packages/parser/src/ast/languages/types.ts
@@ -108,7 +108,7 @@ export interface LanguageDefinition {
    * (`rack/protection.rb`, resolved via `$LOAD_PATH`) — a sibling file like
    * `rack/protection/base.rb` is a separate, unrelated module that merely
    * shares a directory, not an implicit member of the `rack/protection`
-   * specifier. Go is the opposite and deliberately leaves this unset:
+   * specifier. Go is the opposite and sets this to `false`:
    * `import "mymodule/internal/fs"` normalizes (after #877's module-prefix
    * stripping) to the bare `internal/fs`, which names a PACKAGE — every
    * `.go` file inside that directory is a member of the package, so

--- a/packages/parser/src/ast/languages/typescript.ts
+++ b/packages/parser/src/ast/languages/typescript.ts
@@ -17,13 +17,23 @@ export const typescriptDefinition: LanguageDefinition = {
 
   // ADR-015 (#1038): verified against a real corpus (zod), not inherited.
   // TypeScript's import extractor stores the raw specifier text verbatim
-  // (see `javascript.ts`'s shared `JavaScriptImportExtractor`), but a
-  // relative (`./x`) or workspace-package specifier is already resolved to a
-  // concrete file upstream (`ast/symbols.ts`'s `resolveRelativeImport`/
-  // `resolveWorkspaceImport`), before `matchesFile` ever runs -- so a bare
-  // specifier that reaches these flags is a genuinely external npm package
-  // with no corresponding local file, never the language's own typical
-  // whole-module test-import convention Swift's flag exists for.
+  // (see `javascript.ts`'s shared `JavaScriptImportExtractor`), and a
+  // relative (`./x`) specifier is resolved to a concrete file upstream
+  // (`ast/symbols.ts`'s `resolveRelativeImport`) before `matchesFile` ever
+  // runs. Correction from an earlier draft of this comment, caught during
+  // verification: it is NOT true that every remaining bare specifier is a
+  // genuinely external npm package. `resolveWorkspaceImport` only resolves
+  // an EXACT bare package name from an npm/yarn `workspaces` field
+  // (`workspace-packages.ts`) -- zod itself is a pnpm workspace (no npm
+  // `workspaces` field; `pnpm-workspace.yaml` is deliberately out of that
+  // resolver's v1 scope), so zod's own 165 internal SUBPATH self-references
+  // (`zod/v3`, `zod/v4`, etc. -- see `singleFileImports` below) reach these
+  // flags unresolved too, not because they're external, but because subpath
+  // `exports` resolution is a separate, out-of-scope gap. Either way --
+  // genuinely external, or an unresolved internal subpath -- neither is the
+  // language's own typical whole-module test-import convention Swift's flag
+  // exists for, so the value below is unaffected; only the reasoning
+  // needed correcting.
   // `wholeModuleImports: false`: no whole-module-only import shape exists --
   // every internal zod import found (`packages/zod/src/v3/types.ts:10-35`)
   // is an ordinary relative specifier (`"./errors.js"`, `"./helpers/util.js"`).

--- a/packages/parser/src/ast/languages/typescript.ts
+++ b/packages/parser/src/ast/languages/typescript.ts
@@ -15,6 +15,33 @@ export const typescriptDefinition: LanguageDefinition = {
   importExtractor: new TypeScriptImportExtractor(),
   symbolExtractor: new TypeScriptSymbolExtractor(),
 
+  // ADR-015 (#1038): verified against a real corpus (zod), not inherited.
+  // TypeScript's import extractor stores the raw specifier text verbatim
+  // (see `javascript.ts`'s shared `JavaScriptImportExtractor`), but a
+  // relative (`./x`) or workspace-package specifier is already resolved to a
+  // concrete file upstream (`ast/symbols.ts`'s `resolveRelativeImport`/
+  // `resolveWorkspaceImport`), before `matchesFile` ever runs -- so a bare
+  // specifier that reaches these flags is a genuinely external npm package
+  // with no corresponding local file, never the language's own typical
+  // whole-module test-import convention Swift's flag exists for.
+  // `wholeModuleImports: false`: no whole-module-only import shape exists --
+  // every internal zod import found (`packages/zod/src/v3/types.ts:10-35`)
+  // is an ordinary relative specifier (`"./errors.js"`, `"./helpers/util.js"`).
+  wholeModuleImports: false,
+  // `singleFileImports: false`: preserves the permissive default. A real
+  // bare MULTI-segment specifier does occur (`zod/v3` in
+  // `packages/zod/src/v3/tests/array.test.ts:4`, a package.json `exports`
+  // subpath resolving to exactly one file, `src/v3/index.ts`), but it
+  // doesn't reach Strategies 1/2 at all (no literal substring match against
+  // the normalized target once path-matching runs -- a separate, pre-existing
+  // gap in subpath-`exports` resolution, not something this flag governs
+  // either way), so there is no live case for this flag to disambiguate.
+  singleFileImports: false,
+  // `namespaceStyleImports: false`: TypeScript specifiers are relative paths
+  // or npm package names, never a case-insensitive directory-mirroring
+  // namespace -- confirmed no such convention in the zod corpus.
+  namespaceStyleImports: false,
+
   complexity: jsTsComplexityConfig,
 
   symbols: {


### PR DESCRIPTION
Implements ADR-015 (revised), fixes #1038.

Adds `docs/architecture/decisions/0015-required-matcher-path-language-fields.md`
— the ADR existed only as #1038's issue thread before this PR; per this
repo's own ADR convention ("number sequentially and commit it through the
normal PR review process"), implementing the decision means committing the
record. This also fixes a real `docs-truth` CI failure (the changeset's
`ADR-015` reference had no matching file) by making the reference true
rather than deleting it. The ADR corrects the same C# factual error noted
below in the permanent record, not just here.

## What changed

Made the three matcher-path fields on `LanguageDefinition`
(`wholeModuleImports`, `singleFileImports`, `namespaceStyleImports`)
**required** instead of optional. Every one of the 11 language definitions
now declares all three explicitly, each backed by a citation against a real
corpus. `enclosingNamespaceAccess`, `sameDirectoryTestConvention`, and
`samePackageTestConvention` (test-association policy, not matcher path) are
untouched, as scoped.

The type change is trivial. The verification is the deliverable.

## Per-language x per-field evidence table

Legend: **T**/**F** = declared value. Corpus paths are relative to each
project's own root.

| Language | wholeModuleImports | singleFileImports | namespaceStyleImports |
|---|---|---|---|
| **typescript** (zod) | **F** — every internal import in `packages/zod/src/v3/types.ts:10-35` is relative (`"./errors.js"`, `"./helpers/util.js"`); a bare specifier reaching this flag is either external, or (zod is a pnpm workspace, so `resolveWorkspaceImport`'s npm/yarn-only resolution never fires for it) one of zod's own 165 unresolved internal subpath self-references (`zod/v3`, `zod/v4`, ...) — either way, not the whole-module test-import shape this flag means | **F** — the same `zod/v3` subpath specifier (`packages/zod/src/v3/tests/array.test.ts:4`, resolving to exactly one file, `src/v3/index.ts`) never reaches Strategies 1/2 (no literal substring match once normalized) — a separate, pre-existing subpath-`exports` gap, not something this flag governs | **F** — no case-insensitive namespace convention |
| **javascript** (express) | **F** — `express.js:18,20,21` uses relative requires for internal modules (`./application`, `./request`, `./response`); `express.js:15,17,19` (`body-parser`, `merge-descriptors`, `router`) are genuinely external | **F** — no live internal bare multi-segment require to disambiguate | **F** — no such convention |
| **python** (requests) | **F, must-stay** — `tests/test_requests.py:19-20` (`import requests`; `from requests.adapters import HTTPAdapter`) resolve TODAY via Strategy 5 (`matchesPythonModule`); setting this `true` would short-circuit Strategy 5 for every bare Python import and regress a real, currently-working resolution (confirmed: `src/requests/__init__.py` has 9+ dependents in this PR's own corpus dump) | **F** — inapplicable; Python's dotted specifiers never contain `/`, so they never reach the slash-based multi-segment branch this flag gates | **F** — case-sensitive, Strategy 5 owns this |
| **rust** (anyhow == dtolnay/anyhow) | **F** — `src/lib.rs:252-263` (`mod backtrace;` etc.) resolves via the #1021 mod-marker system, bypassing these flags; `use crate::error::ErrorImpl;` (`lib.rs:265`) resolves via ordinary Strategy 2 | **F, must-stay** (per #1021/#1024's own reasoning, not re-derived) — a single Rust file routinely has both a `mod x;` and a `use crate::y;`; `mod`-derived specifiers carry their own marker instead (see `rust-mod-marker.ts`); `use`/`self::`/`super::` need the permissive package-directory leniency this flag's `false` preserves | **F, must-stay, bug-preventing** — `src/error.rs:8` and `src/context.rs:2` have `use crate::{Error, StdError};`, the exact grouped-use shape whose first-wins bare `"Error"` case-insensitively self-matched `src/error.rs` before #1028/#1032; `true` would reintroduce that exact self-edge |
| **go** (chi) | **F** — `"github.com/go-chi/chi/v5/_examples/versions/data"` (`main.go:14`) names a package directory, already resolvable (not structurally unresolvable) via Strategy 2 | **F, canonical non-example, load-bearing not just safe** — `main.go:14`'s multi-segment bare specifier `_examples/versions/data` correctly resolves to `_examples/versions/data/{article,errors}.go` via Strategy 2's interior-hit leniency; **confirmed by directly toggling the flag against the real `importMatchesTarget`: `true` measurably deletes both edges** (target string continues past the shared `data` segment, so exact-tail matching fails) | **F** — case-sensitive, directory case matches import path exactly |
| **java** (javapoet) | **F** — precise `import com.example.Foo;`; javapoet's own package (`com/squareup/javapoet`) is a single flat directory with no sub-packages, so this corpus has no cross-package internal import to independently exercise (noted honestly — the `false` rests on `JavaImportExtractor`'s dotted, never-ambiguous shape, not a same-repo cross-package repro) | **F** — inapplicable; `JavaImportExtractor.getImportPath` stores the raw dotted path (`path.split('.')`), never converted to `/` | **F** — case-sensitive, confirmed exact-case in this corpus |
| **csharp** (mediatr) | **F** — corrects an error in issue #1038's own "current state" table, which listed C# as already setting `wholeModuleImports`. It does not and never has — `registry.test.ts`'s pre-existing `hasWholeModuleImports('csharp')).toBe(false)` assertion and `csharp.ts`'s own comment ("setting `wholeModuleImports` here would discard all of them and regress #866") both already said so. `test/MediatR.DependencyInjectionTests/MicrosoftDependencyInjectionTests.cs:1-2` shows a real, precise, working per-file `using`. All three fields are newly declared for C# in this PR. | **F** — inapplicable; `CSharpImportExtractor.getImportPath` returns the dotted qualified name verbatim, never converted to `/` | **F** — `src/MediatR/Pipeline/RequestExceptionActionProcessorBehavior.cs:1`'s `namespace MediatR.Pipeline;` matches `src/MediatR/Pipeline/` exactly; no case divergence the way PHP's PSR-4 has |
| **ruby** (sinatra) | **F** — no Ruby equivalent of Swift's whole-module-only shape; `require`/`require_relative` always names a specific file | **T (kept)** — re-verified with a stronger, fully-internal example than the original citation: `lib/sinatra/base.rb:22`'s `require 'sinatra/indifferent_hash'` resolves to exactly `lib/sinatra/indifferent_hash.rb` (confirmed on disk, no sibling directory) | **F** — case-sensitive `$LOAD_PATH` file paths, no PSR-4-style convention |
| **kotlin** (klaxon) | **F** — real cross-package imports confirmed (unlike javapoet's flat layout): `JsonObjectConverter.kt:3`'s `import com.beust.klaxon.internal.firstNotNullResult` and `StateMachine.kt:3-4`'s `import com.beust.klaxon.token.Token` both resolve to real directories on disk | **F** — inapplicable; `KotlinImportExtractor` stores the raw dotted path, never converted to `/` (mirrors Java) | **F** — case-sensitive, confirmed exact-case (`com.beust.klaxon.token` -> `com/beust/klaxon/token/`) |
| **php** (monolog) | **F** (newly declared) — PHP's `use` resolves precisely via Strategy 4's own dedicated mapping | **F** (newly declared) — PHP's normalized specifiers usually end in a class name (`Logger.php:17`'s `use Monolog\Handler\HandlerInterface;`, mapping to exactly one file) which would arguably also satisfy single-file semantics, but there is no confirmed case today where Strategies 1/2's leniency produces a wrong match for PHP, so left `false` (no behavior change) rather than speculatively tightened | **T (kept)** — re-verified: `composer.json:57` maps `"Monolog\\": "src/Monolog"`, `Logger.php:12` declares `namespace Monolog;`. Honesty note: this corpus's own case happens to match exactly (unlike the canonical Laravel `App\`-vs-`app/` example the flag's doc cites) — PSR-4 is case-insensitive **by spec** regardless, so this stays `true` on the strategy's own merits, not because this particular corpus reproduces a case mismatch |
| **swift** (swiftyjson) | **T (kept)** — re-verified: `Tests/SwiftJSONTests/SubscriptTests.swift:24` has plain `import SwiftyJSON`, bare module name, no file-level signal | **F** (newly declared) — moot in practice; `SwiftImportExtractor` only ever extracts a single bare identifier, never a multi-segment specifier | **F** (newly declared) — case-sensitive, no directory-mirroring convention |

**Net result: exactly 3 of 33 cells are `true` (Swift/`wholeModuleImports`,
Ruby/`singleFileImports`, PHP/`namespaceStyleImports`), each already true
before this PR. Every other cell — including all 21 cells for the 7
previously-silent languages, and 2 of the 3 newly-declared cells for the 4
previously-partial languages — is an evidence-backed `false`, matching the
pre-existing effective default exactly. No pushback needed: every language's
honest value was determinable from its corpus.**

## Behaviour-preserving proof (#1032's methodology)

Full before/after **per-file** dependency-edge dumps (not aggregate counts)
across all 11 corpora, isolated by reverting only the touched files
(`types.ts` + the 11 language definitions) and rebuilding, so any diff is
attributable solely to this change:

```
requests     files= 51  before_edges= 353  after_edges= 353  files_with_diff=0
zod          files=454  before_edges=1265  after_edges=1264  files_with_diff=1
express      files=150  before_edges=2920  after_edges=2920  files_with_diff=0
monolog      files=232  before_edges= 405  after_edges= 405  files_with_diff=0
anyhow       files= 40  before_edges=  27  after_edges=  27  files_with_diff=0
chi          files= 86  before_edges=  11  after_edges=  11  files_with_diff=0
javapoet     files= 43  before_edges=   0  after_edges=   0  files_with_diff=0
mediatr      files=160  before_edges= 578  after_edges= 578  files_with_diff=0
sinatra      files=170  before_edges= 109  after_edges= 109  files_with_diff=0
klaxon       files=103  before_edges=   0  after_edges=   0  files_with_diff=0
swiftyjson   files= 27  before_edges=   0  after_edges=   0  files_with_diff=0
```

10 of 11 corpora are byte-identical. **zod has one file-pair diff
(`v4/core/core.ts`'s dependents gaining/losing `v4/classic/schemas.ts`) —
and it is NOT caused by this change.** Investigation: re-running the
*identical* code (this branch, unmodified between runs) against a fresh,
isolated index twice in a row flips this same pairing back and forth
(present → absent → present across 3 consecutive re-indexes, confirmed with
`result.truncated === false` so it isn't the BFS node cap). Since this PR
touches zero scanning/BFS/re-export code — only declarative per-language
boolean fields — the same non-determinism is provably present on
unmodified `main` too. Filed separately as **#1044** with a root-cause
lead (`buildReExportGraph`'s `Map` iteration order tracks file-scan order,
which isn't asserted stable). Not blocking this PR.

**Hazard for future verifiers using this same corpus protocol**: the first
measurement attempt here used the shared `~/.claude/jobs/.../tmp/corpus/`
path and showed spurious flakiness beyond just this one pairing — traced to
other agents in this session concurrently indexing the same shared corpus
directories (a `lien index --force` racing another process's read/writes on
the identical files). All numbers above are instead from a **private,
per-agent copy** of the corpus (`/tmp/adr015-corpus`, `rsync`'d once) with an
**isolated `LIEN_HOME` per run**, confirmed deterministic by running the
"before" state twice (byte-identical). Any future before/after corpus-diff
work in a multi-agent session should copy the corpus locally first rather
than measuring against a shared path directly.

## Compile-error proof

Added a temporary 12th language definition omitting all three fields:

```ts
export const dummyDefinition: LanguageDefinition = {
  id: 'typescript',
  extensions: ['dummy12th'],
  traverser: {} as unknown as LanguageTraverser,
  exportExtractor: {} as unknown as LanguageExportExtractor,
  complexity: { /* ... */ },
  symbols: { callExpressionTypes: [] },
  // Deliberately omitting wholeModuleImports/singleFileImports/namespaceStyleImports
};
```

`tsc --noEmit` output:

```
src/ast/languages/_dummy12th.ts(7,14): error TS2739: Type '{ id: "typescript"; extensions: string[]; traverser: LanguageTraverser; exportExtractor: LanguageExportExtractor; complexity: { decisionPoints: never[]; ... 4 more ...; operatorKeywords: Set<...>; }; symbols: { ...; }; }' is missing the following properties from type 'LanguageDefinition': wholeModuleImports, singleFileImports, namespaceStyleImports
```

File removed after capturing this; `tsc --noEmit` is clean again on the real
tree.

## Cross-language policy table

Added to `registry.test.ts` (`describe('ADR-015 (#1038): matcher-path
fields are required and declared for all 11 languages')`), asserting what's
genuinely establishable as universal rather than just re-stating
per-language facts:

- Every language declares a real `boolean` (never `undefined`) for all
  three fields — runtime defense-in-depth alongside the compile-time
  contract.
- **At most one of the three flags is `true` per language** — they are
  alternative, largely mutually-exclusive strategies for resolving a bare
  specifier, so a language needing two at once would itself be a finding,
  not a silent combination.
- **These three escape hatches stay sparse** — at most one language sets
  each field `true` today (a tripwire, not a hard limit: a second language
  legitimately needing one is fine, but this test forces a conscious bump
  instead of a third/fourth escape hatch accumulating unnoticed, the exact
  failure mode ADR-015 was written to close off).

## Test/gate evidence

All six gates, plus the full E2E suite across **all 11** corpora (not just
the 5 named in scope) since #1023/#1041 assert dependency edges, complexity,
test associations, symbol extraction, and search across all of them:

```
npm run format:check   ✓ (All matched files use Prettier code style)
npm run lint           ✓ (0 errors, 40 pre-existing warnings, none new)
npm run typecheck       ✓
npm run build           ✓
npm test                ✓ (parser: 54 files / 1673 tests; cli: 72 files / 1629 tests;
                            action: 5 files / 41 tests — all passed)
lien delta              ✓ "no complexity changes across 13 file(s) vs HEAD (190 ms)"

test:e2e:rust           ✓ 18 passed (Anyhow: 27 edges, matches baseline)
test:e2e:php            ✓ 18 passed
test:e2e:go             ✓ 18 passed
test:e2e:ruby           ✓ 18 passed
test:e2e:swift          ✓ 18 passed
test:e2e:python         ✓ 18 passed
test:e2e:typescript     ✓ 18 passed
test:e2e:javascript     ✓ 18 passed
test:e2e:java           ✓ 18 passed
test:e2e:csharp         ✓ 18 passed
test:e2e:kotlin         ✓ 18 passed
```

`registry.test.ts`: 40 tests passed (34 pre-existing + 6 new).

## Independent verification pass (parallel, adversarial)

Four separate agents independently re-derived all 33 cells from the same
corpora, some by directly toggling flags against the real, built
`importMatchesTarget` rather than reading source. **Zero contradictions on
any declared value.** They did catch three real accuracy problems in my
citations, all fixed in follow-up commits before merge:

- **go.ts had a wrong citation** (fixed, commit `bfae334c`): I originally
  claimed a bare single-segment `middleware` import resolves permissively to
  all 49 files in chi's `middleware/` directory. Directly probing the real
  `importMatchesTarget` shows it resolves to **none** of them — I'd
  previously only probed the lower-level `matchesFile` without its language
  guards, which silently defaults Strategy 5 (Python module matching) on and
  produces a false positive. Replaced with the citation this PR's own corpus
  dump already contained: `_examples/versions/data`'s real, load-bearing
  multi-segment interior-hit resolution, confirmed by toggling the flag and
  watching two real edges disappear.
- **typescript.ts overclaimed** (fixed, commit `a7027325`): "every bare
  specifier reaching these flags is a genuinely external npm package" is
  false for zod specifically — it's a pnpm workspace, so
  `resolveWorkspaceImport` never resolves its own 165 internal subpath
  self-references either. Doesn't change the declared value, corrected the
  reasoning.
- **php.ts overclaimed** (fixed, commit `2b715d66`, caught by CodeRabbit
  independently — see below): "PSR-4 is case-insensitive BY SPEC" is wrong;
  PSR-4 mandates exact case, PHP's own namespace resolution is
  case-insensitive at the language level.
- **python.ts's `singleFileImports` claimed "inapplicable"** (fixed, commit
  `10038c13`): true for Python's dotted specifiers, but wrong for relative
  ones — `from . import X` resolves to a bare multi-segment directory path
  that DOES reach this flag, and it's load-bearing there too (confirmed by
  toggling it directly: `api.py`'s `from . import sessions` stops matching
  under strict mode).
- **rust.ts's `singleFileImports` claimed no multi-segment case exists in
  this corpus** (fixed, commit `10038c13`): wrong — `test_downcast.rs`'s
  `use self::common::*;`/`use self::drop::{...}` resolve to genuine
  multi-segment specifiers (`self::` resolves against the importer's own
  directory), independently load-bearing alongside the pre-established
  #1021/#1024 `crate::` reasoning.

Two out-of-scope, separately-filed findings surfaced as a side effect of
probing the real matcher rather than trusting existing test assertions
about it:

- **#1046** (new): Java/Kotlin's ordinary, precise, per-file `import`
  statements never resolve through `importMatchesTarget` at all today —
  Strategy 5 (the only strategy that understands a dotted FQN) was gated to
  Python-only by #929, and no Java/Kotlin-specific replacement was ever
  built. `path-matching.test.ts`'s own Java/Kotlin fixture calls the
  ungated low-level `matchesFile` directly, so it stays green while the real
  path returns nothing. None of this PR's three fields touch Strategy 5 —
  unaffected either way, filed separately.
- **#1044** (already noted above): the pre-existing zod re-export
  non-determinism.

Two evidence-quality caveats on the four pre-existing declarations,
neither changing a value: monolog has **zero** case-only mismatches across
all 214 files (213/214 directory-mirror exactly; the one exception is a
deliberate non-PSR-4 test fixture), so it corroborates PHP's
directory-mirroring half but gives zero evidence for the case-insensitivity
half specifically (already flagged honestly in `php.ts`'s own comment).
SwiftyJSON has exactly one source file, so it cannot distinguish
"structurally unresolvable" from "coincidentally resolvable" for Swift's
`wholeModuleImports` — the specifier-SHAPE claim (bare module name, no
per-file signal) is unambiguous and independently confirmed either way.

## Push back / pre-registered "unknowable" check

None needed. Every language's honest value for all three fields was
determinable from its assigned corpus (or, for Rust's `singleFileImports`,
from the already-established #1021/#1024 reasoning the task said not to
re-derive). No language required guessing or a tri-state "unknown" escape.

## Scope notes

- `enclosingNamespaceAccess`, `sameDirectoryTestConvention`,
  `samePackageTestConvention` untouched, as scoped.
- #1044 filed separately for the pre-existing zod re-export non-determinism
  discovered during verification — not blocking, unrelated to this change's
  own diff.
- #1046 filed separately for the pre-existing Java/Kotlin dotted-FQN
  resolution gap discovered by the independent verification pass — not
  blocking, none of this PR's three fields touch the affected strategy.
- `sameUnitAccessWithoutImport` (Kotlin) also untouched — it isn't on the
  matcher path either (only consumed by `hasDependentAttributionBlindSpot`),
  consistent with the ADR's three-field scope.
