### PR TITLE
fix(parser): make re-export transitive-dependent BFS order-independent (#1044)

### DIFF
--- a/packages/parser/src/dependency-analyzer.test.ts
+++ b/packages/parser/src/dependency-analyzer.test.ts
@@ -496,6 +496,76 @@ describe('analyzeDependencies', () => {
     });
   });
 
+  describe('#1044 re-export BFS is independent of chunk scan order', () => {
+    it('finds a dependent reachable through only one of several depth-1 re-export candidates, regardless of which candidate the BFS visits first', () => {
+      // target ← deadend (genuinely re-exports target)
+      // target ← livechain (genuinely re-exports target)
+      // bridge imports BOTH deadend and livechain, but only genuinely
+      // re-exports from livechain (its own `exports` intersects livechain's
+      // re-exported symbol, not deadend's).
+      // bridge ← consumer (imports ONLY bridge — not target/deadend/
+      // livechain directly).
+      //
+      // consumer is discoverable ONLY if the BFS recognizes bridge as a
+      // re-export-chain continuer of livechain. Pre-fix, a single shared
+      // `visited` set gated both "reported as a dependent" and "queued for
+      // its own re-export exploration": whichever of deadend/livechain the
+      // BFS processed FIRST consumed bridge's slot in that set. If deadend
+      // went first, bridge was reported (correctly) but marked visited
+      // before the livechain check ever ran, so bridge was never enqueued
+      // for further exploration and consumer was silently dropped.
+      // `reExporterPaths`' traversal order comes from iterating a `Map`
+      // built by inserting chunks in the order they were scanned — exactly
+      // what real indexing's concurrent, unordered file scan does not hold
+      // constant across runs of the same, unmodified tree (#1044). Feeding
+      // the identical chunk set in two different array orders (only
+      // deadend/livechain's relative position swaps) reproduces that same
+      // order-dependence deterministically, in-process.
+      const target = createChunk('src/target.ts', [], undefined, {
+        exports: ['targetSymbol'],
+      });
+      const deadend = createChunk('src/deadend.ts', ['src/target.ts'], undefined, {
+        exports: ['targetSymbol'],
+        importedSymbols: { './target': ['targetSymbol'] },
+      });
+      const livechain = createChunk('src/livechain.ts', ['src/target.ts'], undefined, {
+        exports: ['targetSymbol'],
+        importedSymbols: { './target': ['targetSymbol'] },
+      });
+      const bridge = createChunk(
+        'src/bridge.ts',
+        ['src/deadend.ts', 'src/livechain.ts'],
+        undefined,
+        {
+          // Only 'liveSymbol' is re-exported: 'deadOnlySymbol' is imported
+          // from deadend but never appears in bridge's own exports, so
+          // bridge is NOT a re-exporter of deadend (a dead end for the
+          // chain), while it IS a genuine re-exporter of livechain.
+          exports: ['liveSymbol'],
+          importedSymbols: {
+            './deadend': ['deadOnlySymbol'],
+            './livechain': ['liveSymbol'],
+          },
+        },
+      );
+      const consumer = createChunk('src/consumer.ts', ['src/bridge.ts'], undefined, {
+        importedSymbols: { './bridge': ['liveSymbol'] },
+      });
+
+      const orderA = [target, deadend, livechain, bridge, consumer];
+      const orderB = [target, livechain, deadend, bridge, consumer];
+
+      const resultA = analyzeDependencies('src/target.ts', orderA, workspaceRoot);
+      const resultB = analyzeDependencies('src/target.ts', orderB, workspaceRoot);
+
+      const pathsA = resultA.dependents.map(d => d.filepath).sort();
+      const pathsB = resultB.dependents.map(d => d.filepath).sort();
+
+      expect(pathsA).toContain('src/consumer.ts');
+      expect(pathsB).toEqual(pathsA);
+    });
+  });
+
   describe('whole-module-import basename hub (#884)', () => {
     it('does not count Swift whole-module test imports as dependents of a same-basename file', () => {
       const chunks: CodeChunk[] = [

--- a/packages/parser/src/dependency-analyzer.ts
+++ b/packages/parser/src/dependency-analyzer.ts
@@ -613,36 +613,72 @@ function buildReExportGraph<T extends CodeChunk>(
 
 /**
  * Process a single dependent chunk during BFS traversal.
- * Returns the chunk if it's a new dependent, or null if already visited.
- * If the chunk's file is itself a re-exporter, adds it to the BFS queue.
+ *
+ * Returns the chunk if its file hasn't been reported as a dependent yet, or
+ * `null` if it has (dedup for the output list -- `reported`). Independently
+ * of that, if `chunkFile` hasn't already been queued for its OWN re-export
+ * exploration, checks whether it re-exports from `reExporterPath` and -- if
+ * so -- enqueues it (`queued`).
+ *
+ * `reported` and `queued` are deliberately two separate sets, not one
+ * (#1044): a file reachable from more than one depth-1 re-export candidate
+ * (a common shape -- a namespace-import heuristic in `fileIsReExporter`
+ * flags any file that imports-and-also-exports as a "re-exporter," so a
+ * genuine barrel and several files that merely happen to import-for-
+ * internal-use both qualify) is a genuine re-exporter of SOME of those
+ * candidates and not others. A single shared `visited` set used to gate
+ * both concerns at once, so whichever candidate's turn came first in the
+ * (traversal-order-dependent) queue "consumed" the file: if that first
+ * candidate happened to be a dead end (the file doesn't re-export from
+ * it), the file got reported once but never queued for further
+ * exploration, and the genuine chain through a LATER candidate was never
+ * checked at all -- silently dropping every dependent reachable only past
+ * that file, non-deterministically, depending on which candidate the
+ * BFS's traversal order (itself downstream of nondeterministic concurrent
+ * file-scan order) happened to process first. Checking the re-exporter
+ * condition once per (file, candidate) pair -- gated only on `queued`, not
+ * on whether the file was already reported -- makes the result depend on
+ * whether ANY valid chain exists, not on which one was tried first.
  */
 function processTransitiveChunk(
   chunk: CodeChunk,
   reExporterPath: string,
   depth: number,
-  visited: Set<string>,
+  reported: Set<string>,
+  queued: Set<string>,
+  checkedThisStep: Set<string>,
   allChunksByFile: Map<string, CodeChunk[]>,
   normalizePathCached: (path: string) => string,
   queue: Array<[string, number]>,
 ): CodeChunk | null {
   const chunkFile = normalizePathCached(chunk.metadata.file);
-  if (visited.has(chunkFile)) return null;
 
-  visited.add(chunkFile);
-
-  if (depth < MAX_REEXPORT_DEPTH) {
+  // `checkedThisStep` memoizes the re-exporter check per (file,
+  // reExporterPath) pair within one BFS step, since `dependentChunks` can
+  // contain many chunks for the same file -- without it, a dead-end file
+  // with N chunks would re-run `fileIsReExporter` N times for no benefit.
+  if (depth < MAX_REEXPORT_DEPTH && !queued.has(chunkFile) && !checkedThisStep.has(chunkFile)) {
+    checkedThisStep.add(chunkFile);
     const fileChunks = allChunksByFile.get(chunkFile) || [];
     if (fileIsReExporter(fileChunks, reExporterPath, normalizePathCached)) {
       queue.push([chunkFile, depth + 1]);
+      queued.add(chunkFile);
     }
   }
 
+  if (reported.has(chunkFile)) return null;
+  reported.add(chunkFile);
   return chunk;
 }
 
 /**
  * Find transitive dependents through re-export chains using BFS.
  * Bounded to MAX_REEXPORT_DEPTH.
+ *
+ * `reported` (output dedup) and `queued` (BFS-exploration dedup) are kept
+ * as two separate sets -- see `processTransitiveChunk`'s doc comment for why
+ * conflating them into one `visited` set made the result depend on BFS
+ * traversal order (#1044).
  */
 export function findTransitiveDependents(
   reExporterPaths: string[],
@@ -653,26 +689,30 @@ export function findTransitiveDependents(
   existingFiles: Set<string>,
 ): CodeChunk[] {
   const transitiveChunks: CodeChunk[] = [];
-  const visited = new Set<string>([normalizedTarget, ...existingFiles]);
+  const reported = new Set<string>([normalizedTarget, ...existingFiles]);
+  const queued = new Set<string>();
 
   const queue: Array<[string, number]> = [];
   for (const rePath of reExporterPaths) {
-    if (!visited.has(rePath)) {
+    if (!queued.has(rePath)) {
       queue.push([rePath, 1]);
-      visited.add(rePath);
+      queued.add(rePath);
     }
   }
 
   while (queue.length > 0) {
     const [reExporterPath, depth] = queue.shift()!;
     const dependentChunks = findDependentChunks(reExporterPath, importIndex, normalizePathCached);
+    const checkedThisStep = new Set<string>();
 
     for (const chunk of dependentChunks) {
       const result = processTransitiveChunk(
         chunk,
         reExporterPath,
         depth,
-        visited,
+        reported,
+        queued,
+        checkedThisStep,
         allChunksByFile,
         normalizePathCached,
         queue,


### PR DESCRIPTION
## Summary

Fixes #1044: `findDependents`'s re-export transitive-dependent BFS
(`packages/parser/src/dependency-analyzer.ts`) was non-deterministic
across repeated `lien index --force` runs of the same, unmodified source
tree — confirmed empirically (below) and root-caused to a real bug in the
BFS itself, not just an ordering artifact to paper over.

## Root cause (verified, not assumed)

The issue's hypothesis was that scan-order nondeterminism propagates into
`allChunksByFile`'s Map insertion order, which changes BFS traversal
order. That part is correct — traced end-to-end: `packages/core/src/indexer/index.ts`'s
`batchProcessFiles` reads/chunks files through a 4-way `p-limit` pool
(`packages/parser/src/constants.ts`'s `PARSE_STAGE_MAX_CONCURRENCY`), and
`ChunkBatchProcessor.addChunks` serializes *whichever file's async chain
resolves first* into the accumulator via a mutex — a real completion-order
race. `scanAll()`'s `readAllRecords` does `ORDER BY id` (SQLite's
insertion-order primary key), so the chunk array `findDependents` receives
is ordered by that race's outcome, not by file-scan order.

But that traversal-order dependence only *matters* because
`findTransitiveDependents`/`processTransitiveChunk` had a real logic bug:
a single shared `visited` `Set` gated two different concerns at once —
"already reported as a dependent" and "already checked whether this file
continues the re-export chain." A file reachable from **more than one**
depth-1 re-export candidate (common: `fileIsReExporter`'s namespace-import
heuristic flags any file that imports-and-exports as a "re-exporter," not
just genuine barrels — e.g. zod's `core/schemas.ts`, `core/registries.ts`,
`core/parse.ts`, `core/checks.ts`, `core/api.ts` all qualify by virtue of
`import * as core from "./core.js"` plus their own substantial exports,
even though only one of those is a real barrel) is a genuine re-exporter
of *some* of those candidates and not others. Whichever candidate the BFS
queue happened to process first "consumed" the file's `visited` slot — if
that first candidate was a dead end, the file got reported once but the
real chain through a later candidate was **never checked at all**,
silently dropping every dependent reachable only past that file.

Traced the exact zod mechanism with temporary instrumentation (reverted
before this PR):

- `packages/zod/src/v4/classic/schemas.ts` imports `../core/to-json-schema.js`
  directly (only path in).
- `core/to-json-schema.ts` itself imports `./schemas.js` (wildcard —
  qualifies as a chain continuation of `core/schemas.ts`) and
  `./registries.js` (named import, not re-exported — a dead end for
  `core/registries.ts`).
- Depth-1 candidates `[core/schemas, core/registries, core/parse,
  core/checks, core/api]` get processed in `Map`-iteration order.
- When `registries` was dequeued **before** `schemas`, `to-json-schema.ts`
  got marked visited as a (correctly identified) dead-end dependent of
  `registries` — and when `schemas` came up later, `to-json-schema.ts` was
  already "visited," so the real continuation check against `schemas`
  never ran. `classic/schemas.ts` was never discovered.
- When `schemas` was dequeued first, the correct check ran immediately and
  `classic/schemas.ts` was found.

## Which answer is correct

**`classic/schemas.ts` IS a genuine transitive dependent of `core/core.ts`**
via a real, valid re-export chain (`core.ts` → `core/schemas.ts` → `core/to-json-schema.ts`
→ `classic/schemas.ts`, `to-json-schema.ts` re-exporting from `schemas.ts`
via its wildcard `import type * as schemas`). The pre-fix "not found" runs
were the wrong answer, produced only because a coincidental, irrelevant
dead-end path (`registries`) got processed first and stole the file's
`visited` slot before the real chain was ever checked. This isn't a case
where both outcomes are defensible under different definitions — one
outcome corresponds to a real import edge existing, the other to that edge
never being checked.

## The fix

Split the single `visited` `Set` into two: `reported` (output dedup —
unchanged semantics) and `queued` (BFS-exploration dedup), and made the
"does this file continue the chain from `reExporterPath`" check run once
per **(file, candidate)** pair, gated only on `queued`, independent of
whether the file was already `reported`. The result now depends on whether
*any* valid chain exists to a file, not on which candidate happened to be
tried first. Added `checkedThisStep` to keep the check from re-running once
per chunk when a file has many chunks (memoized per BFS step, not per
chunk).

## Verification

### 1. Reproduced the flap first (isolated `LIEN_HOME` per trial, shallow
zod clone, never touching the shared index)

20 fresh-index trials, **pre-fix**, same unmodified zod clone, same built
CLI — `classic/schemas.ts`'s presence in `core/core.ts`'s dependents flips:

```
trial 1: {"totalChunks":5078,"dependentCount":79,"truncated":false,"found":true}
trial 2: {"totalChunks":5078,"dependentCount":79,"truncated":false,"found":true}
trial 3: {"totalChunks":5078,"dependentCount":79,"truncated":false,"found":true}
trial 4: {"totalChunks":5078,"dependentCount":79,"truncated":false,"found":true}
trial 5: {"totalChunks":5078,"dependentCount":79,"truncated":false,"found":true}
trial 6: {"totalChunks":5078,"dependentCount":79,"truncated":false,"found":true}
trial 7: {"totalChunks":5078,"dependentCount":79,"truncated":false,"found":true}
trial 8: {"totalChunks":5078,"dependentCount":78,"truncated":false,"found":false}
trial 9: {"totalChunks":5078,"dependentCount":79,"truncated":false,"found":true}
trial 10: {"totalChunks":5078,"dependentCount":78,"truncated":false,"found":false}
trial 11: {"totalChunks":5078,"dependentCount":79,"truncated":false,"found":true}
trial 12: {"totalChunks":5078,"dependentCount":79,"truncated":false,"found":true}
trial 13: {"totalChunks":5078,"dependentCount":78,"truncated":false,"found":false}
trial 14: {"totalChunks":5078,"dependentCount":79,"truncated":false,"found":true}
trial 15: {"totalChunks":5078,"dependentCount":78,"truncated":false,"found":false}
trial 16: {"totalChunks":5078,"dependentCount":78,"truncated":false,"found":false}
trial 17: {"totalChunks":5078,"dependentCount":78,"truncated":false,"found":false}
trial 18: {"totalChunks":5078,"dependentCount":79,"truncated":false,"found":true}
trial 19: {"totalChunks":5078,"dependentCount":78,"truncated":false,"found":false}
trial 20: {"totalChunks":5078,"dependentCount":79,"truncated":false,"found":true}
```
13/20 found, 7/20 not found (65/35 split — same phenomenon as the issue's
75/25 measurement, exact ratio varies trial-batch to trial-batch since it's
an I/O completion race).

### 2. Proved determinism after the fix — 20/20 identical, full dependent
**set** hash (not just count), fresh full re-index every trial

```
trial 1: {"totalChunks":5078,"dependentCount":97,"truncated":false,"found":true,"setHash":"e6776ff6216521e0"}
trial 2: {"totalChunks":5078,"dependentCount":97,"truncated":false,"found":true,"setHash":"e6776ff6216521e0"}
trial 3: {"totalChunks":5078,"dependentCount":97,"truncated":false,"found":true,"setHash":"e6776ff6216521e0"}
trial 4: {"totalChunks":5078,"dependentCount":97,"truncated":false,"found":true,"setHash":"e6776ff6216521e0"}
trial 5: {"totalChunks":5078,"dependentCount":97,"truncated":false,"found":true,"setHash":"e6776ff6216521e0"}
trial 6: {"totalChunks":5078,"dependentCount":97,"truncated":false,"found":true,"setHash":"e6776ff6216521e0"}
trial 7: {"totalChunks":5078,"dependentCount":97,"truncated":false,"found":true,"setHash":"e6776ff6216521e0"}
trial 8: {"totalChunks":5078,"dependentCount":97,"truncated":false,"found":true,"setHash":"e6776ff6216521e0"}
trial 9: {"totalChunks":5078,"dependentCount":97,"truncated":false,"found":true,"setHash":"e6776ff6216521e0"}
trial 10: {"totalChunks":5078,"dependentCount":97,"truncated":false,"found":true,"setHash":"e6776ff6216521e0"}
trial 11: {"totalChunks":5078,"dependentCount":97,"truncated":false,"found":true,"setHash":"e6776ff6216521e0"}
trial 12: {"totalChunks":5078,"dependentCount":97,"truncated":false,"found":true,"setHash":"e6776ff6216521e0"}
trial 13: {"totalChunks":5078,"dependentCount":97,"truncated":false,"found":true,"setHash":"e6776ff6216521e0"}
trial 14: {"totalChunks":5078,"dependentCount":97,"truncated":false,"found":true,"setHash":"e6776ff6216521e0"}
trial 15: {"totalChunks":5078,"dependentCount":97,"truncated":false,"found":true,"setHash":"e6776ff6216521e0"}
trial 16: {"totalChunks":5078,"dependentCount":97,"truncated":false,"found":true,"setHash":"e6776ff6216521e0"}
trial 17: {"totalChunks":5078,"dependentCount":97,"truncated":false,"found":true,"setHash":"e6776ff6216521e0"}
trial 18: {"totalChunks":5078,"dependentCount":97,"truncated":false,"found":true,"setHash":"e6776ff6216521e0"}
trial 19: {"totalChunks":5078,"dependentCount":97,"truncated":false,"found":true,"setHash":"e6776ff6216521e0"}
trial 20: {"totalChunks":5078,"dependentCount":97,"truncated":false,"found":true,"setHash":"e6776ff6216521e0"}
```
20/20 byte-identical (a `sha256` of the sorted dependents list, not just
the count). `dependentCount` rose from a flapping 78/79 to a stable 97 —
the fix doesn't just pick one of the two old branches, it recovers every
dependent that was reachable through *any* valid chain, which either old
branch was dropping some of.

Both trial batches used the CLI's real `createVectorDB` + `scanAll()` +
`@liendev/parser`'s `findDependents` — the exact `get_dependents` MCP code
path, chunk-in/chunk-out, no mocking. Isolated `LIEN_HOME` per trial
(`/tmp/lien-1044-*`), never the shared index, never a worktree sharing an
OverlayBackend base.

### 3. Checked the other 10 corpora the E2E suite names

Ran 10 pre-fix trials (5 for JS's second target) against each corpus's
`knownSymbolFile` (`packages/cli/test/e2e/real-projects.test.ts`), hashing
the full dependent set each time, then 5 post-fix trials for confirmation.
JavaPoet/Klaxon/SwiftyJSON are excluded — Java/Kotlin/Swift resolve zero
import-graph edges today (#1005, unrelated known gap), so there's no
transitive chain to flap.

| Corpus | Target | Pre-fix unique hashes (10 trials) | Post-fix unique hashes (5 trials) |
|---|---|---|---|
| requests | `src/requests/utils.py` | 1 | 1 |
| express | `lib/express.js` + `lib/utils.js` | 1 | 1 |
| monolog | `src/Monolog/Logger.php` | 1 | 1 |
| anyhow | `src/chain.rs` | 1 | 1 |
| chi | `context.go` | 1 | 1 |
| mediatr | `src/MediatR/IRequestHandler.cs` | 1 | 1 |
| sinatra | `lib/sinatra/base.rb` | 1 | 1 |

**Only zod flapped** among the 11 named corpora, for these target files —
none of the others showed multi-hop chains gated behind more than one
depth-1 candidate for the files checked. Pre-fix and post-fix hashes are
identical for all 7, confirming the fix is a no-op for cases it wasn't
already breaking (no regression).

### 4. Regression test

Added `#1044 re-export BFS is independent of chunk scan order` to
`packages/parser/src/dependency-analyzer.test.ts`: constructs
`target ← deadend` and `target ← livechain` (both genuine re-exporters of
`target`), `bridge` (imports both, but only genuinely re-exports from
`livechain` — `deadend` is a deliberate dead end), and `consumer` (imports
only `bridge`). Feeds the identical chunk set through `analyzeDependencies`
in two different array orders (only `deadend`/`livechain`'s relative
position swaps) and asserts `consumer.ts` is found in both, with identical
sorted dependent lists. Confirmed this test **fails** against the
pre-fix code (`orderA` drops `consumer.ts`) and passes after the fix.

### 5. Six gates

```
npm run format:check   # pass
npm run lint           # 0 errors (40 pre-existing warnings, untouched files)
npm run typecheck      # pass
npm run build           # pass
npm test               # 72 files / 1629 tests (cli) + parser/core/review/action all green
lien delta             # exit 0 — 2 "worsened" (not crossed) complexity entries on the touched functions
```

## Test plan

- [x] Reproduced the flap pre-fix (20 trials, 13/20 vs 7/20 split)
- [x] Proved determinism post-fix (20/20 identical full-set hash)
- [x] Checked the other 10 E2E corpora for flapping (none found; 3 are
      exempt via the pre-existing zero-edge-language gap)
- [x] Added a regression test that fails pre-fix and passes post-fix,
      exercising two different chunk-array orderings (not just "is
      sorted")
- [x] All six gates green

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes a real order-dependence bug in transitive re-export dependent discovery by splitting the conflated `visited` Set into separate `reported` (output dedup) and `queued` (BFS exploration dedup) sets in `processTransitiveChunk`/`findTransitiveDependents`, plus a per-step `checkedThisStep` memoization. The change is localized to the BFS helpers, preserves all existing function signatures, and is accompanied by a regression test that fails pre-fix and passes post-fix. I traced the new logic through the reported regression case, the swapped-order case, multi-chunk files, cycles, and files that are both direct dependents and re-exporters; in all cases the new code correctly explores every valid chain once while deduplicating output.
>
> - Split shared `visited` Set into `reported` and `queued` so a file reachable from multiple depth-1 re-export candidates is checked against each candidate independently of output reporting
> - Added `checkedThisStep` to memoize the re-exporter check per (file, candidate) pair within a single BFS step, avoiding redundant work for multi-chunk files
> - Added regression test `#1044 re-export BFS is independent of chunk scan order` covering both candidate orderings

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit eb0d04d. Updates automatically on new commits.</sup>
<!-- /lien-stats -->