### PR TITLE
fix(cli): resolve project root and index detection for fresh linked worktrees (#1050, #1051)

### DIFF
--- a/packages/cli/src/cli/project-root.test.ts
+++ b/packages/cli/src/cli/project-root.test.ts
@@ -154,5 +154,35 @@ describe('resolveProjectRoot', () => {
 
       expect(resolveProjectRoot(cwd)).toBe(worktreeRoot);
     });
+
+    // #1050: the shape above ("resolves to a linked worktree root...") only
+    // covered a worktree that had ALREADY completed its own overlay build
+    // (`markIndexed(worktreeRoot)`). The actual bug is the FRESH worktree —
+    // no local overlay build yet, so `hasCompletedIndex(worktreeRoot)` is
+    // false — sitting inside a main checkout that DOES have a completed
+    // index. The old two-separate-passes implementation ran the completed-
+    // index walk fully unbounded, so it walked straight past the worktree's
+    // own `.git` file to the main checkout's completed index, silently
+    // resolving every annotate/gc/path/etc. call to the WRONG repository.
+    it('#1050: resolves to the fresh worktree root, not the main checkout, even though only the main checkout has a completed index', async () => {
+      const mainCheckout = await fs.realpath(tmp);
+      await fs.mkdir(path.join(mainCheckout, '.git'));
+      await markIndexed(mainCheckout); // the main checkout HAS a completed index...
+
+      const worktreeRoot = path.join(mainCheckout, '.claude', 'worktrees', 'agent-fresh');
+      await fs.mkdir(worktreeRoot, { recursive: true });
+      await fs.writeFile(
+        path.join(worktreeRoot, '.git'),
+        `gitdir: ${path.join(mainCheckout, '.git', 'worktrees', 'agent-fresh')}\n`,
+      );
+      // ...but the worktree itself does NOT — no markIndexed(worktreeRoot)
+      // call. This is the "fresh, not-yet-locally-indexed" state #1050 is
+      // about.
+
+      const cwd = path.join(worktreeRoot, 'packages', 'cli', 'src');
+      await fs.mkdir(cwd, { recursive: true });
+
+      expect(resolveProjectRoot(cwd)).toBe(worktreeRoot);
+    });
   });
 });

