### PR TITLE
fix(parser): correct three doc-comment citations found after #1045 merged

### DIFF
--- a/.changeset/adr-015-citation-fixes.md
+++ b/.changeset/adr-015-citation-fixes.md
@@ -1,0 +1,21 @@
+---
+"@liendev/parser": patch
+---
+
+Correct three doc-comment citations in `python.ts`, `rust.ts`, and
+`path-matching.ts`, found by an independent verification pass after
+ADR-015 (#1038, PR #1045) merged. All three are comment-only — no
+declared `LanguageDefinition` value or matcher behavior changes:
+
+- `python.ts`: `singleFileImports`'s comment wrongly claimed the flag was
+  "inapplicable" for Python. It's load-bearing via relative imports
+  (`from . import X` resolves to a bare multi-segment path) — confirmed
+  by toggling the flag against the real matcher and watching a real edge
+  (`src/requests/api.py`'s `from . import sessions`) stop resolving.
+- `rust.ts`: `singleFileImports`'s comment wrongly claimed no
+  multi-segment case exists in the `anyhow` corpus. `use self::common::*;`
+  in `tests/test_downcast.rs` resolves to one, independently confirmed
+  load-bearing.
+- `path-matching.ts`: a pre-existing prose overstatement in `matchesFile`'s
+  own doc comment (predates #1045) — only one of the three cited
+  `dtolnay/anyhow` self-edge files matches the shape described.

--- a/packages/parser/src/utils/path-matching.ts
+++ b/packages/parser/src/utils/path-matching.ts
@@ -298,8 +298,10 @@ export function isUnresolvableWholeModuleImport(
  * specifier (the import extractor's "first wins" grouped-use handling)
  * case-insensitively self-match `src/error.rs` on a real `dtolnay/anyhow`
  * clone -- confirmed for three files (`chain.rs`/`context.rs`/`error.rs`),
- * each via a self-referential `pub(crate) use crate::Self type;` naming its
- * own type. See `allowNamespaceMatching` and `importMatchesTarget`, the only
+ * each via a self-referential bare `use crate::<OwnType>;` (grouped or not --
+ * only `chain.rs`'s is `pub(crate)` and ungrouped; `error.rs`/`context.rs`
+ * are plain grouped `use crate::{...}`) naming its own type. See
+ * `allowNamespaceMatching` and `importMatchesTarget`, the only
  * caller that derives it from the importer's language via
  * `hasNamespaceMatchingSemantics`. Every other caller passes the default
  * (`true`), preserving this function's pre-#1028 behavior exactly, mirroring


### PR DESCRIPTION
Follow-up to #1045 (ADR-015, #1038).

## What happened (updated after a duplicate-recovery collision)

PR #1045 was squash-merged (`a676e663`) while two more fix commits were
still in flight on that branch — a race between a push and the merge (the
coordinating session merged on green CI without confirming no further
pushes were coming). Both stranded commits were comment-only,
no-behavior-change corrections found by an independent parallel
verification pass (four Explore agents re-deriving #1045's 33 declared
values from the same corpora).

This PR originally cherry-picked both stranded commits. While it was in
flight, **the coordinating session independently reached the same
conclusion and merged the first one as #1048** (`9191a3b0`, the
`python.ts`/`rust.ts` citation fixes) — a second race, this time two
recovery attempts for the same problem. Rebased onto current `main` after
that landed; the redundant cherry-pick dropped out automatically (`git
rebase` recognized it as already-applied via patch-id). **Final diff is
exactly two files**: `path-matching.ts` (the one commit that was still
genuinely missing) and its changeset.

## What's in it

A small, pre-existing (not introduced by #1045) prose inaccuracy in
`matchesFile`'s own doc comment in `path-matching.ts`, found during the
same verification pass — "each via a self-referential
`pub(crate) use crate::Self type;`" overstated the #1028 `dtolnay/anyhow`
repro; only `chain.rs:8` is `pub(crate)` and ungrouped, `error.rs:8`/
`context.rs:2` are plain grouped `use crate::{...}`. One-line fix, zero
behavior change, zero declared-value change.

## Durable lesson from tonight (recording per the coordinator's request)

**`gh pr checks` reporting all-green can mean the checks are stale against
an already-merged head, not that your latest push is covered.** My own
"wait for CI" polling loop kept reporting a clean bill of health because it
was checking the PR's *recorded* head SHA, which GitHub had stopped
advancing the moment the PR closed — two more commits landed on the branch
ref itself (confirmed via `git ls-remote`) with zero corresponding CI runs
or PR-object updates, because a merged PR doesn't re-open for new pushes.
The fix: compare `gh api repos/OWNER/REPO/pulls/N -q '.head.sha'` against
your local `git rev-parse HEAD` *before* trusting a "checks settled" result,
not just checking for the absence of a `pending` row.

This is the same failure shape as two things already known in this repo:
`path-matching.test.ts`'s Java/Kotlin fixture calling the *ungated*
`matchesFile` directly (asserting the wrong layer, staying green while the
real gated path returns nothing — see #1046, found the same night), and an
E2E matrix that asserted file/chunk counts while real dependency resolution
sat at zero (#1004/#1023's original motivation). A signal that looks like
verification while actually measuring something adjacent to the thing that
matters is the recurring pattern, not a one-off polling bug.

## Gates

```
npm run format:check    ✓
npm run typecheck        ✓
npm run build            ✓
npm test -w @liendev/parser -- run src/utils/path-matching.test.ts src/ast/languages/registry.test.ts
                          ✓ 191 tests (151 + 40)
lien delta --base origin/main   ✓ "no complexity changes across 1 file(s)"
```

Full parser suite, lint, and rust/python E2E were also re-run clean before
the rebase (see thread history); re-ran the targeted subset above after the
rebase since the diff shrank to one source file.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR is a comment-only correction to three doc-comment citations (path-matching.ts, plus the changeset summarizing python.ts and rust.ts corrections). No function bodies, exports, or declared LanguageDefinition values changed. The updated prose in path-matching.ts accurately narrows the description of the dtolnay/anyhow self-edge repro, and the pre-computed stale-literal and sibling-surface signals all resolve to unrelated comments/changelog entries or structurally intentional omissions. There are no behavioral changes for callers to mishandle.
>
> - Narrowed `matchesFile` doc comment to correctly describe only `chain.rs` as `pub(crate)` and ungrouped, with `error.rs`/`context.rs` as plain grouped `use crate::{...}`
> - Added changeset summarizing the comment corrections in python.ts and rust.ts

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 51f54d6. Updates automatically on new commits.</sup>
<!-- /lien-stats -->