### PR TITLE
fix(parser): correct two more ADR-015 citations found by independent verification

### DIFF
--- a/packages/parser/src/ast/languages/python.ts
+++ b/packages/parser/src/ast/languages/python.ts
@@ -574,23 +574,33 @@ export const pythonDefinition: LanguageDefinition = {
 
   // ADR-015 (#1038): verified against a real corpus (requests).
   // `wholeModuleImports: false` -- MUST stay false, not merely "no evidence
-  // for true": `tests/test_requests.py:19-20` has `import requests` (bare)
-  // and `from requests.adapters import HTTPAdapter` (dotted), both resolved
-  // TODAY via `matchesFile`'s Strategy 5 (`matchesPythonModule`,
-  // `../../utils/path-matching.ts`) to `src/requests/__init__.py` and
-  // `src/requests/adapters.py` respectively. `isUnresolvableWholeModuleImport`
-  // runs unconditionally BEFORE Strategy 5 in `importMatchesTarget` -- setting
-  // this to `true` would short-circuit every bare Python import and silently
-  // regress this real, currently-working resolution (confirmed via this PR's
-  // own before/after corpus dump: `src/requests/__init__.py` has 9+
-  // dependents today, including both test files above).
+  // for true", and the blast radius is bigger than one or two examples:
+  // `tests/test_requests.py:19-29` alone has 11 separate `import requests`/
+  // `from requests.X import Y` statements (bare AND dotted -- both count as
+  // "bare" by `isUnresolvableWholeModuleImport`'s slash-only check), all
+  // resolved TODAY via `matchesFile`'s Strategy 5 (`matchesPythonModule`,
+  // `../../utils/path-matching.ts`) to real files (`src/requests/__init__.py`,
+  // `src/requests/adapters.py`, etc.). `isUnresolvableWholeModuleImport` runs
+  // unconditionally BEFORE Strategy 5 in `importMatchesTarget` -- setting
+  // this to `true` would short-circuit EVERY bare or dotted Python import
+  // corpus-wide, not just this one file, and silently regress this real,
+  // currently-working resolution (confirmed via this PR's own before/after
+  // corpus dump: `src/requests/__init__.py` has 9+ dependents today).
   wholeModuleImports: false,
-  // `singleFileImports: false`: inapplicable, not merely unconfirmed --
-  // Python's dotted specifiers (`requests.adapters`) never contain a literal
-  // `/`, so they never reach `matchesAtBoundaryPrecise`'s multi-segment
-  // branch this flag gates; only an already-relative-resolved import (a real
-  // file path by the time it gets here) would, and that's not what this flag
-  // is about.
+  // `singleFileImports: false` -- load-bearing, not merely inapplicable.
+  // Correction from an earlier draft of this comment: Python's DOTTED
+  // specifiers (`requests.adapters`) indeed never contain a literal `/`, so
+  // they never reach `matchesAtBoundaryPrecise`'s multi-segment branch --
+  // but a RELATIVE import does. `convertPythonRelativeImport` turns a bare
+  // `from . import X` into the marker `./`, which `resolveRelativeImport`
+  // then resolves against the importer's own directory into a bare,
+  // multi-segment path (`src/requests/api.py`'s `from . import sessions`,
+  // line 15, resolves to the bare `src/requests`). Confirmed by directly
+  // toggling this flag against the real matcher: permissive (today) matches
+  // `src/requests` against `src/requests/sessions`; strict
+  // (`singleFileImports: true`) does not, which would break this real,
+  // currently-working edge (and the ~10 other `from . import ...`
+  // statements in this same corpus, e.g. `__init__.py:158`, `utils.py:35`).
   singleFileImports: false,
   // `namespaceStyleImports: false`: Python's dotted module paths are
   // case-sensitive and resolved by Strategy 5's own dedicated matcher, never

--- a/packages/parser/src/ast/languages/rust.ts
+++ b/packages/parser/src/ast/languages/rust.ts
@@ -1143,12 +1143,22 @@ export const rustDefinition: LanguageDefinition = {
   // permissive, Go-style package-directory leniency to resolve at all, since
   // a `crate::`-relative path is missing its real `src/`-style directory
   // prefix -- setting this to `true` would apply Ruby's exact-tail semantics
-  // to those specifiers too and regress #1024's own fix. This corpus's own
-  // `use` statements are all single-segment after `crate::`-stripping (no
-  // nested `a::b::c` module path exists in anyhow's flat module layout), so
-  // this flag's multi-segment branch isn't independently exercised here --
-  // the reasoning above is #1021/#1024's own, not re-derived from this
-  // corpus, per the ADR's explicit instruction not to re-litigate it.
+  // to those specifiers too and regress #1024's own fix.
+  //
+  // Correction from an earlier draft of this comment: it claimed this
+  // corpus's `use` statements are all single-segment after `crate::`-
+  // stripping, with no multi-segment case independently exercised here.
+  // That's wrong -- `tests/test_downcast.rs:6-7` has `use self::common::*;`
+  // and `use self::drop::{DetectDrop, Flag};`; `self::` resolves against the
+  // importer's OWN directory (`resolveRustRelativeModulePath`), giving the
+  // genuine multi-segment bare specifiers `tests/common` and `tests/drop` --
+  // matching `tests/common/mod.rs`/`tests/drop/mod.rs` via exactly the same
+  // interior-hit leniency this flag governs. Confirmed by toggling the flag
+  // directly: permissive (today) matches; strict
+  // (`singleFileImports: true`) does not. So this flag IS independently
+  // load-bearing in this corpus too, via `self::`, not only via #1021/#1024's
+  // own `crate::` reasoning (which stands unchanged and is not re-derived
+  // here, per the ADR's explicit instruction).
   singleFileImports: false,
   // `namespaceStyleImports: false` -- MUST stay false, actively bug-preventing,
   // not just unconfirmed: `src/error.rs:8` has `use crate::{Error, StdError};`


### PR DESCRIPTION
Recovers a commit that was lost when I merged #1045 while its author was still improving it. **My coordination error, not a code problem.**

## What happened

#1045 was CI-green and review-clean at `a7027325`, so I merged it (`a676e663`) with `--delete-branch`. Its author then pushed `10038c13` with two further citation corrections, to a branch that no longer existed. This cherry-picks that commit onto `main`.

Two earlier corrections in the same series (`bfae334c` Go, `a7027325` TypeScript) **did** make it in — only this last one was stranded.

## What it corrects

Both are doc-comment/citation fixes. **No declared value changes; no behaviour change.**

- **`python.ts`** — `singleFileImports` was documented as "inapplicable, not merely unconfirmed". That's wrong: `from . import X` resolves to a multi-segment path that is genuinely load-bearing. Verified by flipping the flag and observing `api.py`'s real `from . import sessions` edge break.
- **`rust.ts`** — claimed no multi-segment case exists in the anyhow corpus. Also wrong: `use self::common::*` in `test_downcast.rs` resolves to a genuine multi-segment specifier, load-bearing independently of the pre-established `crate::` reasoning from #1021/#1024.

## Why these matter despite being comments

ADR-015's entire premise is that `unset` and `false` are runtime-identical, so a declared `false` is a *claim of verification*. A comment that justifies a correct value with a wrong reason propagates that reason into `docs/architecture/decisions/0015-required-matcher-path-language-fields.md`, whose purpose is that the next contributor can trust the reasoning without re-deriving it.

Both errors were found the same way, and it's worth recording: **independent agents probing the real built matcher at runtime** — toggling flags and observing which edges break — rather than reading source. Reading source produced the wrong claims; probing caught them. That method found five citation errors in total across this series (two by CodeRabbit, three by runtime probing), and zero wrong values.

## Verification

The declared values in #1045 were independently cross-checked by four agents covering all 11 languages: **zero contradictions on any of the 33 determinations.** Every correction in this series has been to reasoning or citations, never to a value.

Related: #1038 (ADR-015), #1045 (the merged change), #1046 (Java/Kotlin dotted-FQN gap, found during the same cross-check).

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR is a pure comment-only cherry-pick that corrects two ADR-015 citation comments in `python.ts` and `rust.ts`. No declared `LanguageDefinition` values change (`wholeModuleImports: false`, `singleFileImports: false`, `namespaceStyleImports: false` remain identical), and no executable code is modified. The only risk is documentation accuracy, which the PR explicitly addresses by replacing incorrect reasoning with independently verified corpus examples.
>
> - Updated `python.ts` comment to explain why `singleFileImports: false` is load-bearing for relative `from . import X` paths, not merely inapplicable
> - Updated `rust.ts` comment to note that `self::` multi-segment specifiers (e.g., `tests/common`, `tests/drop`) independently exercise the `singleFileImports: false` flag
> - No runtime behavior or exported API changes

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 8710a02. Updates automatically on new commits.</sup>
<!-- /lien-stats -->