--- a/packages/cli/src/cli/project-root.ts
+++ b/packages/cli/src/cli/project-root.ts
@@ -4,23 +4,6 @@ import { getIndexDir, VERSION_FILE } from '@liendev/core';
 import { type AbsolutePath, toAbsolutePath } from '../types/paths.js';
 
 /**
- * Walk upward from `start` (inclusive) looking for a directory that satisfies
- * `predicate`. Returns the first match, or `null` if none is found by the
- * time the filesystem root is reached.
- */
-function walkUp(start: string, predicate: (dir: string) => boolean): string | null {
-  let dir = start;
-  const fsRoot = path.parse(dir).root;
-  // Loop is inclusive of fsRoot — a repo rooted at / (or a drive root) is
-  // rare but valid, and should still be detected before giving up.
-  while (true) {
-    if (predicate(dir)) return dir;
-    if (dir === fsRoot) return null;
-    dir = path.dirname(dir);
-  }
-}
-
-/**
  * Has `dir` ever completed a real `lien index` (or worktree-overlay) build?
  * Checks for `VERSION_FILE` inside `dir`'s own index directory (keyed by
  * `dir`'s absolute path — see `getIndexDir`), which both backends write ONLY
@@ -48,29 +31,56 @@ function hasGitMarker(dir: string): boolean {
 }
 
 /**
- * Resolve the project root for `start`. Two-pass, nearest match wins each
- * pass:
+ * Resolve the project root for `start`. A single bounded walk upward,
+ * nearest match wins, checking BOTH signals at every directory before moving
+ * to its parent:
  *
- * 1. Nearest ancestor (inclusive) that has already completed a real
- *    `lien index` build (`hasCompletedIndex`). This wins even when a `.git`
- *    sits closer, farther, or in between — a directory Lien has actually
- *    indexed is a stronger signal than "some ancestor happens to be a git
- *    repo."
- * 2. Nearest ancestor with a `.git` marker (file or dir), the original
- *    heuristic — used only when no ancestor has a completed index.
- * 3. The resolved `start` path itself, unchanged.
+ * 1. Has this directory already completed a real `lien index` build
+ *    (`hasCompletedIndex`)? If so, return it immediately — a directory Lien
+ *    has actually indexed is a stronger signal than "some ancestor happens
+ *    to be a git repo," even when a `.git` sits closer, farther, or in
+ *    between (the #894 fix).
+ * 2. Otherwise, does this directory have a `.git` marker (file or dir)? If
+ *    so, STOP here and return it — do not keep walking past it looking for
+ *    a completed index further out. A `.git` marker is a repo/worktree
+ *    boundary; a completed index belonging to a *different* repository on
+ *    the other side of that boundary must never win.
+ * 3. If the walk reaches the filesystem root without matching either check,
+ *    fall back to the resolved `start` path itself, unchanged.
  *
  * This exists to keep read-side commands (`annotate`, `gc`, `path`,
  * `store-paths`, `recap`, `nudge`, `verify-tests` — every consumer of this
  * function) from resolving a *different* root than the one `lien index` was
- * actually run against. The failure mode (#894): a directory with no `.git`
- * of its own (a monorepo subdirectory indexed as its own project, or a repo
- * nested inside a larger checkout) sits under an unrelated outer `.git`.
- * Walking straight to that outer `.git` — the old, single-pass behavior —
- * silently lands on a root that was never indexed, while the directory the
- * caller actually meant sits right there with a real index. Pass 1 fixes
- * that by checking "was this directory actually indexed" before ever
- * considering `.git` at all.
+ * actually run against.
+ *
+ * The #894 shape: a directory with no `.git` of its own (a monorepo
+ * subdirectory indexed as its own project, or a repo nested inside a larger
+ * checkout) sits under an unrelated outer `.git`. Walking straight to that
+ * outer `.git` silently lands on a root that was never indexed, while the
+ * directory the caller actually meant sits right there with a real index.
+ * Checking "was this directory actually indexed" before considering `.git`
+ * fixes that — as long as the indexed directory is reached before any `.git`
+ * marker, which it always is in that shape (the indexed directory itself has
+ * no `.git`).
+ *
+ * The #1050 shape (a linked git worktree — see
+ * `docs/architecture/worktree-aware-indexing.md`): the worktree's own root
+ * has a `.git` FILE (the linked-worktree marker), and — being a Claude Code
+ * agent worktree under `<main>/.claude/worktrees/<name>` — sits *inside* the
+ * main checkout's directory tree, whose `.git` DIRECTORY is therefore a
+ * filesystem ancestor of the worktree. Before the worktree's own first
+ * `lien index` (i.e. its `OverlayBackend` has never completed a local
+ * build), the worktree itself has no completed index — but the main
+ * checkout, further up the same walk, very likely does. The old two-
+ * separate-passes design ran the completed-index check as its own fully
+ * unbounded walk, so it walked straight past the worktree's own `.git` file
+ * to the main checkout's completed index, silently resolving every
+ * annotate/gc/path/etc. call to the WRONG repository. Bounding the walk so
+ * it stops the moment it hits a `.git` marker — checking for a completed
+ * index no further out than that boundary — fixes it: the worktree's own
+ * `.git` file is the nearest marker, so the walk stops there, exactly like a
+ * plain `.git`-only walk always did, whether or not the worktree has
+ * completed its own overlay build yet.
  *
  * `lien index`/`lien init`/`lien serve` deliberately do NOT go through this
  * function — they take `process.cwd()` (or an explicit `--root`/`--path`) as
@@ -81,12 +91,13 @@ function hasGitMarker(dir: string): boolean {
  */
 export function resolveProjectRoot(start: string = process.cwd()): AbsolutePath {
   const resolvedStart = path.resolve(start);
+  const fsRoot = path.parse(resolvedStart).root;
 
-  const indexed = walkUp(resolvedStart, hasCompletedIndex);
-  if (indexed) return toAbsolutePath(indexed);
-
-  const gitRoot = walkUp(resolvedStart, hasGitMarker);
-  if (gitRoot) return toAbsolutePath(gitRoot);
-
-  return toAbsolutePath(resolvedStart);
+  let dir = resolvedStart;
+  while (true) {
+    if (hasCompletedIndex(dir)) return toAbsolutePath(dir);
+    if (hasGitMarker(dir)) return toAbsolutePath(dir);
+    if (dir === fsRoot) return toAbsolutePath(resolvedStart);
+    dir = path.dirname(dir);
+  }
 }

