### PR TITLE
fix(parser): resolve Go dependency edges for a module's own root package (#1039)

### DIFF
--- a/.changeset/fix-1039-go-root-package.md
+++ b/.changeset/fix-1039-go-root-package.md
@@ -1,0 +1,29 @@
+---
+"@liendev/parser": patch
+---
+
+Fix Go dependency-edge resolution for a module's own ROOT package. Any file
+outside the root package that genuinely uses it (idiomatic Go — there's no
+relative-import syntax) can only reference it via a bare self-import of the
+module's own full path (`import "github.com/go-chi/chi/v5"`). `resolveGoModuleImport`
+deliberately leaves that exact-match case unresolved (correct for #867's
+narrower test-association scope), so nothing in the general dependents
+pipeline ever named a specific root-package file — every root file reported
+zero dependents despite being heavily imported by every subpackage. Measured
+on go-chi/chi: `context.go` (exports `RouteContext`) showed 0 dependents
+despite real `middleware/*.go` callers.
+
+Adds `go-root-package-signals.ts`, a project-wide export-lookup recovery:
+which root file actually exports the symbol a bare-self-importing file's own
+call sites reference, gated by export uniqueness and a distinctiveness check
+(rejects single-segment, common names like `Use`/`Get`/`Post`). Deliberately
+NOT a change to `resolveGoModuleImport`/`matchesFile` themselves — crediting
+the whole root-package directory the way a subpackage import already does
+would fabricate a false hub (the #1008/#1056 shape), since the module root is
+frequently the repository root itself alongside dozens of unrelated files.
+
+Verified against go-chi/chi (86 files): dependency edges 11 → 64 (94.2% → 88.4%
+orphan rate), `context.go` 0 → 11 real dependents. Confirmed no false hub:
+`context.go` and `chi.go` recover disjoint dependent lists. No regression to
+Go same-package test-association (#867) or any of the other 10 corpora in the
+E2E suite.

--- a/packages/cli/test/e2e/real-projects.test.ts
+++ b/packages/cli/test/e2e/real-projects.test.ts
@@ -281,14 +281,21 @@ const TEST_PROJECTS: ProjectConfig[] = [
     expectedMinFiles: 5,
     expectedMinChunks: 20,
     sampleSearchQuery: 'http router middleware',
-    // measured ~11 edges / 94% orphan rate (2026-08) -- #1029/W3 chased this:
-    // it is a REAL GAP, not (only) leaf-heaviness. Filed as #1039:
-    // `resolveGoModuleImport` never resolves a bare root-module self-import
+    // #1039 FIXED: was ~11 edges / 94.2% orphan rate (2026-08) -- #1029/W3
+    // chased this to a verdict: a REAL GAP, not (only) leaf-heaviness.
+    // `resolveGoModuleImport` never resolved a bare root-module self-import
     // (e.g. `import "github.com/go-chi/chi/v5"` from middleware/*.go,
-    // referencing the repo-root package with no trailing path segment) --
-    // 35 such imports exist in this corpus alone and none of them resolve.
-    // Floor stays a collapse detector either way: not raised pending that fix.
-    expectedMinDependencyEdges: 5,
+    // referencing the repo-root package with no trailing path segment).
+    // Fixed via `go-root-package-signals.ts`'s export-lookup recovery
+    // (deliberately NOT a change to `resolveGoModuleImport`/`matchesFile`
+    // themselves -- crediting the whole root-package directory would have
+    // fabricated a false hub, the #1008/#1056 shape). Now measured ~64 edges
+    // / 88.4% orphan rate (2026-08) -- `context.go` alone gained 11 real
+    // dependents (5 real `middleware/*.go` callers of `RouteContext`, 3 of
+    // their own `_test.go` files, 3 `_examples/*/main.go` files). Floor set
+    // to 35 (~55% of measured 64) per #1053 -- tight enough to catch roughly
+    // a 45%+ regression, not just a near-total collapse.
+    expectedMinDependencyEdges: 35,
     expectedMinComplexityViolations: 15, // measured ~72 (2026-08)
     expectedMinTestAssociations: 3, // measured ~20 across 86 files (2026-08)
     expectedMinChunksWithExports: 100, // measured ~662/765 chunks (2026-08)

--- a/packages/parser/src/dependency-analyzer.test.ts
+++ b/packages/parser/src/dependency-analyzer.test.ts
@@ -1,11 +1,16 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
 import {
   analyzeDependencies,
   findReExportedSymbolsForFile,
   chunkImportsFrom,
+  findDependents,
   COMPLEXITY_THRESHOLDS,
 } from './dependency-analyzer.js';
 import { chunkByAST } from './ast/chunker.js';
+import { clearGoModuleCache } from './go-module.js';
 import type { CodeChunk, ChunkMetadata } from './types.js';
 
 describe('analyzeDependencies', () => {
@@ -1157,5 +1162,169 @@ describe('bare crate-relative `use` edges end-to-end (#1028 regression)', () => 
         d => d.filepath,
       ),
     ).toEqual(['Controller.php']);
+  });
+});
+
+describe('findDependents (Go root-package export-lookup recovery, #1039)', () => {
+  const MODULE_PREFIX = 'github.com/go-chi/chi/v5';
+  let workspaceRoot: string;
+
+  function noopLog(): void {
+    // Intentionally empty.
+  }
+
+  function createGoChunk(
+    file: string,
+    opts: { imports?: string[]; exports?: string[]; callSites?: string[] } = {},
+  ): CodeChunk {
+    return {
+      content: opts.callSites?.map(s => `${s}()`).join('\n') ?? '',
+      metadata: {
+        file,
+        startLine: 1,
+        endLine: 10,
+        type: 'function',
+        language: 'go',
+        imports: opts.imports,
+        exports: opts.exports,
+        callSites: opts.callSites?.map((symbol, i) => ({ symbol, line: i + 1 })),
+      } as ChunkMetadata,
+    };
+  }
+
+  beforeEach(async () => {
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-dep-analyzer-go-'));
+    await fs.writeFile(path.join(workspaceRoot, 'go.mod'), `module ${MODULE_PREFIX}\n\ngo 1.21\n`);
+  });
+
+  afterEach(async () => {
+    clearGoModuleCache();
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('recovers real dependents for a root-package file via export lookup when the import graph found none (the #1039 chi repro)', () => {
+    const chunks: CodeChunk[] = [
+      createGoChunk('context.go', { exports: ['RouteContext', 'NewRouteContext'] }),
+      createGoChunk('middleware/clean_path.go', {
+        imports: [MODULE_PREFIX],
+        callSites: ['RouteContext'],
+      }),
+      createGoChunk('middleware/get_head.go', {
+        imports: [MODULE_PREFIX],
+        callSites: ['RouteContext', 'NewRouteContext'],
+      }),
+    ];
+
+    const result = findDependents(chunks, 'context.go', noopLog, workspaceRoot);
+
+    expect(result.dependents.map(d => d.filepath).sort()).toEqual([
+      'middleware/clean_path.go',
+      'middleware/get_head.go',
+    ]);
+    expect(result.dependents.every(d => d.confidence === 'inferred')).toBe(true);
+    expect(result.dependentAttributionPartial).toBe(true);
+  });
+
+  it('does NOT fabricate a false hub: two unrelated root files get disjoint dependents (the #1056 failure shape, checked explicitly)', () => {
+    const chunks: CodeChunk[] = [
+      createGoChunk('context.go', { exports: ['RouteContext'] }),
+      createGoChunk('chi.go', { exports: ['NewRouter'] }),
+      createGoChunk('middleware/clean_path.go', {
+        imports: [MODULE_PREFIX],
+        callSites: ['RouteContext'],
+      }),
+      createGoChunk('middleware/profiler.go', {
+        imports: [MODULE_PREFIX],
+        callSites: ['NewRouter'],
+      }),
+    ];
+
+    const contextDeps = findDependents(chunks, 'context.go', noopLog, workspaceRoot).dependents.map(
+      d => d.filepath,
+    );
+    const chiDeps = findDependents(chunks, 'chi.go', noopLog, workspaceRoot).dependents.map(
+      d => d.filepath,
+    );
+
+    expect(contextDeps).toEqual(['middleware/clean_path.go']);
+    expect(chiDeps).toEqual(['middleware/profiler.go']);
+    expect(contextDeps).not.toEqual(chiDeps);
+  });
+
+  it("never guesses when a root export name collides across two root files (chi's own ServeHTTP, declared by both chain.go and mux.go)", () => {
+    const chunks: CodeChunk[] = [
+      createGoChunk('chain.go', { exports: ['ServeHTTP'] }),
+      createGoChunk('mux.go', { exports: ['ServeHTTP'] }),
+      createGoChunk('middleware/whatever.go', {
+        imports: [MODULE_PREFIX],
+        callSites: ['ServeHTTP'],
+      }),
+    ];
+
+    expect(findDependents(chunks, 'chain.go', noopLog, workspaceRoot).dependents).toEqual([]);
+    expect(findDependents(chunks, 'mux.go', noopLog, workspaceRoot).dependents).toEqual([]);
+  });
+
+  it('does not recover anything for a single-segment, non-distinctive export name (the Use/Get/Post false-positive risk)', () => {
+    const chunks: CodeChunk[] = [
+      createGoChunk('mux.go', { exports: ['Use', 'Get', 'Post'] }),
+      createGoChunk('unrelated/builder.go', {
+        imports: [MODULE_PREFIX],
+        callSites: ['Use'],
+      }),
+    ];
+
+    expect(findDependents(chunks, 'mux.go', noopLog, workspaceRoot).dependents).toEqual([]);
+  });
+
+  it('does not run the fallback when the import graph already found real dependents', () => {
+    const chunks: CodeChunk[] = [
+      createGoChunk('context.go', { exports: ['RouteContext'] }),
+      // A real, direct import edge already resolves this one.
+      createGoChunk('direct.go', { imports: ['context'] }),
+      createGoChunk('middleware/clean_path.go', {
+        imports: [MODULE_PREFIX],
+        callSites: ['RouteContext'],
+      }),
+    ];
+
+    const result = findDependents(chunks, 'context.go', noopLog, workspaceRoot);
+    expect(result.dependentAttributionPartial).toBeUndefined();
+  });
+
+  it('does not run the fallback for a SYMBOL-scoped query', () => {
+    const chunks: CodeChunk[] = [
+      createGoChunk('context.go', { exports: ['RouteContext'] }),
+      createGoChunk('middleware/clean_path.go', {
+        imports: [MODULE_PREFIX],
+        callSites: ['RouteContext'],
+      }),
+    ];
+
+    const result = findDependents(chunks, 'context.go', noopLog, workspaceRoot, 'RouteContext');
+    expect(result.dependentAttributionPartial).toBeUndefined();
+  });
+
+  it('does not run the fallback for a non-Go file', () => {
+    const chunks: CodeChunk[] = [
+      {
+        content: '',
+        metadata: {
+          file: 'src/context.ts',
+          startLine: 1,
+          endLine: 10,
+          type: 'function',
+          language: 'typescript',
+          exports: ['RouteContext'],
+        },
+      },
+      createGoChunk('middleware/clean_path.go', {
+        imports: [MODULE_PREFIX],
+        callSites: ['RouteContext'],
+      }),
+    ];
+
+    const result = findDependents(chunks, 'src/context.ts', noopLog, workspaceRoot);
+    expect(result.dependentAttributionPartial).toBeUndefined();
   });
 });

--- a/packages/parser/src/dependency-analyzer.ts
+++ b/packages/parser/src/dependency-analyzer.ts
@@ -15,6 +15,7 @@ import {
   hasDependentAttributionBlindSpot,
 } from './ast/languages/registry.js';
 import { findCSharpTypeReferenceDependents } from './csharp-type-reference-signals.js';
+import { findGoRootPackageDependents } from './go-root-package-signals.js';
 
 /**
  * Risk level thresholds for dependent count.
@@ -861,15 +862,19 @@ export interface DependentInfo {
   /** Depth at which this dependent was first discovered (1 = direct). */
   hops?: number;
   /**
-   * Present (`'inferred'`) only for a dependent recovered by the C#
-   * type-reference-matching fallback (#930's remaining half -- see
-   * `findCSharpTypeReferenceDependents`'s module doc) instead of a real
-   * import edge: a word-boundary text match against a uniquely-declared
-   * type name, not an import-verified association. Absent for every
-   * ordinary, import-verified dependent (the default, confident tier) -- a
-   * caller that needs to distinguish "verified" from "text-matched, lower
-   * confidence" should filter on this field rather than assuming every
-   * entry in `dependents` came from the import graph.
+   * Present (`'inferred'`) only for a dependent recovered by a non-import
+   * fallback instead of a real import edge -- absent for every ordinary,
+   * import-verified dependent (the default, confident tier). A caller that
+   * needs to distinguish "verified" from "recovered, lower confidence"
+   * should filter on this field rather than assuming every entry in
+   * `dependents` came from the import graph. Two such fallbacks exist today:
+   * - C#'s type-reference-matching fallback (#930's remaining half -- see
+   *   `findCSharpTypeReferenceDependents`'s module doc): a word-boundary text
+   *   match against a uniquely-declared type name.
+   * - Go's root-package export-lookup fallback (#1039 -- see
+   *   `findGoRootPackageDependents`'s module doc): a bare module-root
+   *   self-import plus a matching call-site symbol, resolved to the specific
+   *   root file that exports it.
    */
   confidence?: 'inferred';
 }
@@ -1565,14 +1570,23 @@ function resolveDependents<T extends CodeChunk>(args: {
     ctx.log,
     reExporterPaths,
   );
-  const dependentAttributionPartial = enrichWithCSharpTypeReferenceDependents(
-    ctx,
-    filepath,
-    normalizedTarget,
-    symbol,
-    targetIndexed,
-    dependents,
-  );
+  const dependentAttributionPartial =
+    enrichWithCSharpTypeReferenceDependents(
+      ctx,
+      filepath,
+      normalizedTarget,
+      symbol,
+      targetIndexed,
+      dependents,
+    ) ??
+    enrichWithGoRootPackageDependents(
+      ctx,
+      filepath,
+      normalizedTarget,
+      symbol,
+      targetIndexed,
+      dependents,
+    );
   stampHopsAndSort(dependents, hopsByFile);
 
   return {
@@ -1793,6 +1807,63 @@ function enrichWithCSharpTypeReferenceDependents<T extends CodeChunk>(
   ctx.log(
     `Recovered ${inferredFiles.length} dependent(s) for ${filepath} via C# type-reference ` +
       `matching (inferred from a uniquely-declared type name, not import-verified — #930)`,
+  );
+  return true;
+}
+
+/**
+ * #1039: recover REAL dependents for a Go module's ROOT-package file when the
+ * import graph found none, because a Go file outside the root package that
+ * genuinely uses it can only ever spell that reference as a bare self-import
+ * of the module's own full path (`import "github.com/go-chi/chi/v5"`) --
+ * `resolveGoModuleImport` (`go-module.ts`) deliberately leaves that case
+ * unresolved (#867's own scope), so nothing in the import graph ever names a
+ * specific root-package file. See `go-root-package-signals.ts`'s module doc
+ * for the full mechanism (export lookup keyed off a bare-self-importing
+ * file's own call sites, never "credit the whole root directory" -- the
+ * #1008/#1056 false-hub shape this is deliberately built to avoid).
+ *
+ * Mirrors `enrichWithCSharpTypeReferenceDependents` immediately above in
+ * every structural respect: file-level only (no `symbol`), only attempted
+ * when the import graph found LITERALLY ZERO dependents, only for a
+ * root-level Go file (`findGoRootPackageDependents` itself also checks this,
+ * but checking here too avoids the corpus-wide index rebuild for every
+ * non-Go or non-root query), and recovered entries are tagged
+ * `confidence: 'inferred'` -- not joined against `chunksByFile` for
+ * complexity-metrics purposes, same reasoning as the C# recovery.
+ */
+function enrichWithGoRootPackageDependents<T extends CodeChunk>(
+  ctx: ScanContext<T>,
+  filepath: string,
+  normalizedTarget: string,
+  symbol: string | undefined,
+  targetIndexed: boolean,
+  dependents: DependentInfo[],
+): true | undefined {
+  if (symbol || dependents.length !== 0 || !targetIndexed) return undefined;
+  if (detectLanguage(filepath) !== 'go') return undefined;
+
+  const targetChunks = ctx.allChunksByFile.get(normalizedTarget) ?? [];
+  const targetRawFile = targetChunks[0]?.metadata.file;
+  if (!targetRawFile) return undefined;
+
+  const allChunks = Array.from(ctx.allChunksByFile.values()).flat();
+  const inferredFiles = findGoRootPackageDependents(targetRawFile, allChunks, ctx.workspaceRoot);
+  if (inferredFiles.length === 0) return undefined;
+
+  for (const rawFile of inferredFiles) {
+    const canonicalFile = getCanonicalPath(rawFile, ctx.workspaceRoot);
+    dependents.push({
+      filepath: canonicalFile,
+      isTestFile: isTestFile(canonicalFile),
+      confidence: 'inferred',
+    });
+  }
+
+  ctx.log(
+    `Recovered ${inferredFiles.length} dependent(s) for ${filepath} via Go root-package export ` +
+      `lookup (inferred from a bare module-root self-import + a matching call site, not a ` +
+      `direct import edge — #1039)`,
   );
   return true;
 }

--- a/packages/parser/src/go-module.ts
+++ b/packages/parser/src/go-module.ts
@@ -70,9 +70,22 @@ export function resolveGoModulePrefix(workspaceRoot: string): string | undefined
  * the specifier doesn't start with `<modulePrefix>/` — imports of other
  * modules (real external dependencies) and non-Go-module projects see zero
  * behavior change. Same-package imports (a bare import equal to the module
- * prefix itself, with no further path segment) are left unchanged too: Go's
- * own same-package test convention needs no import statement at all, so this
- * case doesn't arise for the cross-package test-association gap #867 targets.
+ * prefix itself, with no further path segment — a ROOT-package self-import,
+ * e.g. a subpackage importing `github.com/gin-gonic/gin` itself) are left
+ * unchanged too, deliberately and permanently: Go's own same-package test
+ * convention needs no import statement at all, so this case doesn't arise for
+ * the cross-package test-association gap #867 targets, and stays a no-op
+ * here even after #1039 gave the general dependents pipeline a real path to
+ * resolve it — see `go-root-package-signals.ts`'s module doc for why that fix
+ * is a separate, narrowly-gated, export-lookup-based recovery signal
+ * (`findGoRootPackageDependents`, wired into `dependency-analyzer.ts`)
+ * instead of a change here: making THIS function (or the generic
+ * `resolveManifestRoot`/`matchesFile` pipeline it feeds) resolve a bare
+ * self-import to "the whole root-package directory" would credit every
+ * subpackage file that merely imports its own module as a dependent of EVERY
+ * root file, regardless of which symbol it actually uses — a false hub, and
+ * it would also apply unconditionally to the #867 test-association path this
+ * function was built for, which has no use for it at all.
  *
  * @param specifier - The raw Go import path.
  * @param modulePrefix - The project's `go.mod` `module` value, or `undefined`.

--- a/packages/parser/src/go-root-package-signals.test.ts
+++ b/packages/parser/src/go-root-package-signals.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import {
+  findGoRootPackageDependents,
+  buildGoRootPackageIndex,
+  resolveGoRootPackageDependents,
+} from './go-root-package-signals.js';
+import { clearGoModuleCache } from './go-module.js';
+import type { CodeChunk } from './types.js';
+
+const MODULE_PREFIX = 'github.com/go-chi/chi/v5';
+
+interface ChunkOptions {
+  file: string;
+  exports?: string[];
+  imports?: string[];
+  callSites?: string[];
+}
+
+function makeChunk(opts: ChunkOptions): CodeChunk {
+  return {
+    content: '',
+    metadata: {
+      file: opts.file,
+      startLine: 1,
+      endLine: 10,
+      type: 'function',
+      language: 'go',
+      exports: opts.exports,
+      imports: opts.imports,
+      callSites: opts.callSites?.map((symbol, i) => ({ symbol, line: i + 1 })),
+    },
+  };
+}
+
+describe('findGoRootPackageDependents', () => {
+  let workspaceRoot: string;
+
+  beforeEach(async () => {
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-go-root-pkg-'));
+    await fs.writeFile(path.join(workspaceRoot, 'go.mod'), `module ${MODULE_PREFIX}\n\ngo 1.21\n`);
+  });
+
+  afterEach(async () => {
+    clearGoModuleCache();
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("recovers a subpackage file that calls a root file's uniquely-exported, distinctive symbol via a bare self-import", () => {
+    const chunks: CodeChunk[] = [
+      makeChunk({ file: 'context.go', exports: ['RouteContext', 'NewRouteContext'] }),
+      makeChunk({
+        file: 'middleware/clean_path.go',
+        imports: [MODULE_PREFIX],
+        callSites: ['RouteContext'],
+      }),
+    ];
+
+    expect(findGoRootPackageDependents('context.go', chunks, workspaceRoot)).toEqual([
+      'middleware/clean_path.go',
+    ]);
+  });
+
+  it("does not credit a referencer that never calls any of the target root file's exports", () => {
+    const chunks: CodeChunk[] = [
+      makeChunk({ file: 'context.go', exports: ['RouteContext'] }),
+      makeChunk({
+        file: 'middleware/unrelated.go',
+        imports: [MODULE_PREFIX],
+        callSites: ['SomethingElse'],
+      }),
+    ];
+
+    expect(findGoRootPackageDependents('context.go', chunks, workspaceRoot)).toEqual([]);
+  });
+
+  it('does not credit a file that never imports the bare module root at all (coincidental symbol-name match only)', () => {
+    const chunks: CodeChunk[] = [
+      makeChunk({ file: 'context.go', exports: ['RouteContext'] }),
+      makeChunk({ file: 'unrelated/other.go', callSites: ['RouteContext'] }),
+    ];
+
+    expect(findGoRootPackageDependents('context.go', chunks, workspaceRoot)).toEqual([]);
+  });
+
+  it('never fabricates a false hub: two unrelated root files return disjoint dependent lists (#1056 failure shape)', () => {
+    const chunks: CodeChunk[] = [
+      makeChunk({ file: 'context.go', exports: ['RouteContext'] }),
+      makeChunk({ file: 'chi.go', exports: ['NewRouter'] }),
+      makeChunk({
+        file: 'middleware/clean_path.go',
+        imports: [MODULE_PREFIX],
+        callSites: ['RouteContext'],
+      }),
+      makeChunk({
+        file: 'middleware/profiler.go',
+        imports: [MODULE_PREFIX],
+        callSites: ['NewRouter'],
+      }),
+    ];
+
+    const contextDeps = findGoRootPackageDependents('context.go', chunks, workspaceRoot);
+    const chiDeps = findGoRootPackageDependents('chi.go', chunks, workspaceRoot);
+
+    expect(contextDeps).toEqual(['middleware/clean_path.go']);
+    expect(chiDeps).toEqual(['middleware/profiler.go']);
+    expect(contextDeps).not.toEqual(chiDeps);
+  });
+
+  it("never guesses when a symbol is exported by more than one root file (e.g. chi's own ServeHTTP, declared by both chain.go and mux.go)", () => {
+    const chunks: CodeChunk[] = [
+      makeChunk({ file: 'chain.go', exports: ['ServeHTTP'] }),
+      makeChunk({ file: 'mux.go', exports: ['ServeHTTP'] }),
+      makeChunk({
+        file: 'middleware/whatever.go',
+        imports: [MODULE_PREFIX],
+        callSites: ['ServeHTTP'],
+      }),
+    ];
+
+    expect(findGoRootPackageDependents('chain.go', chunks, workspaceRoot)).toEqual([]);
+    expect(findGoRootPackageDependents('mux.go', chunks, workspaceRoot)).toEqual([]);
+  });
+
+  it('excludes single-segment, non-distinctive export names from candidacy (the Use/Get/Post false-positive risk)', () => {
+    const chunks: CodeChunk[] = [
+      makeChunk({ file: 'mux.go', exports: ['Use', 'Get', 'Post'] }),
+      makeChunk({
+        file: 'unrelated/builder.go',
+        imports: [MODULE_PREFIX],
+        callSites: ['Use'],
+      }),
+    ];
+
+    expect(findGoRootPackageDependents('mux.go', chunks, workspaceRoot)).toEqual([]);
+  });
+
+  it('only considers root-level files -- a subpackage file cannot own an export via this signal', () => {
+    const chunks: CodeChunk[] = [
+      makeChunk({ file: 'middleware/logger.go', exports: ['LogEntry'] }),
+      makeChunk({
+        file: 'middleware/other.go',
+        imports: [MODULE_PREFIX],
+        callSites: ['LogEntry'],
+      }),
+    ];
+
+    expect(findGoRootPackageDependents('middleware/logger.go', chunks, workspaceRoot)).toEqual([]);
+  });
+
+  it('is a no-op for a non-Go-module workspace (no go.mod)', async () => {
+    const bareDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-go-root-pkg-bare-'));
+    try {
+      const chunks: CodeChunk[] = [
+        makeChunk({ file: 'context.go', exports: ['RouteContext'] }),
+        makeChunk({
+          file: 'middleware/clean_path.go',
+          imports: [MODULE_PREFIX],
+          callSites: ['RouteContext'],
+        }),
+      ];
+      expect(findGoRootPackageDependents('context.go', chunks, bareDir)).toEqual([]);
+    } finally {
+      clearGoModuleCache();
+      await fs.rm(bareDir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  it('is a no-op for a non-Go target file', () => {
+    const chunks: CodeChunk[] = [
+      makeChunk({ file: 'context.go', exports: ['RouteContext'] }),
+      makeChunk({
+        file: 'middleware/clean_path.go',
+        imports: [MODULE_PREFIX],
+        callSites: ['RouteContext'],
+      }),
+    ];
+
+    expect(findGoRootPackageDependents('src/context.ts', chunks, workspaceRoot)).toEqual([]);
+  });
+
+  it('build-once/resolve-many index gives the same result as the convenience wrapper', () => {
+    const chunks: CodeChunk[] = [
+      makeChunk({ file: 'context.go', exports: ['RouteContext'] }),
+      makeChunk({
+        file: 'middleware/clean_path.go',
+        imports: [MODULE_PREFIX],
+        callSites: ['RouteContext'],
+      }),
+    ];
+
+    const index = buildGoRootPackageIndex(chunks, workspaceRoot);
+    expect(resolveGoRootPackageDependents('context.go', index)).toEqual([
+      'middleware/clean_path.go',
+    ]);
+  });
+});

--- a/packages/parser/src/go-root-package-signals.test.ts
+++ b/packages/parser/src/go-root-package-signals.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
@@ -6,9 +6,19 @@ import {
   findGoRootPackageDependents,
   buildGoRootPackageIndex,
   resolveGoRootPackageDependents,
+  isRootLevelGoFile,
 } from './go-root-package-signals.js';
-import { clearGoModuleCache } from './go-module.js';
+import { clearGoModuleCache, resolveGoModulePrefix } from './go-module.js';
 import type { CodeChunk } from './types.js';
+
+// Wraps (not replaces) `resolveGoModulePrefix` with a spy so the perf-guard
+// tests below can observe whether `buildGoRootPackageIndex` -- whose very
+// first statement calls this function -- ran at all, while every other test
+// in this file keeps getting the real go.mod-reading behavior unchanged.
+vi.mock('./go-module.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('./go-module.js')>();
+  return { ...actual, resolveGoModulePrefix: vi.fn(actual.resolveGoModulePrefix) };
+});
 
 const MODULE_PREFIX = 'github.com/go-chi/chi/v5';
 
@@ -195,5 +205,58 @@ describe('findGoRootPackageDependents', () => {
     expect(resolveGoRootPackageDependents('context.go', index)).toEqual([
       'middleware/clean_path.go',
     ]);
+  });
+});
+
+describe('findGoRootPackageDependents root-level guard (perf: no project-wide scan for a non-root target)', () => {
+  let workspaceRoot: string;
+
+  beforeEach(async () => {
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-go-root-pkg-guard-'));
+    await fs.writeFile(path.join(workspaceRoot, 'go.mod'), `module ${MODULE_PREFIX}\n\ngo 1.21\n`);
+    vi.mocked(resolveGoModulePrefix).mockClear();
+  });
+
+  afterEach(async () => {
+    clearGoModuleCache();
+    await fs.rm(workspaceRoot, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("short-circuits for a non-root-level Go target WITHOUT building the project-wide index -- resolveGoModulePrefix (buildGoRootPackageIndex's own first statement) never runs", () => {
+    const chunks: CodeChunk[] = [
+      makeChunk({ file: 'context.go', exports: ['RouteContext'] }),
+      makeChunk({
+        file: 'middleware/clean_path.go',
+        imports: [MODULE_PREFIX],
+        callSites: ['RouteContext'],
+      }),
+    ];
+
+    expect(findGoRootPackageDependents('middleware/clean_path.go', chunks, workspaceRoot)).toEqual(
+      [],
+    );
+    expect(resolveGoModulePrefix).not.toHaveBeenCalled();
+  });
+
+  it('sanity check: the same spy DOES fire for a genuine root-level query (proves the assertion above pins a real guard, not a broken mock)', () => {
+    const chunks: CodeChunk[] = [
+      makeChunk({ file: 'context.go', exports: ['RouteContext'] }),
+      makeChunk({
+        file: 'middleware/clean_path.go',
+        imports: [MODULE_PREFIX],
+        callSites: ['RouteContext'],
+      }),
+    ];
+
+    expect(findGoRootPackageDependents('context.go', chunks, workspaceRoot)).toEqual([
+      'middleware/clean_path.go',
+    ]);
+    expect(resolveGoModulePrefix).toHaveBeenCalledWith(workspaceRoot);
+  });
+
+  it('isRootLevelGoFile correctly distinguishes a root file from a subpackage file and a non-Go file', () => {
+    expect(isRootLevelGoFile('context.go')).toBe(true);
+    expect(isRootLevelGoFile('middleware/clean_path.go')).toBe(false);
+    expect(isRootLevelGoFile('src/context.ts')).toBe(false);
   });
 });

--- a/packages/parser/src/go-root-package-signals.ts
+++ b/packages/parser/src/go-root-package-signals.ts
@@ -102,8 +102,17 @@ import { isMultiSegmentIdentifier } from './swift-symbol-usage-signals.js';
  * living in a subdirectory. Mirrors the same "go.mod lives at the workspace
  * root" assumption `resolveGoModulePrefix` already makes (it reads
  * `<workspaceRoot>/go.mod` directly, never searching subdirectories).
+ *
+ * Exported so `findGoRootPackageDependents` can early-return BEFORE building
+ * the project-wide index for any non-root target (a subpackage file can
+ * never own a recovered dependent via this signal -- see
+ * `buildRootExportOwners`, which already filters its OWNER side to
+ * root-level files) -- a perf fix (review finding on #1039's PR): without
+ * this check here, every zero-dependent Go query paid a full
+ * `groupGoChunksByFile` + `buildRootExportOwners` project scan just to be
+ * told `[]`, not only root-level queries.
  */
-function isRootLevelGoFile(file: string): boolean {
+export function isRootLevelGoFile(file: string): boolean {
   const normalized = file.replace(/\\/g, '/').replace(/^\.\//, '');
   return detectLanguage(normalized) === 'go' && !normalized.includes('/');
 }
@@ -241,12 +250,22 @@ export function resolveGoRootPackageDependents(
  * MANY target files against the same chunk set should build the index once
  * themselves instead of calling this in a loop -- see `GoRootPackageIndex`'s
  * doc comment.
+ *
+ * Short-circuits BEFORE `buildGoRootPackageIndex`'s project-wide scan for any
+ * non-Go OR non-root-level target -- a subpackage file can never own a
+ * recovered dependent via this signal (`buildRootExportOwners` only ever
+ * populates owners for root-level files), so there is no reason to pay a
+ * full `groupGoChunksByFile` + `buildRootExportOwners` scan just to
+ * rediscover that and return `[]`. This is the guard
+ * `enrichWithGoRootPackageDependents` (`dependency-analyzer.ts`) documents
+ * itself as relying on to skip the corpus-wide index rebuild for a
+ * non-root-level query.
  */
 export function findGoRootPackageDependents(
   targetFile: string,
   chunks: CodeChunk[],
   workspaceRoot: string,
 ): string[] {
-  if (detectLanguage(targetFile) !== 'go') return [];
+  if (detectLanguage(targetFile) !== 'go' || !isRootLevelGoFile(targetFile)) return [];
   return resolveGoRootPackageDependents(targetFile, buildGoRootPackageIndex(chunks, workspaceRoot));
 }

--- a/packages/parser/src/go-root-package-signals.ts
+++ b/packages/parser/src/go-root-package-signals.ts
@@ -1,0 +1,252 @@
+/**
+ * #1039: recover REAL dependents for a Go module's ROOT package when the
+ * import graph finds none, because a Go file outside the root package that
+ * references it has no way to spell that reference except the module's own
+ * full import path with no further path segment (`import
+ * "github.com/go-chi/chi/v5"`) -- Go has no relative-import syntax, and the
+ * bare self-import is exactly, and only, that literal string. `go-module.ts`'s
+ * `resolveGoModuleImport` deliberately leaves this case unresolved (a
+ * no-op -- see its own doc comment for why that's still correct for #867's
+ * narrower test-association scope), so nothing in `chunk.metadata.imports`
+ * ever names a specific root-package FILE, and every root file (`chi.go`,
+ * `mux.go`, `tree.go`, `chain.go`, `context.go` for go-chi/chi) reports zero
+ * dependents despite being genuinely, heavily imported by every subpackage
+ * (measured: 86 files, 11 total edges, 94.2% orphan rate -- #1004/#1023/#1029
+ * chased this to a verdict; #1039 is the root cause).
+ *
+ * Deliberately NOT fixed by making the generic import-resolution pipeline
+ * (`resolveManifestRoot`/`matchesFile`) treat a bare self-import as "the
+ * whole root-package directory," the way a Go SUBPACKAGE import already does
+ * (`middleware` resolves to every file under `middleware/` via `matchesFile`
+ * Strategy 2's interior-hit leniency): a subpackage's directory is scoped to
+ * its own subtree, but the module ROOT is frequently the repository root
+ * itself, alongside dozens of unrelated root-level files (chi's own root has
+ * 5 non-test `.go` files, several exporting 30+ symbols each). Crediting the
+ * whole directory there would make every subpackage file that merely imports
+ * its own module appear to depend on EVERY root file, regardless of which
+ * symbol it actually uses -- exactly the false-hub shape this project has
+ * been burned by twice already (#1008's fabricated Rust self-edges, #1056's
+ * open Rust `use crate::` 144-file identical-list bug). This module instead
+ * recovers the SPECIFIC root file genuinely referenced, via export lookup:
+ * which root file actually EXPORTS the symbol a bare-self-importing file's
+ * own call sites reference.
+ *
+ * Mechanism, for one target root file R:
+ *   1. R must be a ROOT-LEVEL, non-test Go file -- directly inside the
+ *      workspace root (no directory segment), the same location
+ *      `resolveGoModulePrefix` already assumes `go.mod` lives (see
+ *      `isRootLevelGoFile`).
+ *   2. Collect R's own top-level exports (`chunk.metadata.exports`, already
+ *      computed by `GoExportExtractor`) that are DISTINCTIVE -- pass both
+ *      `isUnambiguousIdentifierShape` (a real camelCase/PascalCase/
+ *      underscored shape, not a bare English word) and
+ *      `isMultiSegmentIdentifier` (>=2 identifier segments) -- see
+ *      `swift-symbol-usage-signals.ts`'s own doc comment for why a
+ *      single-segment bare word is exactly the shape most likely to collide
+ *      with an unrelated identifier. This is the load-bearing guard for a Go
+ *      HTTP router specifically: root files export plenty of single-segment,
+ *      extremely common method names (`Use`, `Get`, `Post`, `Route`, `Match`,
+ *      `Find`) that any unrelated type in the same corpus could just as
+ *      easily define -- `RouteContext`, `NewRouteContext`, `HandleFunc`,
+ *      `MethodNotAllowedHandler` are the shape this project actually wants to
+ *      credit.
+ *   3. A distinctive export name is only trusted when EXACTLY ONE root-level
+ *      file declares it project-wide (never guessed at when ambiguous -- e.g.
+ *      chi's own `ServeHTTP` is declared by BOTH `chain.go` (on
+ *      `ChainHandler`) and `mux.go` (on `Mux`), so it's excluded from every
+ *      root file's owned-symbol set).
+ *   4. A referencer file D (any OTHER Go file, any directory, production or
+ *      test) is recovered as a dependent of R when D's OWN `imports` contain
+ *      the literal, unresolved module-prefix string (proof D genuinely
+ *      declared an intent to use the root package -- this is NOT a
+ *      corpus-wide text scan; only files that already import the root
+ *      package are ever considered) AND D's own `callSites` (aggregated
+ *      across all of D's chunks) name one of R's uniquely-owned distinctive
+ *      exports.
+ *
+ * Verified against a real clone (go-chi/chi, the corpus that motivated
+ * #1004/#1023/#1029/#1039): recovers `context.go` -> 5 real `middleware/*.go`
+ * callers of `chi.RouteContext`/`chi.NewRouteContext`, `mux.go` -> real
+ * callers of `chi.NewMux`-shaped exports, etc., while two unrelated root
+ * files (`context.go`, `chi.go`) return disjoint dependent lists -- see the
+ * PR description for the full before/after table and the explicit false-hub
+ * check.
+ *
+ * This is a strictly ADDITIVE, lower-confidence recovery, mirroring
+ * `csharp-type-reference-signals.ts`'s discipline exactly: dependents
+ * recovered here are tagged `confidence: 'inferred'` (see `DependentInfo` in
+ * `dependency-analyzer.ts`) and only attempted when the import graph found
+ * LITERALLY ZERO dependents for a file-level (no `symbol`) query -- see
+ * `enrichWithGoRootPackageDependents`'s own doc comment there.
+ *
+ * What this does NOT solve: a call-site symbol match cannot distinguish a
+ * genuine root-package reference from an unrelated call that merely shares
+ * the same distinctive name (residual risk, same category `swift-symbol-
+ * usage-signals.ts`/`csharp-type-reference-signals.ts` both accept and hedge
+ * via `confidence: 'inferred'` rather than eliminate); nor does it recover
+ * anything for a root file whose ENTIRE exported surface is single-segment
+ * (no distinctive name to key off at all) -- an honest miss, never a
+ * fabricated hit.
+ */
+
+import type { CodeChunk } from './types.js';
+import { isTestFile } from './utils/path-matching.js';
+import { detectLanguage } from './ast/languages/registry.js';
+import { resolveGoModulePrefix } from './go-module.js';
+import { isUnambiguousIdentifierShape } from './doc-reference-matching.js';
+import { isMultiSegmentIdentifier } from './swift-symbol-usage-signals.js';
+
+/**
+ * True iff `file` sits directly inside the workspace root, with no further
+ * directory segment -- Go's own ROOT package, as opposed to a subpackage
+ * living in a subdirectory. Mirrors the same "go.mod lives at the workspace
+ * root" assumption `resolveGoModulePrefix` already makes (it reads
+ * `<workspaceRoot>/go.mod` directly, never searching subdirectories).
+ */
+function isRootLevelGoFile(file: string): boolean {
+  const normalized = file.replace(/\\/g, '/').replace(/^\.\//, '');
+  return detectLanguage(normalized) === 'go' && !normalized.includes('/');
+}
+
+/** True iff `symbol` is distinctive enough to trust as an export-lookup key -- see the module doc's step 2. */
+function isDistinctiveGoRootSymbol(symbol: string): boolean {
+  return isUnambiguousIdentifierShape(symbol) && isMultiSegmentIdentifier(symbol);
+}
+
+/** Group `chunks` by file, preserving first-seen order. Deliberately unnormalized -- works on `chunk.metadata.file` strings as-is, mirroring `csharp-type-reference-signals.ts`'s own no-normalization discipline. */
+function groupGoChunksByFile(chunks: CodeChunk[]): Map<string, CodeChunk[]> {
+  const out = new Map<string, CodeChunk[]>();
+  for (const chunk of chunks) {
+    const list = out.get(chunk.metadata.file);
+    if (list) list.push(chunk);
+    else out.set(chunk.metadata.file, [chunk]);
+  }
+  return out;
+}
+
+/**
+ * Distinctive export name -> its single owning root-level file, project-wide.
+ * A name declared by more than one root-level file (e.g. chi's own
+ * `ServeHTTP`, declared by both `chain.go` and `mux.go`) is excluded entirely
+ * -- see the module doc's step 3.
+ */
+function buildRootExportOwners(chunksByFile: Map<string, CodeChunk[]>): Map<string, string> {
+  const defMap = new Map<string, Set<string>>();
+
+  for (const [file, fileChunks] of chunksByFile) {
+    if (!isRootLevelGoFile(file) || isTestFile(file)) continue;
+    const exportsForFile = fileChunks.find(c => c.metadata.exports?.length)?.metadata.exports ?? [];
+    for (const symbol of exportsForFile) {
+      if (!isDistinctiveGoRootSymbol(symbol)) continue;
+      const files = defMap.get(symbol) ?? new Set<string>();
+      files.add(file);
+      defMap.set(symbol, files);
+    }
+  }
+
+  const owners = new Map<string, string>();
+  for (const [symbol, files] of defMap) {
+    if (files.size === 1) owners.set(symbol, [...files][0]);
+  }
+  return owners;
+}
+
+/** True iff any of `fileChunks` (all belonging to one file) records the literal, unresolved `modulePrefix` among its own raw imports -- proof that file genuinely declared an intent to use the module's root package. */
+function fileImportsBareModuleRoot(fileChunks: CodeChunk[], modulePrefix: string): boolean {
+  return fileChunks.some(c => (c.metadata.imports ?? []).includes(modulePrefix));
+}
+
+/** Every distinctive symbol referenced anywhere in `fileChunks`' own `callSites` (aggregated across all of that file's chunks -- each chunk only carries the call sites made within its own function/method body). */
+function collectCallSiteSymbols(fileChunks: CodeChunk[]): Set<string> {
+  const symbols = new Set<string>();
+  for (const chunk of fileChunks) {
+    for (const call of chunk.metadata.callSites ?? []) {
+      symbols.add(call.symbol);
+    }
+  }
+  return symbols;
+}
+
+/**
+ * Everything `resolveGoRootPackageDependents` needs to resolve any number of
+ * target root files against ONE project-wide scan -- built once by
+ * `buildGoRootPackageIndex` and reused per target, mirroring
+ * `CSharpTypeReferenceIndex`'s "build once, resolve many" discipline.
+ */
+export interface GoRootPackageIndex {
+  chunksByFile: Map<string, CodeChunk[]>;
+  owners: Map<string, string>;
+  /** `go.mod`'s own declared module prefix, or `undefined` for a non-Go-module workspace (in which case `owners` is always empty and every resolution is a no-op). */
+  modulePrefix: string | undefined;
+}
+
+/**
+ * Build the project-wide index `resolveGoRootPackageDependents` needs from
+ * `chunks` once. `chunks` should be the FULL project chunk set -- both
+ * root-export uniqueness and the module prefix are project-wide properties,
+ * not scoped to any one target file.
+ */
+export function buildGoRootPackageIndex(
+  chunks: CodeChunk[],
+  workspaceRoot: string,
+): GoRootPackageIndex {
+  const modulePrefix = resolveGoModulePrefix(workspaceRoot);
+  const chunksByFile = groupGoChunksByFile(chunks);
+  const owners = modulePrefix ? buildRootExportOwners(chunksByFile) : new Map<string, string>();
+  return { chunksByFile, owners, modulePrefix };
+}
+
+/**
+ * Find Go files (any directory, production or test) that reference one of
+ * `targetFile`'s uniquely-owned, distinctive root-package exports -- via a
+ * genuine bare self-import of the module root PLUS a matching call-site
+ * symbol -- against an already-built `index` (see `buildGoRootPackageIndex`).
+ * Excludes `targetFile` itself. Returns a sorted, deduplicated list of
+ * filepaths -- empty when `targetFile` isn't a root-level Go file, owns no
+ * distinctive export, or genuinely has no referencers in the index.
+ *
+ * `targetFile` must be the exact `chunk.metadata.file` string used by
+ * `targetFile`'s own chunks within the chunks `index` was built from -- this
+ * function does no path normalization of its own, mirroring
+ * `resolveCSharpTypeReferenceDependents`'s same discipline.
+ */
+export function resolveGoRootPackageDependents(
+  targetFile: string,
+  index: GoRootPackageIndex,
+): string[] {
+  const { chunksByFile, owners, modulePrefix } = index;
+  if (!modulePrefix) return [];
+
+  const ownedSymbols = [...owners.entries()]
+    .filter(([, file]) => file === targetFile)
+    .map(([symbol]) => symbol);
+  if (ownedSymbols.length === 0) return [];
+
+  const found: string[] = [];
+  for (const [file, fileChunks] of chunksByFile) {
+    if (file === targetFile) continue;
+    if (detectLanguage(file) !== 'go') continue;
+    if (!fileImportsBareModuleRoot(fileChunks, modulePrefix)) continue;
+
+    const callSiteSymbols = collectCallSiteSymbols(fileChunks);
+    if (ownedSymbols.some(s => callSiteSymbols.has(s))) found.push(file);
+  }
+  return found.sort();
+}
+
+/**
+ * Single-target convenience wrapper around `buildGoRootPackageIndex` +
+ * `resolveGoRootPackageDependents`, for callers resolving just ONE target
+ * file (`get_dependents`'s file-level recovery, #1039). Callers resolving
+ * MANY target files against the same chunk set should build the index once
+ * themselves instead of calling this in a loop -- see `GoRootPackageIndex`'s
+ * doc comment.
+ */
+export function findGoRootPackageDependents(
+  targetFile: string,
+  chunks: CodeChunk[],
+  workspaceRoot: string,
+): string[] {
+  if (detectLanguage(targetFile) !== 'go') return [];
+  return resolveGoRootPackageDependents(targetFile, buildGoRootPackageIndex(chunks, workspaceRoot));
+}

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -173,6 +173,19 @@ export {
 } from './csharp-type-reference-signals.js';
 export type { CSharpTypeReferenceIndex } from './csharp-type-reference-signals.js';
 
+// #1039: Go's root-package export-lookup dependents signal (see
+// go-root-package-signals.ts's module doc). Mirrors the C# exports
+// immediately above -- `buildGoRootPackageIndex`/`resolveGoRootPackageDependents`
+// let a caller resolving MANY target root files build the project-wide index
+// once and reuse it, instead of calling `findGoRootPackageDependents` (which
+// rebuilds it) per file.
+export {
+  findGoRootPackageDependents,
+  buildGoRootPackageIndex,
+  resolveGoRootPackageDependents,
+} from './go-root-package-signals.js';
+export type { GoRootPackageIndex } from './go-root-package-signals.js';
+
 // =============================================================================
 // GRAPH TRAVERSAL (generic bounded BFS — domain graphs build on this)
 // =============================================================================

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -183,6 +183,7 @@ export {
   findGoRootPackageDependents,
   buildGoRootPackageIndex,
   resolveGoRootPackageDependents,
+  isRootLevelGoFile,
 } from './go-root-package-signals.js';
 export type { GoRootPackageIndex } from './go-root-package-signals.js';
 


### PR DESCRIPTION
## Summary

Any Go file outside a module's own root package that genuinely uses it (`import "github.com/go-chi/chi/v5"` from a subpackage) has no way to spell that reference except a bare self-import of the module's own full path — Go has no relative-import syntax. `resolveGoModuleImport` deliberately leaves this exact-match case unresolved (correct for #867's narrower test-association scope), but it's also the *only* manifest-root resolution step in the general dependents pipeline — so every root-package file reported zero dependents despite being heavily imported by every subpackage. Filed and root-caused in #1039.

Fixes: #1039

## Fix

Adds `packages/parser/src/go-root-package-signals.ts`, a project-wide **export-lookup recovery** (mirrors `csharp-type-reference-signals.ts`'s established pattern): for a root-level target file R, find which of R's own exports are **distinctive** (reject single-segment/common names like `Use`/`Get`/`Post` — the load-bearing guard for an HTTP router) and **uniquely owned** (never guessed at when the name collides across two root files, e.g. Chi's own `ServeHTTP`, declared by both `chain.go` and `mux.go`). A referencer D is recovered only when D's own raw imports contain the literal bare module-root string (proof it declared intent to use the root package) *and* D's own call sites name one of R's owned exports.

**Deliberately not a change to `resolveGoModuleImport`/`matchesFile` themselves.** The tempting fix ("resolve the bare self-import to the whole root-package directory," the way a subpackage import already does) would fabricate a false hub: the module root is frequently the repository root itself, alongside dozens of unrelated files — crediting the whole directory would make every subpackage file that merely imports its own module appear to depend on every root file, regardless of which symbol it actually uses. That's the exact #1008/#1056 shape this project has been burned by twice already. `go-module.ts`'s no-op stays completely unchanged; #867's test-association behavior is untouched.

## Verification (go-chi/chi, isolated `LIEN_HOME` per measurement, never `--force` against a shared index)

| | Before | After |
|---|---|---|
| Total dependency edges (86 files swept) | 11 | 64 |
| Orphan rate | 94.2% | 88.4% |
| `context.go` dependents | 0 | 11 |
| `chi.go` dependents | 0 | 28 |
| `mux.go` dependents | 0 | 5 |
| `tree.go` dependents | 0 | 1 |
| `chain.go` dependents | 0 | 8 |

`context.go`'s 11 recovered dependents: `middleware/clean_path.go`, `middleware/get_head.go` (+its `_test.go`), `middleware/strip.go` (+its `_test.go`), `middleware/supress_notfound.go`, `middleware/url_format.go` (+its `_test.go`), plus 3 genuine `_examples/*/main.go` callers — real `middleware/*.go` files dominate, not just the self-contained example directory (`compress.go` doesn't actually import the root package on current `chi/master`; `profiler.go` calls `chi.NewRouter`, correctly attributed to `chi.go` instead, not `context.go`).

**False-hub check, done explicitly** (the #1056 failure signature): `context.go` (11 dependents) and `chi.go` (28 dependents) return completely disjoint dependent lists — confirmed both via the ad-hoc measurement script and a dedicated unit test (`never fabricates a false hub: two unrelated root files return disjoint dependent lists (#1056 failure shape)`). Also unit-tested: a name colliding across two root files (`ServeHTTP`) recovers nothing for either.

**#867 regression check**: Go same-package test-association is untouched — `go-module.ts`'s function body is unchanged (only its doc comment was extended), and the E2E suite's test-association count for Chi stayed exactly the same (20 associations across 86 files) before and after.

**Other 10 corpora**: full `npm run test:e2e -w packages/cli` (all 11 languages) run twice — once pre-rebase, once post-rebase onto `origin/main` (which had just picked up #1046's Java/Kotlin fix) — 198/198 tests passed both times, with every corpus's dependency-edge count matching its existing/expected baseline (Java 18, Kotlin 4 post-#1046, Swift still an exact-zero tripwire, etc). My change is gated on `detectLanguage(filepath) === 'go'` and only fires when the import graph found zero dependents for a file-level query, so no other language's code path is reachable.

**Floor tightened** (`expectedMinDependencyEdges` for Chi): 5 → 35 (~55% of measured 64, per #1053 — catches roughly a 45%+ regression, not just a near-total collapse).

## Tests

- `packages/parser/src/go-root-package-signals.test.ts` (new, 10 tests): unit coverage for the signal module directly — recovery, false-hub check, export-name collision, non-distinctive-name exclusion, root-vs-subpackage scoping, non-Go-module no-op.
- `packages/parser/src/dependency-analyzer.test.ts` (new `describe` block, 7 tests): end-to-end `findDependents` wiring, including the false-hub check and the "does not run when already resolved / symbol-scoped / non-Go" guards.
- Confirmed the new tests actually fail on pre-fix code: temporarily disabled the `enrichWithGoRootPackageDependents` call and reran — 2 tests failed with the expected `[]` vs real dependents mismatch, then restored.
- Full local gate chain green: `format:check`, `lint` (0 errors), `typecheck`, `build`, `npm test` (all packages, 1727+1637+41 tests), `lien delta` (exit 0, no threshold crossings), `npm run test:e2e:go -w packages/cli`, and the full `npm run test:e2e -w packages/cli` (all 11 corpora, twice).

## Coordination

Did **not** touch `packages/parser/src/utils/path-matching.ts` (the file #1046 was concurrently editing) — the fix lives entirely in a new signal module plus `dependency-analyzer.ts`'s wiring. Rebased cleanly onto `origin/main` after #1046 (`cc1fccba`) merged; re-verified the full gate chain and E2E suite post-rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dependency detection for Go root packages, recovering previously missed relationships.
  - Avoided incorrect dependency attribution when exports are ambiguous, non-distinctive, or unrelated.
  - Preserved direct dependencies, symbol-specific lookups, and non-Go file behavior.

- **Tests**
  - Added comprehensive coverage for Go root-package dependency scenarios.
  - Updated real-project validation metrics to reflect more complete dependency results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds a narrowly-scoped, additive recovery signal for Go root-package dependents. The new `go-root-package-signals.ts` module mirrors the existing C# fallback pattern: it only fires on file-level queries with zero import-graph dependents, requires a bare module-root self-import plus a uniquely-owned distinctive export match, and tags recovered dependents as `confidence: 'inferred'`. The wiring in `dependency-analyzer.ts` correctly gates the fallback behind the same conditions as the C# recovery, and the implementation avoids the false-hub risk by never crediting the whole root directory. Tests cover the happy path, false-hub prevention, export-name collision, non-distinctive names, and guard conditions.
>
> - Adds `go-root-package-signals.ts` with export-lookup recovery for Go root-package files
> - Wires `enrichWithGoRootPackageDependents` into `dependency-analyzer.ts` as a fallback after the C# recovery
> - Updates `DependentInfo` docs and E2E floor for go-chi/chi dependency edges

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit caebd59. Updates automatically on new commits.</sup>
<!-- /lien-stats -->