### PR TITLE
fix(parser): C# enclosing-namespace test-association convention (#1040)

### DIFF
--- a/packages/cli/src/cli/annotate-cmd.test.ts
+++ b/packages/cli/src/cli/annotate-cmd.test.ts
@@ -1206,13 +1206,18 @@ describe('annotateCommand — --tests-only (integration)', () => {
     }
   });
 
-  // #930/#943, end-to-end: a C# source file reachable only via implicit
-  // enclosing-namespace access (no `using` names it at all) still surfaces
-  // its non-import type-reference fallback through the real
-  // `scanTestAssociations` -> `computeCSharpTypeReferenceTestFallback` ->
-  // `findCSharpTypeReferenceDependents` -> `formatTestReminder` pipeline --
-  // mirrors the Swift symbol-usage integration test immediately above.
-  it('prints the type-reference fallback reminder for a C# file with no import signal', async () => {
+  // #930/#943/#1040, end-to-end: a C# source file reachable only via implicit
+  // enclosing-namespace access (no `using` names it at all) now resolves as a
+  // REAL, direct test association -- not merely the inferred fallback this
+  // test originally demonstrated. #1040 folded the same
+  // `findCSharpTypeReferenceDependents` signal directly into
+  // `findTestAssociationsFromChunks` (`test-associations.ts`'s
+  // `collectCSharpNamespaceTests`), so `tests` itself is non-empty here now,
+  // and `computeCSharpTypeReferenceTestFallback`'s `if (tests.length > 0)
+  // return [];` guard always short-circuits for this fixture -- see that
+  // function's own doc comment for why it is provably unreachable for ANY
+  // C# fixture post-#1040, not just this one.
+  it('prints the direct-tests reminder for a C# file reachable only via enclosing-namespace access (#1040)', async () => {
     const fs = await import('fs/promises');
     const repoRoot = path.resolve(process.cwd(), '..', '..');
     const fixtureDir = path.join(repoRoot, '__annotate_csharp_fixture__');
@@ -1264,7 +1269,7 @@ describe('annotateCommand — --tests-only (integration)', () => {
       expect(errSpy).not.toHaveBeenCalled();
       expect(logSpy).toHaveBeenCalledTimes(1);
       expect(logSpy.mock.calls[0][0]).toBe(
-        `Lien: you changed ${csharpTarget} — no import-verified test match, but type-reference matching suggests: Serilog.Tests/Configuration/LoggerConfigurationTests.cs (inferred, not import-verified). Consider running them before completing.`,
+        `Lien: you changed ${csharpTarget} — associated tests: Serilog.Tests/Configuration/LoggerConfigurationTests.cs. Run them before completing.`,
       );
     } finally {
       await fs.rm(fixtureDir, { recursive: true, force: true });

--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -371,10 +371,22 @@ function computeSwiftSymbolUsageFallback(
  * `findCSharpTypeReferenceDependents` -- the SAME namespace-scoped signal
  * `get_dependents`'s file-level recovery already relies on (#930/#943) --
  * filtered down to the TEST-file subset of `filepath`'s recovered
- * dependents. Measured on serilog/serilog: 116/216 (54%) of files gain a
- * recovered test-file dependent this way, cutting the previous 100%
- * "test coverage not determinable" figure roughly in half. Deliberately NOT
- * merged into `tests` itself, mirroring every other fallback tier here.
+ * dependents. Originally measured on serilog/serilog: 116/216 (54%) of files
+ * gained a recovered test-file dependent this way, cutting the previous 100%
+ * "test coverage not determinable" figure roughly in half.
+ *
+ * #1040 note: this tier is now PROVABLY UNREACHABLE (always returns `[]`).
+ * `test-associations.ts`'s `findTestAssociationsFromChunks` -- which
+ * produces `tests` above -- now folds this exact same
+ * `findCSharpTypeReferenceDependents(filepath, allChunks).filter(isTestFile)`
+ * computation directly into its own result set (`collectCSharpNamespaceTests`),
+ * using the identical `filepath`/`allChunks`. So whenever this function's own
+ * `if (tests.length > 0) return [];` guard would fall through, its
+ * subsequent computation is guaranteed to reproduce a `[]` that already
+ * informed `tests` being empty in the first place. Kept as dead code for now
+ * rather than folded into this PR's scope -- removing it means also
+ * unwinding `csharpTypeReferenceTests`'s ~13 call sites through
+ * `AnnotationData`/`formatTests`/the tests-only path, a separate cleanup.
  */
 function computeCSharpTypeReferenceTestFallback(
   tests: string[],

--- a/packages/cli/src/mcp/handlers/get-files-context.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.ts
@@ -17,12 +17,16 @@ import {
   toJavaTestCandidate,
   buildJavaTestDirIndex,
   pairJavaBasenameTest,
+  hasEnclosingNamespaceAccess,
+  buildCSharpTypeReferenceIndex,
+  resolveCSharpTypeReferenceDependents,
   MAX_CHUNKS_PER_FILE,
   DEFAULT_COMPLEXITY_DELTA_THRESHOLDS,
   type GoTestCandidate,
   type GoTestDirIndex,
   type JavaTestCandidate,
   type JavaTestDirIndex,
+  type CSharpTypeReferenceIndex,
 } from '@liendev/parser';
 import type { SearchResult, VectorDBInterface } from '@liendev/core';
 
@@ -387,6 +391,59 @@ function collectJavaBasenameTestFiles(
 }
 
 /**
+ * True when `filepath`'s language sets `enclosingNamespaceAccess` (C# today,
+ * #930/#1040) — mirrors `hasGoSameDirectoryConvention`/`hasJavaSamePackageConvention` above.
+ */
+function hasCSharpEnclosingNamespaceConvention(filepath: string): boolean {
+  const language = detectLanguage(filepath);
+  return language !== null && hasEnclosingNamespaceAccess(language);
+}
+
+/**
+ * #1040: C#'s enclosing-namespace type-reference index, built once per
+ * `findTestAssociations` call and reused for every target file below —
+ * mirrors `buildGoTestDirIndexFromChunks`/`buildJavaTestDirIndexFromChunks`
+ * immediately above. `resolveCSharpTypeReferenceDependents` needs each
+ * chunk's file keyed EXACTLY as it appears in the index (see that
+ * function's doc comment in `@liendev/parser`), so chunk paths are
+ * canonicalized to workspace-relative first — `chunk.metadata.file` can be
+ * absolute here, the same reason every other tier's index builder above
+ * calls `getCanonicalPath` before comparing against `filepath` (always
+ * workspace-relative, the tool's own argument form).
+ */
+function buildCSharpTestIndexFromChunks(
+  allChunks: SearchResult[],
+  workspaceRoot: string,
+): CSharpTypeReferenceIndex {
+  const canonicalChunks = allChunks.map(chunk => ({
+    ...chunk,
+    metadata: { ...chunk.metadata, file: getCanonicalPath(chunk.metadata.file, workspaceRoot) },
+  }));
+  return buildCSharpTypeReferenceIndex(canonicalChunks);
+}
+
+/**
+ * #1040: C#'s enclosing-namespace test convention has no basename pairing to
+ * fall back on (a C# test class's file name routinely bears no relation to
+ * the specific type(s) it covers). Reuses
+ * `resolveCSharpTypeReferenceDependents` — the SAME namespace-scoped signal
+ * `get_dependents`'s file-level recovery already relies on (#930) — filtered
+ * to the test-file subset of `filepath`'s recovered dependents. See
+ * `@liendev/parser`'s `test-associations.ts` (`collectCSharpNamespaceTests`)
+ * for the full precision reasoning; this is `get_files_context`'s own
+ * separate implementation of the identical tier.
+ */
+function collectCSharpNamespaceTestFiles(
+  filepath: string,
+  csharpIndex: CSharpTypeReferenceIndex,
+  workspaceRoot: string,
+): string[] {
+  if (!hasCSharpEnclosingNamespaceConvention(filepath)) return [];
+  const canonicalTarget = getCanonicalPath(filepath, workspaceRoot);
+  return resolveCSharpTypeReferenceDependents(canonicalTarget, csharpIndex).filter(isTestFile);
+}
+
+/**
  * Find test files that import the given source files.
  *
  * Scans all indexed chunks to find test files that have import
@@ -400,9 +457,11 @@ function collectJavaBasenameTestFiles(
  *
  * Also folds in #902 tier 1 (Go's same-directory basename-paired test
  * convention, which carries no import statement at all) — see
- * `buildGoTestDirIndexFromChunks`/`collectGoBasenameTestFiles` above — and
+ * `buildGoTestDirIndexFromChunks`/`collectGoBasenameTestFiles` above —
  * #925 tier 1 (Java's same-package equivalent) — see
- * `buildJavaTestDirIndexFromChunks`/`collectJavaBasenameTestFiles` above.
+ * `buildJavaTestDirIndexFromChunks`/`collectJavaBasenameTestFiles` above —
+ * and #1040 (C#'s enclosing-namespace equivalent) — see
+ * `buildCSharpTestIndexFromChunks`/`collectCSharpNamespaceTestFiles` above.
  *
  * @param filepaths - Array of source file paths
  * @param allChunks - All chunks from the vector database
@@ -411,13 +470,14 @@ function collectJavaBasenameTestFiles(
  */
 export function findTestAssociations(
   filepaths: string[],
-  allChunks: Array<{ metadata: { file: string; imports?: string[] } }>,
+  allChunks: SearchResult[],
   ctx: HandlerContext,
 ): string[][] {
   const { workspaceRoot } = ctx;
   const { normalize } = createPathCache(workspaceRoot);
   const goTestDirIndex = buildGoTestDirIndexFromChunks(allChunks, workspaceRoot, normalize);
   const javaTestDirIndex = buildJavaTestDirIndexFromChunks(allChunks, workspaceRoot, normalize);
+  const csharpIndex = buildCSharpTestIndexFromChunks(allChunks, workspaceRoot);
 
   return filepaths.map(filepath => {
     const normalizedTarget = normalize(filepath);
@@ -425,6 +485,7 @@ export function findTestAssociations(
       ...collectImportMatchedTestFiles(allChunks, normalizedTarget, normalize, workspaceRoot),
       ...collectGoBasenameTestFiles(filepath, normalizedTarget, goTestDirIndex),
       ...collectJavaBasenameTestFiles(filepath, normalizedTarget, javaTestDirIndex),
+      ...collectCSharpNamespaceTestFiles(filepath, csharpIndex, workspaceRoot),
     ]);
 
     return Array.from(testFiles);

--- a/packages/cli/src/mcp/server.get-files-context.test.ts
+++ b/packages/cli/src/mcp/server.get-files-context.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { getCanonicalPath, normalizePath, matchesFile, isTestFile } from '@liendev/parser';
+import type { SearchResult } from '@liendev/core';
 import {
   searchFileChunks,
   findRelatedChunks,
@@ -8,6 +9,28 @@ import {
   buildFilesData,
   createPathCache,
 } from './handlers/get-files-context.js';
+
+/**
+ * Minimal `SearchResult` builder for `findTestAssociations` tests below —
+ * these only exercise import/basename-based matching, so `content` and the
+ * scoring fields are irrelevant filler; only `metadata.file`/`imports`
+ * matter to the assertions.
+ */
+function mockSearchResult(file: string, imports?: string[]): SearchResult {
+  return {
+    content: '',
+    metadata: {
+      file,
+      startLine: 1,
+      endLine: 1,
+      type: 'block',
+      language: 'typescript',
+      ...(imports ? { imports } : {}),
+    },
+    score: 0,
+    relevance: 'not_relevant',
+  };
+}
 
 /**
  * Unit tests for get_files_context handler and helper functions.
@@ -327,24 +350,9 @@ describe('get_files_context - Helper Functions', () => {
   describe('findTestAssociations', () => {
     it('should find test files that import target', () => {
       const mockChunks = [
-        {
-          metadata: {
-            file: 'src/__tests__/auth.test.ts',
-            imports: ['../auth', '../utils'],
-          },
-        },
-        {
-          metadata: {
-            file: 'src/__tests__/user.test.ts',
-            imports: ['../user', '../auth'],
-          },
-        },
-        {
-          metadata: {
-            file: 'src/helper.ts',
-            imports: ['./auth'],
-          },
-        },
+        mockSearchResult('src/__tests__/auth.test.ts', ['../auth', '../utils']),
+        mockSearchResult('src/__tests__/user.test.ts', ['../user', '../auth']),
+        mockSearchResult('src/helper.ts', ['./auth']),
       ];
 
       const ctx = {
@@ -362,14 +370,7 @@ describe('get_files_context - Helper Functions', () => {
     });
 
     it('should not include non-test files', () => {
-      const mockChunks = [
-        {
-          metadata: {
-            file: 'src/helper.ts',
-            imports: ['./auth'],
-          },
-        },
-      ];
+      const mockChunks = [mockSearchResult('src/helper.ts', ['./auth'])];
 
       const ctx = {
         vectorDB: {} as any,
@@ -384,14 +385,7 @@ describe('get_files_context - Helper Functions', () => {
     });
 
     it('should handle chunks with no imports', () => {
-      const mockChunks = [
-        {
-          metadata: {
-            file: 'src/__tests__/auth.test.ts',
-            // No imports property
-          },
-        },
-      ];
+      const mockChunks = [mockSearchResult('src/__tests__/auth.test.ts')];
 
       const ctx = {
         vectorDB: {} as any,

--- a/packages/cli/src/mcp/server.get-files-context.test.ts
+++ b/packages/cli/src/mcp/server.get-files-context.test.ts
@@ -33,6 +33,41 @@ function mockSearchResult(file: string, imports?: string[]): SearchResult {
 }
 
 /**
+ * #1040: a real C# type declaration/usage `SearchResult`, optionally
+ * namespaced (a `namespace X;` line prefixed into content) -- mirrors
+ * `@liendev/parser`'s own `csharp-type-reference-signals.test.ts` helpers,
+ * needed here because `findTestAssociations`'s C# tier
+ * (`collectCSharpNamespaceTestFiles`) reads `content`/`symbolType`/`symbolName`,
+ * not just `metadata.file`/`imports` like the plain `mockSearchResult` above.
+ */
+function mockCSharpChunk(opts: {
+  file: string;
+  symbolName: string;
+  namespace?: string;
+  declares?: boolean;
+  references?: string[];
+}): SearchResult {
+  const nsPrefix = opts.namespace ? `namespace ${opts.namespace};\n\n` : '';
+  const body = opts.declares
+    ? `public class ${opts.symbolName} { }`
+    : (opts.references ?? []).map(name => `var x = new ${name}();`).join('\n');
+  return {
+    content: `${nsPrefix}${body}`,
+    metadata: {
+      file: opts.file,
+      startLine: 1,
+      endLine: 10,
+      type: opts.declares ? 'class' : 'function',
+      language: 'csharp',
+      symbolName: opts.symbolName,
+      symbolType: opts.declares ? 'class' : 'method',
+    },
+    score: 0,
+    relevance: 'not_relevant',
+  };
+}
+
+/**
  * Unit tests for get_files_context handler and helper functions.
  *
  * Tests cover:
@@ -397,6 +432,37 @@ describe('get_files_context - Helper Functions', () => {
       const result = findTestAssociations(['src/auth.ts'], mockChunks, ctx);
 
       expect(result[0]).toHaveLength(0);
+    });
+
+    // #1040: C#'s enclosing-namespace test convention has no import
+    // statement AND no basename relationship to its subject (unlike Go/Java's
+    // tiers above) -- see `collectCSharpNamespaceTestFiles`.
+    it('associates a C# test file with its subject via enclosing-namespace access, with no import and no basename match (#1040)', () => {
+      const mockChunks = [
+        mockCSharpChunk({
+          file: 'src/MediatR/IRequestHandler.cs',
+          symbolName: 'IRequestHandler',
+          namespace: 'MediatR',
+          declares: true,
+        }),
+        mockCSharpChunk({
+          file: 'test/MediatR.Tests/PipelineTests.cs',
+          symbolName: 'TestMethod',
+          namespace: 'MediatR.Tests',
+          references: ['IRequestHandler'],
+        }),
+      ];
+
+      const ctx = {
+        vectorDB: {} as any,
+        embeddings: {} as any,
+        log: vi.fn(),
+        workspaceRoot,
+      };
+
+      const result = findTestAssociations(['src/MediatR/IRequestHandler.cs'], mockChunks, ctx);
+
+      expect(result[0]).toEqual(['test/MediatR.Tests/PipelineTests.cs']);
     });
   });
 

--- a/packages/cli/test/e2e/real-projects.test.ts
+++ b/packages/cli/test/e2e/real-projects.test.ts
@@ -150,24 +150,24 @@ const KNOWN_ZERO_EDGE_LANGUAGES = new Set(['java', 'kotlin', 'swift']);
  * - **swift**: documented and accepted, #869 ("whole-module-import
  *   languages have no per-file test-association signal -- structural gap,
  *   not a matching bug"). Measured: SwiftyJSON, 0/27 files.
- * - **csharp**: a NEW gap found while building this test, filed as #1040.
- *   `test-associations.ts` wires in a same-convention fallback for Go
- *   (`hasSameDirectoryTestConvention`) and Java (`hasSamePackageTestConvention`)
- *   but has no C# case, even though C# is the one language with
- *   `enclosingNamespaceAccess` for general dependents (#930) -- a C# test
- *   file in a nested namespace (e.g. `MediatR.Tests`) sees its parent
- *   namespace's (`MediatR`) types with no `using` statement at all, the
- *   same shape as Go/Java's no-import test conventions, but nothing gives
- *   that convention credit for test-association purposes. Measured: MediatR,
- *   0/160 files, confirmed not a sampling artifact (checked all 160, not
- *   just the 100-file sample).
+ *
+ * **csharp is FIXED (#1040)** and no longer belongs in this set:
+ * `test-associations.ts` now reuses `resolveCSharpTypeReferenceDependents`
+ * (the SAME namespace-scoped signal `get_dependents`'s file-level recovery
+ * already relied on, #930) filtered to test files, recovering C#'s
+ * enclosing-namespace test convention -- a C# test file in a nested
+ * namespace (e.g. `MediatR.Tests`) sees its parent namespace's (`MediatR`)
+ * types with no `using` statement at all, the same shape as Go/Java's
+ * no-import test conventions. Measured: MediatR, 0/160 -> 60/160 files (269
+ * associations across all 160; see MediatR's own `expectedMinTestAssociations`
+ * for the 100-file-sampled floor this test actually asserts).
  *
  * Note this is a DIFFERENT set from `KNOWN_ZERO_EDGE_LANGUAGES`: Java is
  * zero-edge (#1005) but NOT zero-test-association -- `samePackageTestConvention`
  * covers test association only, not dependents, exactly as #1005 documents.
  * Measured: JavaPoet, 13/43 files, real non-zero test associations.
  */
-const KNOWN_ZERO_TESTASSOC_LANGUAGES = new Set(['csharp', 'kotlin', 'swift']);
+const KNOWN_ZERO_TESTASSOC_LANGUAGES = new Set(['kotlin', 'swift']);
 
 /**
  * Test projects for each supported language
@@ -312,12 +312,14 @@ const TEST_PROJECTS: ProjectConfig[] = [
     sampleSearchQuery: 'mediator request handler',
     expectedMinDependencyEdges: 20, // measured ~578 (2026-07); floor is a collapse detector, not a target
     expectedMinComplexityViolations: 5, // measured ~20 (2026-08)
-    // KNOWN GAP: #1040 (filed by #1029/W3) -- C# resolves 0 test
-    // associations today despite MediatR shipping a real test project. See
-    // KNOWN_ZERO_TESTASSOC_LANGUAGES: asserted as an exact-zero tripwire,
-    // not a floor, elsewhere in this file. This value is unused while csharp
-    // is in that set, but keeps the field non-optional for every project.
-    expectedMinTestAssociations: 0,
+    // #1040 FIXED: C# resolved 0 test associations before this fix despite
+    // MediatR shipping a real test project (root cause: the enclosing-
+    // namespace test convention had no case in test-associations.ts). Now
+    // measured ~175 across a 100-file sample of 160 (2026-08; ~269 across
+    // all 160 files, unsampled). Floor set to 90 (~51% of the measured 175)
+    // per #1053 -- tight enough to catch roughly a 50%+ regression, not just
+    // a near-total collapse.
+    expectedMinTestAssociations: 90,
     expectedMinChunksWithExports: 200, // measured ~1376/1449 chunks (2026-08)
     knownSymbolQuery: 'IRequestHandler',
     knownSymbolFile: 'src/MediatR/IRequestHandler.cs',

--- a/packages/parser/src/csharp-type-reference-signals.test.ts
+++ b/packages/parser/src/csharp-type-reference-signals.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { findCSharpTypeReferenceDependents } from './csharp-type-reference-signals.js';
+import {
+  findCSharpTypeReferenceDependents,
+  buildCSharpTypeReferenceIndex,
+  resolveCSharpTypeReferenceDependents,
+} from './csharp-type-reference-signals.js';
 import type { CodeChunk } from './types.js';
 
 interface ChunkOptions {
@@ -415,5 +419,43 @@ describe('findCSharpTypeReferenceDependents', () => {
         'src/Capturing/PropertyValueConverter.cs',
       ]);
     });
+  });
+});
+
+// #1040: `buildCSharpTypeReferenceIndex` + `resolveCSharpTypeReferenceDependents`
+// let a caller resolve MANY target files against one project-wide scan --
+// extracted from `findCSharpTypeReferenceDependents` so `test-associations.ts`
+// doesn't rebuild the index per target file (see that module's
+// `collectCSharpNamespaceTests`).
+describe('buildCSharpTypeReferenceIndex + resolveCSharpTypeReferenceDependents (#1040 build-once API)', () => {
+  it('resolving against a pre-built index matches findCSharpTypeReferenceDependents for the same target', () => {
+    const chunks: CodeChunk[] = [
+      declChunk('src/Parsing/Alignment.cs', 'Alignment'),
+      usageChunk('src/Rendering/Padding.cs', ['Alignment']),
+    ];
+
+    const index = buildCSharpTypeReferenceIndex(chunks);
+
+    expect(resolveCSharpTypeReferenceDependents('src/Parsing/Alignment.cs', index)).toEqual(
+      findCSharpTypeReferenceDependents('src/Parsing/Alignment.cs', chunks),
+    );
+  });
+
+  it('resolves multiple different target files against the SAME built index without rebuilding it per target', () => {
+    const chunks: CodeChunk[] = [
+      declChunk('src/Parsing/Alignment.cs', 'Alignment'),
+      declChunk('src/Rendering/Padding.cs', 'Padding'),
+      usageChunk('test/AlignmentTests.cs', ['Alignment']),
+      usageChunk('test/PaddingTests.cs', ['Padding']),
+    ];
+
+    const index = buildCSharpTypeReferenceIndex(chunks);
+
+    expect(resolveCSharpTypeReferenceDependents('src/Parsing/Alignment.cs', index)).toEqual([
+      'test/AlignmentTests.cs',
+    ]);
+    expect(resolveCSharpTypeReferenceDependents('src/Rendering/Padding.cs', index)).toEqual([
+      'test/PaddingTests.cs',
+    ]);
   });
 });

--- a/packages/parser/src/csharp-type-reference-signals.ts
+++ b/packages/parser/src/csharp-type-reference-signals.ts
@@ -131,15 +131,24 @@
  * `grep -rlw` across the entire `src`+`test` tree, not just the 5 known
  * files).
  *
- * Deliberately scoped to file-level `get_dependents` recovery (via this
- * package's `dependency-analyzer.ts`), NOT test-association -- unlike Go/Java/Swift's
- * same-shaped signals, which stay confined to `lien annotate`'s test-
- * coverage line. #930's remaining gap is specifically that `get_dependents`
- * itself reports a false `dependentCount: 0` / `riskLevel: "low"` "all
- * clear" on a file that has 5 real callers -- an honesty label
- * (`dependentAttributionIncomplete`, #936) already covers the "we don't
- * know" case; this module is what lets the tool answer "we found some"
- * instead, when it genuinely can.
+ * Originally scoped to file-level `get_dependents` recovery only (via this
+ * package's `dependency-analyzer.ts`) -- #930's gap was specifically that
+ * `get_dependents` itself reported a false `dependentCount: 0` /
+ * `riskLevel: "low"` "all clear" on a file that has 5 real callers, which an
+ * honesty label (`dependentAttributionIncomplete`, #936) already covered for
+ * the "we don't know" case; this module is what lets the tool answer "we
+ * found some" instead, when it genuinely can.
+ *
+ * #1040 widens this to test-association too: this is the SAME mechanism
+ * that lets a C# test file in a nested namespace (`MediatR.Tests`) reach its
+ * subject's types (`MediatR`) with no `using` directive at all -- the exact
+ * shape Go's `sameDirectoryTestConvention` and Java's `samePackageTestConvention`
+ * exist to paper over for their own no-import test conventions. Rather than
+ * a THIRD, independent namespace notion for test-association specifically,
+ * `test-associations.ts` (and `get_files_context`) reuse
+ * `buildCSharpTypeReferenceIndex`/`resolveCSharpTypeReferenceDependents`
+ * directly, filtering the recovered dependents down to the test-file subset
+ * -- see those call sites for the measured MediatR corpus numbers.
  */
 
 import type { CodeChunk } from './types.js';
@@ -529,36 +538,59 @@ function resolveTier2NamespaceScopedDependents(
 }
 
 /**
- * Find C# files (any file, production or test) that reference one of
- * `targetFile`'s declared type names, either because the name is uniquely
- * declared project-wide (tier 1) or because namespace scoping + shadowing
- * unambiguously resolves an otherwise globally-ambiguous name back to
- * `targetFile` for that specific referencer (tier 2) -- see the module doc
- * for both rules. Excludes `targetFile` itself. Returns a sorted,
- * deduplicated list of filepaths -- empty when `targetFile` isn't a C# file,
- * declares no resolvable type, or genuinely has no textual referrers in
- * `chunks`.
- *
- * `targetFile` must be the exact `chunk.metadata.file` string used by
- * `targetFile`'s own chunks within `chunks` (not a separately-normalized
- * path) -- this function does no path normalization of its own and relies
- * on plain string equality throughout, mirroring
- * `swift-symbol-usage-signals.ts`'s same discipline.
- *
- * `chunks` should be the FULL project chunk set -- uniqueness (tier 1) and
- * namespace scoping (tier 2) are both project-wide properties, not scoped to
- * `targetFile` alone.
+ * Everything `resolveCSharpTypeReferenceDependents` needs to resolve any
+ * number of target files against ONE project-wide scan -- built once by
+ * `buildCSharpTypeReferenceIndex` and reused per target, so a caller
+ * resolving many target files (e.g. `test-associations.ts`'s per-file loop,
+ * #1040) doesn't re-scan the full chunk set for every one of them, the same
+ * "build the index once, resolve many" discipline
+ * `go-same-directory-tests.ts`/`java-same-package-tests.ts` already use for
+ * their own directory/package indexes.
  */
-export function findCSharpTypeReferenceDependents(
-  targetFile: string,
-  chunks: CodeChunk[],
-): string[] {
-  if (detectLanguage(targetFile) !== 'csharp') return [];
+export interface CSharpTypeReferenceIndex {
+  chunksByFile: Map<string, CodeChunk[]>;
+  namespaceByFile: Map<string, string | undefined>;
+  declarations: CSharpTypeDeclaration[];
+  defMap: Map<string, Set<string>>;
+}
 
+/**
+ * Build the project-wide index `resolveCSharpTypeReferenceDependents` needs
+ * (file->chunks, file->derived namespace, every type declaration, and the
+ * type-name->declaring-files map) from `chunks` once. `chunks` should be the
+ * FULL project chunk set -- uniqueness (tier 1) and namespace scoping (tier 2)
+ * are both project-wide properties, not scoped to any one target file.
+ */
+export function buildCSharpTypeReferenceIndex(chunks: CodeChunk[]): CSharpTypeReferenceIndex {
   const chunksByFile = groupCSharpChunksByFile(chunks);
   const namespaceByFile = buildCSharpNamespaceIndex(chunksByFile);
   const declarations = collectCSharpTypeDeclarations(chunks, namespaceByFile);
   const defMap = buildCSharpTypeOwnerMap(declarations);
+  return { chunksByFile, namespaceByFile, declarations, defMap };
+}
+
+/**
+ * Find C# files (any file, production or test) that reference one of
+ * `targetFile`'s declared type names against an already-built `index` (see
+ * `buildCSharpTypeReferenceIndex`), either because the name is uniquely
+ * declared project-wide (tier 1) or because namespace scoping + shadowing
+ * unambiguously resolves an otherwise globally-ambiguous name back to
+ * `targetFile` for that specific referencer (tier 2) -- see the module doc
+ * for both rules. Excludes `targetFile` itself. Returns a sorted,
+ * deduplicated list of filepaths -- empty when `targetFile` declares no
+ * resolvable type or genuinely has no textual referrers in the index.
+ *
+ * `targetFile` must be the exact `chunk.metadata.file` string used by
+ * `targetFile`'s own chunks within the chunks `index` was built from (not a
+ * separately-normalized path) -- this function does no path normalization of
+ * its own and relies on plain string equality throughout, mirroring
+ * `swift-symbol-usage-signals.ts`'s same discipline.
+ */
+export function resolveCSharpTypeReferenceDependents(
+  targetFile: string,
+  index: CSharpTypeReferenceIndex,
+): string[] {
+  const { chunksByFile, namespaceByFile, declarations, defMap } = index;
 
   const tier1 = resolveTier1UniqueDependents(targetFile, defMap, chunksByFile);
   const tier2 = resolveTier2NamespaceScopedDependents(
@@ -570,4 +602,20 @@ export function findCSharpTypeReferenceDependents(
   );
 
   return [...new Set([...tier1, ...tier2])].sort();
+}
+
+/**
+ * Single-target convenience wrapper around `buildCSharpTypeReferenceIndex` +
+ * `resolveCSharpTypeReferenceDependents`, for callers resolving just ONE
+ * target file (`get_dependents`'s file-level recovery, #930/#943). Callers
+ * resolving MANY target files against the same chunk set should build the
+ * index once themselves instead of calling this in a loop -- see
+ * `CSharpTypeReferenceIndex`'s doc comment.
+ */
+export function findCSharpTypeReferenceDependents(
+  targetFile: string,
+  chunks: CodeChunk[],
+): string[] {
+  if (detectLanguage(targetFile) !== 'csharp') return [];
+  return resolveCSharpTypeReferenceDependents(targetFile, buildCSharpTypeReferenceIndex(chunks));
 }

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -159,10 +159,19 @@ export {
   isTypeShapedIdentifier,
 } from './swift-symbol-usage-signals.js';
 
-// #930 (part 2): C#'s non-import type-reference dependents signal, used by
-// `get_dependents` (not test-association) -- see
-// csharp-type-reference-signals.ts's module doc.
-export { findCSharpTypeReferenceDependents } from './csharp-type-reference-signals.js';
+// #930 (part 2): C#'s non-import type-reference signal, originally built for
+// `get_dependents` and reused by test-association (#1040) -- see
+// csharp-type-reference-signals.ts's module doc. `buildCSharpTypeReferenceIndex`/
+// `resolveCSharpTypeReferenceDependents` let a caller resolving MANY target
+// files (e.g. `get_files_context`'s `findTestAssociations`) build the
+// project-wide index once and reuse it, instead of calling
+// `findCSharpTypeReferenceDependents` (which rebuilds it) per file.
+export {
+  findCSharpTypeReferenceDependents,
+  buildCSharpTypeReferenceIndex,
+  resolveCSharpTypeReferenceDependents,
+} from './csharp-type-reference-signals.js';
+export type { CSharpTypeReferenceIndex } from './csharp-type-reference-signals.js';
 
 // =============================================================================
 // GRAPH TRAVERSAL (generic bounded BFS — domain graphs build on this)

--- a/packages/parser/src/test-associations.test.ts
+++ b/packages/parser/src/test-associations.test.ts
@@ -266,6 +266,118 @@ describe('findTestAssociationsFromChunks', () => {
     });
   });
 
+  describe('C# enclosing-namespace test convention (#1040)', () => {
+    // A real C# type declaration chunk, optionally namespaced (a `namespace
+    // X;` line prefixed into content, mirroring how a real file's derived
+    // namespace is recovered from chunk content -- see
+    // `csharp-type-reference-signals.ts`'s `deriveCSharpNamespace`).
+    function csharpDecl(file: string, symbolName: string, namespace?: string): CodeChunk {
+      const nsPrefix = namespace ? `namespace ${namespace};\n\n` : '';
+      return {
+        content: `${nsPrefix}public class ${symbolName} { }`,
+        metadata: {
+          file,
+          startLine: 1,
+          endLine: 10,
+          type: 'class',
+          language: 'csharp',
+          symbolName,
+          symbolType: 'class',
+        },
+      };
+    }
+
+    // A C# usage chunk (e.g. a test method) that references `references` by
+    // bare name, with no `using` import naming the referenced type at all --
+    // the exact MediatR/#1040 repro shape.
+    function csharpUsage(file: string, references: string[], namespace?: string): CodeChunk {
+      const nsPrefix = namespace ? `namespace ${namespace};\n\n` : '';
+      return {
+        content: `${nsPrefix}${references.map(name => `var x = new ${name}();`).join('\n')}`,
+        metadata: {
+          file,
+          startLine: 1,
+          endLine: 10,
+          type: 'function',
+          language: 'csharp',
+          symbolName: 'TestMethod',
+          symbolType: 'method',
+        },
+      };
+    }
+
+    it('associates a C# test file with its subject via enclosing-namespace access, with NO import and NO basename relationship (MediatR repro)', () => {
+      // The exact #1040 shape: `IRequestHandler.cs` declares `IRequestHandler`
+      // in namespace `MediatR`; `PipelineTests.cs` sits in the nested
+      // `MediatR.Tests` namespace and references `IRequestHandler` completely
+      // unqualified, with no `using MediatR;` anywhere -- legal because C#
+      // namespace lookup walks outward through enclosing namespaces. Neither
+      // file's basename bears any relation to the other, so Go/Java's
+      // basename-pairing tier-1 convention would never have caught this even
+      // if C# opted into it.
+      const chunks: CodeChunk[] = [
+        csharpDecl('src/MediatR/IRequestHandler.cs', 'IRequestHandler', 'MediatR'),
+        csharpUsage('test/MediatR.Tests/PipelineTests.cs', ['IRequestHandler'], 'MediatR.Tests'),
+      ];
+
+      const result = findTestAssociationsFromChunks(['src/MediatR/IRequestHandler.cs'], chunks);
+
+      expect(result.get('src/MediatR/IRequestHandler.cs')).toEqual([
+        'test/MediatR.Tests/PipelineTests.cs',
+      ]);
+    });
+
+    it('does not fabricate an association for a globally ambiguous type name with a genuine same-depth clash (never guesses)', () => {
+      // Two DIFFERENT files declare the SAME type name in the SAME namespace
+      // depth -- a genuine tie tier 2's shadowing rule refuses to guess at,
+      // mirroring `csharp-type-reference-signals.test.ts`'s identical tier-2
+      // test. The precision bar here matters: #1040 must not trade a false
+      // "0 associations" for a false PAIRING.
+      const chunks: CodeChunk[] = [
+        csharpDecl('src/Foo/Widget.cs', 'Widget', 'App.Foo'),
+        csharpDecl('src/Bar/Widget.cs', 'Widget', 'App.Bar'),
+        csharpUsage('test/AppTests.cs', ['Widget'], 'App'),
+      ];
+
+      const result = findTestAssociationsFromChunks(['src/Foo/Widget.cs'], chunks);
+
+      expect(result.has('src/Foo/Widget.cs')).toBe(false);
+    });
+
+    it('does not apply the enclosing-namespace convention to a non-C# language', () => {
+      // A same-shaped nested-namespace/no-import reference in a language
+      // that does NOT set `enclosingNamespaceAccess` must not get this
+      // treatment -- only real import-based matching (or that language's own
+      // convention) applies.
+      const chunks: CodeChunk[] = [
+        makeChunk('src/widget.ts'),
+        makeChunk('test/widget.test.ts'), // no import -- would only match via C#'s convention
+      ];
+
+      const result = findTestAssociationsFromChunks(['src/widget.ts'], chunks);
+
+      expect(result.has('src/widget.ts')).toBe(false);
+    });
+
+    it('composes with a real import-based match without duplicating the test file', () => {
+      const chunks: CodeChunk[] = [
+        csharpDecl('src/MediatR/IRequestHandler.cs', 'IRequestHandler', 'MediatR'),
+        csharpUsage('test/MediatR.Tests/PipelineTests.cs', ['IRequestHandler'], 'MediatR.Tests'),
+        makeChunk('test/MediatR.Tests/OtherTests.cs', ['src/MediatR/IRequestHandler']),
+      ];
+
+      const result = findTestAssociationsFromChunks(['src/MediatR/IRequestHandler.cs'], chunks);
+
+      expect(result.get('src/MediatR/IRequestHandler.cs')).toHaveLength(2);
+      expect(result.get('src/MediatR/IRequestHandler.cs')).toContain(
+        'test/MediatR.Tests/PipelineTests.cs',
+      );
+      expect(result.get('src/MediatR/IRequestHandler.cs')).toContain(
+        'test/MediatR.Tests/OtherTests.cs',
+      );
+    });
+  });
+
   describe('direct-importer ranking (#929)', () => {
     // The real hono repro: `src/utils/jwt/jwt.test.ts` imports `./jws`
     // directly (an exact, unambiguous reference), but scan order alone

--- a/packages/parser/src/test-associations.ts
+++ b/packages/parser/src/test-associations.ts
@@ -13,6 +13,7 @@ import {
   detectLanguage,
   hasSameDirectoryTestConvention,
   hasSamePackageTestConvention,
+  hasEnclosingNamespaceAccess,
 } from './ast/languages/registry.js';
 import {
   buildGoTestDirIndex,
@@ -27,6 +28,11 @@ import {
   type JavaTestCandidate,
   type JavaTestDirIndex,
 } from './java-same-package-tests.js';
+import {
+  buildCSharpTypeReferenceIndex,
+  resolveCSharpTypeReferenceDependents,
+  type CSharpTypeReferenceIndex,
+} from './csharp-type-reference-signals.js';
 import type { CodeChunk } from './types.js';
 
 /**
@@ -47,6 +53,16 @@ function hasGoSameDirectoryConvention(filepath: string): boolean {
 function hasJavaSamePackageConvention(filepath: string): boolean {
   const language = detectLanguage(filepath);
   return language !== null && hasSamePackageTestConvention(language);
+}
+
+/**
+ * True when `filepath`'s language sets `enclosingNamespaceAccess` (C#
+ * today, #930/#1040) -- mirrors `hasGoSameDirectoryConvention` /
+ * `hasJavaSamePackageConvention` above.
+ */
+function hasCSharpEnclosingNamespaceConvention(filepath: string): boolean {
+  const language = detectLanguage(filepath);
+  return language !== null && hasEnclosingNamespaceAccess(language);
 }
 
 /**
@@ -151,6 +167,33 @@ function collectJavaBasenameTests(
 }
 
 /**
+ * #1040: C#'s enclosing-namespace test convention has no basename pairing to
+ * fall back on (unlike Go/Java, a C# test class's file name routinely bears
+ * no relation to the specific type(s) it covers -- e.g. MediatR's
+ * `PipelineTests.cs` tests `IPipelineBehavior`/`IRequestHandler`, declared in
+ * files with neither name). Instead, this reuses
+ * `resolveCSharpTypeReferenceDependents` -- the SAME namespace-scoped
+ * signal `get_dependents`'s file-level recovery already relies on (#930,
+ * `csharp-type-reference-signals.ts`) -- filtered down to the test-file
+ * subset of `filepath`'s recovered dependents. Both of that signal's tiers
+ * already refuse to guess on ambiguity (global-uniqueness for tier 1,
+ * namespace-enclosure + shadowing for tier 2), so this is folded directly
+ * into the returned association set here, the same "real recovery, not just
+ * an honesty label" treatment Go/Java's own tier 1 gets above -- unlike
+ * `annotate-cmd.ts`'s OWN, separate, last-resort-only use of this same
+ * function (kept distinct there because it only fires when this module's
+ * import-based `tests` came back empty).
+ */
+function collectCSharpNamespaceTests(
+  filepath: string,
+  csharpIndex: CSharpTypeReferenceIndex,
+): string[] {
+  return hasCSharpEnclosingNamespaceConvention(filepath)
+    ? resolveCSharpTypeReferenceDependents(filepath, csharpIndex).filter(isTestFile)
+    : [];
+}
+
+/**
  * #902: Go's dominant same-package test convention emits no import statement
  * at all, so `collectImportMatchedTests` is structurally blind to it. Builds
  * a directory index of same-directory-test-convention (Go) test chunks --
@@ -220,6 +263,11 @@ export function findTestAssociationsFromChunks(
   // fallback, see annotate-cmd.ts.
   const goTestDirIndex = buildGoTestDirIndexFrom(testChunks, normalize);
   const javaTestDirIndex = buildJavaTestDirIndexFrom(testChunks, normalize);
+  // #1040: C#'s enclosing-namespace test-association index, built once
+  // (project-wide, not just `testChunks` -- tier 1's global-uniqueness gate
+  // needs every declaration) and reused for every target file below, same
+  // "build once" discipline as the two indexes above.
+  const csharpIndex = buildCSharpTypeReferenceIndex(chunks);
 
   for (const filepath of filepaths) {
     const normalizedTarget = normalize(filepath);
@@ -227,6 +275,7 @@ export function findTestAssociationsFromChunks(
       ...collectImportMatchedTests(testChunks, normalizedTarget, normalize),
       ...collectGoBasenameTests(filepath, normalizedTarget, goTestDirIndex),
       ...collectJavaBasenameTests(filepath, normalizedTarget, javaTestDirIndex),
+      ...collectCSharpNamespaceTests(filepath, csharpIndex),
     ]);
 
     if (testFiles.size > 0) {


### PR DESCRIPTION
## Summary

Fixes #1040. C# test-association resolution measured **0/160 files** on the MediatR corpus despite it shipping a real, substantial `MediatR.Tests` project. Root cause: `test-associations.ts` wires in same-convention no-import test recovery for Go (`hasSameDirectoryTestConvention`) and Java (`hasSamePackageTestConvention`), but had no case for C#'s enclosing-namespace access — a C# test file in a nested namespace (`MediatR.Tests`) sees its subject's parent namespace (`MediatR`) with no `using` directive at all, so import-based matching is structurally blind to it, and there was no basename-pairing fallback (unlike Go/Java) since a C# test class's filename routinely bears no relation to the type(s) it covers (e.g. `PipelineTests.cs` tests `IRequestHandler`/`IPipelineBehavior`, declared in differently-named files).

This exact mechanism (real lexical namespace scoping with shadowing, built across #930/#936/#937/#938/#943/#971) already existed in `csharp-type-reference-signals.ts` for `get_dependents`'s file-level recovery. Per the issue's steer, this reuses it rather than hand-rolling a second namespace notion:

- Extracted `buildCSharpTypeReferenceIndex` + `resolveCSharpTypeReferenceDependents` out of `findCSharpTypeReferenceDependents` (now a thin wrapper, behavior-identical for existing `get_dependents` callers) so a caller resolving MANY target files builds the project-wide index once instead of per-file — the same "build once, resolve many" discipline Go/Java's own directory/package indexes already use.
- Wired this into `test-associations.ts`'s `findTestAssociationsFromChunks` (`collectCSharpNamespaceTests`), folded directly into the returned association set — the same "real recovery, not just an honesty label" treatment Go/Java's tier-1 basename pairing gets, per the issue's explicit comparison to those two functions.
- Wired the identical tier into `get_files_context`'s own separate `findTestAssociations` implementation (`collectCSharpNamespaceTestFiles`), since that MCP handler doesn't call the parser's shared function — it has its own reimplementation operating on `SearchResult[]` from the SQLite scan, canonicalizing paths the same way its Go/Java tiers already do.

## Before/after (MediatR, `jbogard/MediatR`, all 160 indexed files, not a sample)

```
Before: Total files: 160 | Files with >=1 test association: 0   | Total associations: 0
After:  Total files: 160 | Files with >=1 test association: 60  | Total associations: 269
```

Measured via both the parser-level `findTestAssociationsFromChunks` and the MCP-handler-level `findTestAssociations` directly — identical numbers on both paths. Also verified via the E2E harness itself (`npm run test:e2e:csharp -w packages/cli`, 100-file sample): 0 → ~169-175 associations, 0 → ~36-37/100 files.

## Precision reasoning (why this isn't fabricated)

- Reused signal, not new: `resolveCSharpTypeReferenceDependents` is the same two-tier mechanism (tier 1: type name unique project-wide + identifier-boundary text match; tier 2: namespace-enclosure + shadowing for ambiguous names, refusing to guess on a genuine same-depth tie) already shipped and verified against serilog/serilog with zero false positives project-wide (checked via `grep -rlw` across the whole tree). I did not weaken either tier's "never guess" discipline.
- Spot-checked several MediatR pairs by hand (e.g. `Mediator.cs` → `ServiceFactoryTests.cs` via `new Mediator(serviceProvider)`; `IRequest.cs` → `PipeLineMultiCallToConstructorTest.cs` via `IRequest<TResponse>`) — all genuine references, not coincidental name collisions.
- Added a conservative-precision regression test in `test-associations.test.ts`: two files declaring the identical type name at the same namespace depth (`App.Foo.Widget` / `App.Bar.Widget`, both referenced from `App.AppTests`) correctly resolve to **no** association rather than guessing — this is the failure mode the task asked me to guard against.
- Did not widen to any other language. `enclosingNamespaceAccess` is a C#-only flag (verified: `hasEnclosingNamespaceAccess` only returns true for `csharp` in the registry); Kotlin/Swift stay in `KNOWN_ZERO_TESTASSOC_LANGUAGES` untouched, per #928's precedent against language-blind fuzzy matching.

## Decoy-test check (per this repo's #1002 lesson)

Verified the new E2E floor is not a decoy by actually reverting all 6 changed source files to `HEAD~1` (parser + get_files_context + their re-exports), rebuilding the whole monorepo, and re-running `test:e2e:csharp`:

```
FAIL  should resolve real test associations ... — expected 0 to be greater than or equal to 90
```//
Confirmed the ONLY failure was the test-association floor (indexing, dependency edges, search, complexity all still passed unmodified) — restored the fix, rebuilt, and the same run went green (18/18).

## E2E floor (per #1053)

`KNOWN_ZERO_TESTASSOC_LANGUAGES` no longer includes `csharp`. MediatR's `expectedMinTestAssociations` is set to **90** — ~51% of the measured 175 (100-file sample) — tight enough to catch roughly a 50%+ regression rather than only a near-total collapse.

## Known follow-up (not fixed here, flagged in code)

`annotate-cmd.ts`'s own `computeCSharpTypeReferenceTestFallback` (a fifth, last-resort tier that fires only when `tests` is empty) is now **provably always `[]`** for C#, because `tests` itself already contains the identical `findCSharpTypeReferenceDependents(...).filter(isTestFile)` computation via this fix. One existing integration test in `annotate-cmd.test.ts` exercised this fallback end-to-end and now correctly resolves via the primary "associated tests" path instead — updated its expectation accordingly. Removing the now-dead `csharpTypeReferenceTests` plumbing (~13 call sites through `AnnotationData`/`formatTests`/the tests-only path) is a separate, larger cleanup I deliberately left out of this PR's scope; documented in a code comment at the fallback's definition.

## Dogfooding

- Ran `lien index` + direct `findTestAssociationsFromChunks`/`findTestAssociations` calls against a real shallow clone of MediatR (before and after).
- Ran the full `test:e2e:csharp` harness (real clone, real index, real MCP-shaped chunk scan) — 18/18 green.
- Ran the full `test/e2e/real-projects.test.ts` suite across all 11 real-project corpora (198/198 green) to confirm no cross-language regression.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint` (0 errors; pre-existing warnings unrelated to this change)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` (all workspaces green)
- [x] `node packages/cli/dist/index.js delta` (exit 0)
- [x] `npm run test:e2e:csharp -w packages/cli` (18/18)
- [x] Full `test/e2e/real-projects.test.ts` (198/198)
- [x] Decoy-test verification: reverted fix, confirmed the new floor fails; restored fix, confirmed green

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 3 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 1 | +0 |
| ⏱️ time to understand | 1 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR fixes C# test-association resolution by reusing the existing enclosing-namespace type-reference signal in two test-association paths (`findTestAssociationsFromChunks` and `get_files_context`'s `findTestAssociations`). It extracts a build-once index API from `csharp-type-reference-signals.ts` and wires it in with the same precision safeguards (global uniqueness + namespace shadowing, no guessing on ambiguity). The change is well-isolated to C#, does not alter existing Go/Java behavior, and includes regression tests for the key precision case (same-depth name clash).
>
> - Extracted `buildCSharpTypeReferenceIndex`/`resolveCSharpTypeReferenceDependents` so multi-target callers build the project-wide index once.
> - Wired C# enclosing-namespace test recovery into `findTestAssociationsFromChunks` and `get_files_context`'s `findTestAssociations`.
> - Updated the C# fallback in `annotate-cmd.ts` to document that it is now unreachable, without removing the dead-code plumbing in this PR.
> - Raised MediatR's E2E `expectedMinTestAssociations` floor from 0 to 90 and removed `csharp` from `KNOWN_ZERO_TESTASSOC_LANGUAGES`.

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 39f5c5a. Updates automatically on new commits.</sup>
<!-- /lien-stats -->