--- a/packages/cli/src/utils/index-freshness.ts
+++ b/packages/cli/src/utils/index-freshness.ts
@@ -1,7 +1,13 @@
 import fs from 'fs/promises';
 import path from 'path';
 import type { VectorDBInterface } from '@liendev/core';
-import { getIndexDir, isGitRepo, getCurrentBranch, getCurrentCommit } from '@liendev/core';
+import {
+  getIndexDir,
+  isGitRepo,
+  getCurrentBranch,
+  getCurrentCommit,
+  resolveIndexStrategy,
+} from '@liendev/core';
 
 /**
  * Filename of the SQLite structural store inside the index directory.
@@ -12,9 +18,20 @@ import { getIndexDir, isGitRepo, getCurrentBranch, getCurrentCommit } from '@lie
  */
 const STRUCTURAL_DB_FILENAME = 'structural.db';
 
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Cheap, side-effect-free existence check for the structural store: does
- * `<indexDir>/structural.db` exist on disk?
+ * `<indexDir>/structural.db` exist on disk — either `rootDir`'s own (the
+ * standalone case), or, for a linked git worktree in overlay mode, the
+ * shared base's?
  *
  * Every read-only CLI command that needs to tell "this project has never
  * been indexed" apart from "the index is just empty" MUST call this BEFORE
@@ -31,14 +48,31 @@ const STRUCTURAL_DB_FILENAME = 'structural.db';
  * This consolidates what used to be `lien api-delta`'s own local
  * `hasStructuralIndex` — the same guard, reused rather than re-invented at
  * every new read-only call site (`lien complexity`, `lien annotate`).
+ *
+ * #1051 fix: this used to check ONLY `getIndexDir(rootDir)` — for a linked
+ * worktree that's `OverlayBackend.dbPath`, the worktree's own *local* overlay
+ * database, which doesn't exist until the worktree completes at least one
+ * local `lien index`/overlay build. A fresh worktree that has never run
+ * `lien index` locally therefore reported S0 ("never indexed") even though
+ * the *shared base* index — what `OverlayBackend` actually reads from, per
+ * `docs/architecture/worktree-aware-indexing.md` — was fully populated. The
+ * local check runs first (cheapest, and correct for both the common
+ * standalone case and a worktree that has already self-healed); only when it
+ * misses do we ask `resolveIndexStrategy` whether `rootDir` is a worktree in
+ * overlay mode and, if so, check the base's `structural.db` instead. This
+ * mirrors `findUnindexedPaths`'s #1014 fix (reading the merged base+overlay
+ * view instead of the overlay manifest alone) one layer up, at the
+ * whole-index existence check rather than the per-path one.
  */
 export async function hasStructuralIndex(rootDir: string): Promise<boolean> {
-  try {
-    await fs.access(path.join(getIndexDir(rootDir), STRUCTURAL_DB_FILENAME));
+  if (await fileExists(path.join(getIndexDir(rootDir), STRUCTURAL_DB_FILENAME))) {
     return true;
-  } catch {
-    return false;
   }
+
+  const strategy = await resolveIndexStrategy(rootDir);
+  if (strategy.mode !== 'overlay') return false;
+
+  return fileExists(path.join(strategy.baseIndexDir, STRUCTURAL_DB_FILENAME));
 }
 
 interface StoredGitState {

--- a/packages/cli/test/integration/index-state-matrix.test.ts
+++ b/packages/cli/test/integration/index-state-matrix.test.ts
@@ -44,6 +44,7 @@ import { configGetCommand } from '../../src/cli/config.js';
 import { handleSearchCode } from '../../src/mcp/handlers/search-code.js';
 import { handleGetFilesContext } from '../../src/mcp/handlers/get-files-context.js';
 import { handleGetDependents } from '../../src/mcp/handlers/get-dependents.js';
+import { clearDependencyCache } from '../../src/mcp/handlers/dependency-analyzer.js';
 import { handleGetComplexity } from '../../src/mcp/handlers/get-complexity.js';
 import { handleListFunctions } from '../../src/mcp/handlers/list-functions.js';
 import { handleFindSimilar } from '../../src/mcp/handlers/find-similar.js';
@@ -58,7 +59,27 @@ const execFileAsync = promisify(execFile);
 // apply (never a silent omission) rather than being skipped.
 // ============================================================================
 
-type EntryPointState = 'S0' | 'S1' | 'S2' | 'S3' | 'ok' | 'n/a';
+type EntryPointState =
+  | 'S0'
+  | 'S1'
+  | 'S2'
+  | 'S3'
+  | 'ok'
+  | 'n/a'
+  // Layout axis (#1050, #1051) — orthogonal to the whole-index STATES above:
+  // a linked git worktree nested inside its own main checkout (the standard
+  // Claude Code agent-fleet layout) is backed by an `OverlayBackend`, where
+  // `dbPath` is the worktree's own writable overlay and `baseIndexDir` is the
+  // main checkout's read-only base. `worktree-fresh` = the worktree has never
+  // completed its own local `lien index` (no local overlay `structural.db`
+  // yet), but the main checkout's base IS fully populated — the exact shape
+  // both issues require. `worktree-none` = the same fresh-worktree layout,
+  // but the main checkout ALSO has never been indexed, proving the fix
+  // doesn't overcorrect a genuine S0 into a false "ok" (CLAUDE.md's hard
+  // constraint: never turn a real S0 into a false clean, and never turn a
+  // real base into a false S0 either).
+  | 'worktree-fresh'
+  | 'worktree-none';
 
 interface TableRow {
   entryPoint: string;
@@ -119,6 +140,40 @@ const TABLE: TableRow[] = [
     entryPoint: 'lien api-delta',
     state: 'ok',
     expected: 'enriched:true with real dependentCount',
+  },
+  // --- Layout axis (#1050, #1051): a FRESH linked worktree nested inside
+  //     its own main checkout, whose base index is fully populated. See the
+  //     `EntryPointState` doc comment above for the two sub-shapes.
+  {
+    entryPoint: 'lien complexity',
+    state: 'worktree-fresh',
+    expected: 'real report from the shared base — no false "Index not found" (#1051 fix)',
+  },
+  {
+    entryPoint: 'lien complexity',
+    state: 'worktree-none',
+    expected: 'still a real hard error (base also never indexed — no overcorrection)',
+  },
+  {
+    entryPoint: 'lien api-delta',
+    state: 'worktree-fresh',
+    expected: 'enriched:true with a real dependentCount from the shared base (#1051 fix)',
+  },
+  {
+    entryPoint: 'lien api-delta',
+    state: 'worktree-none',
+    expected: 'still degrades (enriched:false) — base also never indexed, no overcorrection',
+  },
+  {
+    entryPoint: 'lien annotate',
+    state: 'worktree-fresh',
+    expected: 'real dependents/tests annotation from the shared base (#1051 fix)',
+  },
+  {
+    entryPoint: 'lien path',
+    state: 'worktree-fresh',
+    expected:
+      '`path --root` resolves to the WORKTREE itself, never the outer main checkout (#1050 fix)',
   },
   // --- CLI, index-independent (never touch the structural store at all) ---
   {
@@ -320,6 +375,18 @@ describe('index-state × entry-point matrix (#1029 W1)', () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(async () => {
+    // `findDependents`'s module-level `scanCache` (dependency-analyzer.ts) is
+    // keyed ONLY by `indexVersion` (a plain number), with no project-root
+    // component — safe in production (one `lien serve` process = one root),
+    // but this file drives `get_dependents`/`annotate` against many DIFFERENT
+    // roots in rapid succession within one process. Two unrelated tests'
+    // stores can legitimately land on the same version stamp (timestamp-
+    // based), and without this reset the second test's empty/different store
+    // would silently serve the first test's cached chunks — a real, if
+    // narrow, flake surfaced by adding more indexing-heavy tests here (the
+    // worktree/overlay section below).
+    clearDependencyCache();
+
     dir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-ism-'));
     dir = await fs.realpath(dir); // resolve macOS /var -> /private/var
     originalCwd = process.cwd();
@@ -528,6 +595,160 @@ describe('index-state × entry-point matrix (#1029 W1)', () => {
       // would make this test brittle to fixture changes.
       expect(addChange.enriched).toBe(true);
       expect(addChange.dependentCount).toBeGreaterThan(0);
+    });
+  });
+
+  // ==========================================================================
+  // Worktree/overlay layout axis (#1050, #1051) — every state proven above
+  // was against a STANDALONE index. Every one of `index-state-matrix.test.ts`'s
+  // original 36 cases (#1029 W1) ran against `dir` directly; none of them
+  // touched a linked git worktree, so this whole layout axis was invisible to
+  // the detector — exactly why #1050/#1051 shipped unnoticed.
+  //
+  // A linked worktree nested inside its own main checkout (the standard
+  // Claude Code agent-fleet layout: `<main>/.claude/worktrees/<name>` — see
+  // `docs/architecture/worktree-aware-indexing.md`) is backed by an
+  // `OverlayBackend`: `dbPath` is the worktree's own writable overlay,
+  // `baseIndexDir` is the main checkout's read-only base. Before this fix:
+  //
+  //  - #1051: `hasStructuralIndex` checked ONLY the worktree's own (not-yet-
+  //    built) overlay `structural.db`, so `lien complexity`/`lien api-delta`
+  //    reported a false S0 ("Index not found") on a fresh worktree despite a
+  //    fully populated, reachable base.
+  //  - #1050: `resolveProjectRoot`'s completed-index walk was unbounded, so
+  //    it walked straight past the worktree's own `.git` FILE (the linked-
+  //    worktree marker) to the outer main checkout's already-completed
+  //    index — silently resolving `lien path`/`annotate`/`gc`/etc. to the
+  //    WRONG repository.
+  //
+  // `worktree-none` cases prove the fix doesn't overcorrect: a fresh
+  // worktree whose base is ALSO never indexed must still report a real S0,
+  // never a false "ok".
+  // ==========================================================================
+
+  describe('worktree/overlay layout (#1050, #1051)', () => {
+    let worktreeRoot: string | undefined;
+
+    afterEach(async () => {
+      if (worktreeRoot) {
+        await execFileAsync('git', ['worktree', 'remove', '--force', worktreeRoot], {
+          cwd: dir,
+        }).catch(() => undefined);
+      }
+      worktreeRoot = undefined;
+    });
+
+    /**
+     * Create a linked worktree of `dir` (the outer `beforeEach`'s main
+     * checkout), nested inside it at `.claude/worktrees/<name>` — the exact
+     * layout that triggers #1050/#1051 — and chdir into it. The worktree's
+     * own `lien index` is deliberately never run: that "fresh" state (no
+     * local overlay build yet) is the whole point of this axis.
+     */
+    async function chdirIntoFreshNestedWorktree(): Promise<string> {
+      const wtDir = path.join(dir, '.claude', 'worktrees', 'agent-fresh');
+      await fs.mkdir(path.join(dir, '.claude', 'worktrees'), { recursive: true });
+      await git(dir, 'worktree', 'add', '-q', wtDir, '-b', 'worktree-agent-fresh');
+      worktreeRoot = await fs.realpath(wtDir);
+      process.chdir(worktreeRoot);
+      return worktreeRoot;
+    }
+
+    describe('lien complexity', () => {
+      it('worktree-fresh: real report from the shared base, not a false "Index not found" (#1051)', async () => {
+        await buildHealthyIndex(dir);
+        await chdirIntoFreshNestedWorktree();
+
+        await complexityCommand({ format: 'json' });
+
+        expect(errSpy).not.toHaveBeenCalledWith(expect.stringContaining('Index not found'));
+        const output = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+        expect(output.summary.filesAnalyzed).toBeGreaterThan(0);
+        expect(output.summary.totalViolations).toBeGreaterThan(0);
+      });
+
+      it('worktree-none: still a real hard error when the base ALSO has never been indexed (no overcorrection)', async () => {
+        await initRepo(dir);
+        await fs.writeFile(path.join(dir, 'a.ts'), 'export const a = 1;\n');
+        await commitAll(dir, 'init');
+        await chdirIntoFreshNestedWorktree();
+
+        await complexityCommand({ format: 'text' });
+
+        expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('Index not found'));
+        expect(exitSpy).toHaveBeenCalledWith(1);
+      });
+    });
+
+    describe('lien api-delta', () => {
+      it('worktree-fresh: enriches with a real dependentCount from the shared base (#1051)', async () => {
+        await buildHealthyIndex(dir);
+        await chdirIntoFreshNestedWorktree();
+        // Uncommitted signature change on top of the real indexed base state
+        // — `caller.ts` is a real, already-indexed dependent of `add`.
+        await fs.writeFile(
+          path.join(worktreeRoot!, 'math.ts'),
+          [
+            'export function add(a: number, b: number, c: number): number {',
+            '  return a + b + c;',
+            '}',
+            '',
+            'export function manyBranches(x: number): number { return x; }',
+            '',
+          ].join('\n'),
+        );
+
+        await apiDeltaCommand({ format: 'json', file: 'math.ts' });
+
+        const printed = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+        const addChange = printed.changes.find((c: { symbol: string }) => c.symbol === 'add');
+        expect(addChange.enriched).toBe(true);
+        expect(addChange.dependentCount).toBeGreaterThan(0);
+      });
+
+      it('worktree-none: still degrades (enriched:false) when the base ALSO has never been indexed', async () => {
+        await initRepo(dir);
+        await fs.writeFile(
+          path.join(dir, 'a.ts'),
+          'export function formatUser(user) { return user.name; }\n',
+        );
+        await commitAll(dir, 'init');
+        await chdirIntoFreshNestedWorktree();
+        await fs.writeFile(
+          path.join(worktreeRoot!, 'a.ts'),
+          'export function formatUser(user, opts) { return user.name; }\n',
+        );
+
+        await apiDeltaCommand({ format: 'json', file: 'a.ts' });
+
+        const printed = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
+        expect(printed.changes[0]).toMatchObject({ enriched: false, dependentCount: null });
+      });
+    });
+
+    describe('lien annotate', () => {
+      it('worktree-fresh: real dependents/tests annotation from the shared base (#1051)', async () => {
+        await buildHealthyIndex(dir);
+        await chdirIntoFreshNestedWorktree();
+
+        await annotateCommand('math.ts');
+
+        expect(allLogged()).toContain('Lien impact for math.ts');
+        expect(allLogged()).not.toContain('no index found');
+      });
+    });
+
+    describe('lien path --root', () => {
+      it('worktree-fresh: resolves to the WORKTREE itself, never the outer main checkout (#1050)', async () => {
+        await buildHealthyIndex(dir);
+        const wtRoot = await chdirIntoFreshNestedWorktree();
+
+        pathCommand({ root: true });
+
+        const printed = allLogged().trim();
+        expect(printed).toBe(wtRoot);
+        expect(printed).not.toBe(dir);
+      });
     });
   });
 

--- a/packages/cli/test/integration/index-state-matrix.test.ts
+++ b/packages/cli/test/integration/index-state-matrix.test.ts
@@ -631,6 +631,16 @@ describe('index-state × entry-point matrix (#1029 W1)', () => {
 
     afterEach(async () => {
       if (worktreeRoot) {
+        // Restore cwd to the (still-alive) main checkout BEFORE removing the
+        // worktree — CodeRabbit correctly flagged that leaving process.cwd()
+        // pointed at worktreeRoot while `git worktree remove` deletes that
+        // very directory risks an ENOENT the moment anything (vitest's own
+        // internal bookkeeping between hooks, not just this file's code)
+        // calls `process.cwd()` before the outer afterEach's
+        // `process.chdir(originalCwd)` runs. `dir` itself isn't removed
+        // until the outer afterEach's `fs.rm(dir, ...)`, so it's a safe,
+        // still-existing intermediate landing spot.
+        process.chdir(dir);
         await execFileAsync('git', ['worktree', 'remove', '--force', worktreeRoot], {
           cwd: dir,
         }).catch(() => undefined);


### PR DESCRIPTION
## Summary

Fixes #1050. Fixes #1051. Two contradictory bugs that both fire on the same
layout: a linked git worktree, nested inside its own main checkout (the
standard layout every worktree-isolated agent session in this repo uses),
that has never run its own local `lien index`.

- **#1050**: `resolveProjectRoot` silently resolved to the outer main
  checkout instead of the worktree — a confident WRONG-repo answer for
  `lien annotate`/`gc`/`path`/`store-paths`/`recap`/`nudge`/`verify-tests`.
- **#1051**: `hasStructuralIndex` reported a false S0 ("Index not found")
  for `lien complexity`/`lien api-delta` on the same worktree, despite the
  shared base index being fully populated.

Both share the root-cause shape of #1014: checking only one of two on-disk
locations (`OverlayBackend.dbPath`, the worktree's own overlay, vs.
`baseIndexDir`, the shared base) instead of asking whether the current root
is a linked worktree with a usable base.

## Root causes

**#1050** — `resolveProjectRoot`'s "nearest ancestor with a completed
index" check (`packages/cli/src/cli/project-root.ts`) ran as its own fully
unbounded walk, separate from the `.git`-marker walk. For a worktree nested
under `<main>/.claude/worktrees/<name>`, the worktree's own `.git` FILE (the
linked-worktree marker) sits closer than the main checkout's `.git`
DIRECTORY — but before the worktree's first `lien index`, only the main
checkout has a completed index. The unbounded completed-index walk crossed
straight over the worktree's own `.git` boundary to find it.

Fix: merge the two passes into one bounded walk. At each directory, check
"has a completed index" first (preserving the #894 behavior), then "is this
a `.git` marker" — and STOP there if so, never continuing past a repo/
worktree boundary hunting for a completed index on the other side.

**#1051** — `hasStructuralIndex` (`packages/cli/src/utils/index-freshness.ts`)
checked only `<getIndexDir(rootDir)>/structural.db`. For an `OverlayBackend`,
that's the worktree's own *local* overlay DB, which doesn't exist until the
worktree completes at least one local build — even though the *shared base*
(what `OverlayBackend` is designed to serve reads from) is fully populated.

Fix: when the local check misses, ask `resolveIndexStrategy` (already the
canonical, exported classifier from `@liendev/core`) whether `rootDir` is a
worktree in overlay mode, and if so check the base's `structural.db` instead.

Both fixes route through the existing canonical classifiers per CLAUDE.md's
index-state-honesty policy — no hand-rolled index-state logic.

## Reproduction (before/after, real linked worktree, isolated LIEN_HOME)

Built this branch's CLI, created a small synthetic git repo, indexed it, then
`git worktree add`'d a linked worktree nested inside it at
`.claude/worktrees/agent-fresh` — never running `lien index` in the
worktree itself (the exact "fresh" state both issues require).

**Before (pre-fix):**
```
$ lien path --root
/private/tmp/lien-repro-Hyltcc/main          # WRONG — should be the worktree

$ lien complexity
Error: Index not found
Run lien index to index your codebase first
EXIT=1                                        # WRONG — base is fully populated

$ lien api-delta --file math.ts --format json
{"filepath":"math.ts","changes":[{"symbol":"add", ... ,"dependentCount":null,"enriched":false, ...}]}
                                               # degraded — should be enriched
```

**After (this fix):**
```
$ lien path --root
/private/tmp/lien-repro-Hyltcc/main/.claude/worktrees/agent-fresh   # correct

$ lien complexity
🔍 Complexity Analysis
Summary:
  Files analyzed: 2
  Violations: 0 (0 errors, 0 warnings)
✓ No violations found!
EXIT=0

$ lien annotate math.ts
Lien impact for math.ts:
  • 1 file imports this — caller.ts; risk: medium (1 production caller, 1 untested, max complexity 1).
  • No test coverage.

$ lien api-delta --file math.ts --format json
{"filepath":"math.ts","changes":[{"symbol":"add", ... ,"dependentCount":1,"riskLevel":"medium","enriched":true, ...}]}
```

## Coverage gap closed

`packages/cli/test/integration/index-state-matrix.test.ts` (#1043's
index-state-honesty detector) had **zero** worktree/overlay cases across its
original 36 — the states axis was covered, the layout axis wasn't, which is
exactly why #1050/#1051 shipped unnoticed. Added a `worktree/overlay layout
(#1050, #1051)` section:

- **6 new tests**, covering `lien complexity`, `lien api-delta`,
  `lien annotate`, and `lien path --root` against a real linked
  `git worktree add` nested under a fixture main checkout, real
  `indexCodebase`-built base index, real CLI command entry points (no
  `createVectorDB` mocking).
- Each entry point has a `worktree-fresh` case (base populated, worktree
  never locally indexed — the bug shape) and, for the two gate/advisory
  commands, a `worktree-none` control (base ALSO never indexed) proving the
  fix doesn't overcorrect a genuine S0 into a false "ok" — the hard
  constraint from CLAUDE.md's index-state-honesty policy.
- Verified each new test is a real detector: reverted the source fix locally
  and confirmed all 4 `worktree-fresh` tests fail with the exact bug
  symptoms (wrong root / false "Index not found" / silently degraded
  enrichment), then restored the fix and confirmed green.
- Also added a focused unit-level regression test to `project-root.test.ts`
  for the same #1050 shape (fresh worktree over an already-indexed main
  checkout), independently verified to fail against the pre-fix walk.

Also reset `dependency-analyzer.ts`'s module-level `scanCache` (keyed only by
`indexVersion`, no project-root component) in the matrix file's shared
`beforeEach` — the new indexing-heavy worktree tests exposed a latent
cross-test flake where two different fixtures' version stamps collided and
served stale cached dependents. Reused the existing `clearDependencyCache()`
export (already used by `dependency-analyzer.test.ts`) rather than inventing
a new mechanism.

## Dogfood / verification

- `npm run format:check` / `npm run lint` (0 errors, pre-existing warnings
  only) / `npm run typecheck` / `npm run build` — all clean.
- `npm test` (full root suite: parser-native, parser, core, review, cli,
  action) — all green, 1636 CLI tests + 407 core tests passing.
- `lien delta` — exit 0 (both touched functions gained complexity but stayed
  under threshold; no new-over-threshold or crossed function).
- Reproduced both bugs live and re-verified the fix against a real
  `git worktree add`-created linked worktree with an isolated `LIEN_HOME`
  (never touched the shared `~/.lien` index or this repo's own worktree
  fleet).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes two linked-worktree root/index resolution bugs. `resolveProjectRoot` now performs a single bounded upward walk that stops at the first `.git` marker, preventing fresh worktrees from resolving to their outer main checkout. `hasStructuralIndex` now falls back to the shared base index when the worktree has no local overlay yet. Both fixes route through existing canonical classifiers and are accompanied by regression tests covering the bug shape and the negative-control `worktree-none` case to prevent overcorrection.
>
> - Merged two-pass root walk into one bounded pass in `resolveProjectRoot`
> - Added base-index fallback for overlay worktrees in `hasStructuralIndex`
> - Added 6 integration tests plus a focused unit test for the fresh-worktree layout

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit bf581eb. Updates automatically on new commits.</sup>
<!-- /lien-stats -->