### PR TITLE
fix(parser): resolve Rust bare crate-root imports via export lookup (#1056)

### DIFF
--- a/.changeset/fix-1056-rust-crate-root-export-lookup.md
+++ b/.changeset/fix-1056-rust-crate-root-export-lookup.md
@@ -1,0 +1,35 @@
+---
+"@liendev/parser": patch
+---
+
+Fix Rust `get_dependents` fabricating an identical dependent list for every
+file in a crate when consumed via `use crate_name::Symbol;` (a cross-crate
+import naming only the crate + a symbol, no submodule path — the ordinary
+shape for consuming what a crate's `lib.rs` re-exports). `resolveRustCrateImport`
+resolved this to the crate's bare `src/` directory, which fabricated a match
+against every file the crate contains via `matchesFile`'s Go-style package-
+directory leniency. Measured on serde-rs/serde: `serde_derive/src/de.rs` and
+`serde_derive/src/dummy.rs` — two unrelated files — both returned the
+identical 144-file "dependent" list.
+
+Adds `rust-crate-exports.ts`, a crate-root export lookup: reads the target
+crate's own `lib.rs`/`main.rs` directly for (a) top-level `pub` items and
+(b) `#[proc_macro_derive(Name)]` names (the exact serde/serde_derive shape),
+and narrows the bare crate-root import to the ONE file that actually
+declares the symbol. When the symbol can't be found there, emits nothing —
+an honest gap, not a fabricated crate-wide match. The resolved specifier
+reuses the existing #1021 mod-marker mechanism for exact-single-file
+matching.
+
+Verified against a real serde-rs/serde clone: `de.rs`/`dummy.rs` now
+correctly show their one real dependent (`lib.rs`, via its own `mod de;`/
+`mod dummy;`); `internals/ast.rs` shows a genuinely different, much smaller
+list of real internal consumers (15, down from a fabricated 158); `lib.rs`
+itself is unchanged (143 real consumers — the file that actually declares
+`Deserialize`/`Serialize`). `dtolnay/anyhow` (single-crate, non-workspace)
+went from 27 to ~32 edges — an increase, not a decrease: its own crate
+directory is a single-segment `src`, which never hit the multi-segment
+fabrication a workspace member's `<crate>/src` shape does, so its `tests/*.rs`
+integration tests (`use anyhow::Error;`) simply resolve for the first time
+instead of matching nothing. No regression to the other 10 corpora in the
+E2E suite.

--- a/packages/cli/test/e2e/real-projects.test.ts
+++ b/packages/cli/test/e2e/real-projects.test.ts
@@ -260,10 +260,21 @@ const TEST_PROJECTS: ProjectConfig[] = [
     expectedMinChunks: 15,
     sampleSearchQuery: 'error handling context',
     // DELIBERATELY VERY LOW, do not raise from a measured snapshot (#1004).
-    // Current Rust edge counts (measured ~39 pre-fix) are INFLATED by #1021
-    // (`mod x;` fabricates edges to every file under `x/`, plus self-edges).
-    // Once #1021 lands, legitimate edges will DROP -- a floor pinned to
-    // today's inflated number would bake the bug in and block its own fix.
+    // History: ~39 pre-#1021 (`mod x;` fabricated edges to every file under
+    // `x/`, plus self-edges) -> 27 post-#1021/pre-#1056 -> ~32 post-#1056.
+    // The #1056 fix (bare crate-root imports, `use anyhow::Symbol;` from
+    // Anyhow's OWN `tests/*.rs` integration tests -- a single-crate project,
+    // so `resolveRustCrateMap`'s crateDir is the ONE-segment `src`, never the
+    // multi-segment `<member>/src` shape that made serde_derive's fabrication
+    // possible) went from resolving to NOTHING (a bare single-segment `src`
+    // specifier only ever exact-matches a file literally named `src`, so it
+    // silently matched zero real files here) to correctly resolving via a
+    // crate-root export lookup -- a genuine, non-fabricated INCREASE, not a
+    // regression. Confirmed: `src/lib.rs` now shows 5 real test-file
+    // dependents (`Error`/`Context`/etc. consumers) that resolved to nothing
+    // before; every other `src/*.rs` file's dependent set is unchanged.
+    // A floor pinned to any of these snapshots would bake today's number in
+    // and block the next legitimate fix from moving it either direction --
     // 1 just proves resolution hasn't collapsed to zero; it is intentionally
     // not a precision target.
     expectedMinDependencyEdges: 1,

--- a/packages/parser/src/ast/chunker.ts
+++ b/packages/parser/src/ast/chunker.ts
@@ -143,7 +143,11 @@ function buildPythonManifestRoots(workspaceRoot: string): ManifestRoots | undefi
 
 function buildRustManifestRoots(workspaceRoot: string): ManifestRoots | undefined {
   const rustCrateMap = resolveRustCrateMap(workspaceRoot);
-  return rustCrateMap.size > 0 ? { rustCrateMap } : undefined;
+  // `workspaceRoot` is threaded through too (#1056): a bare crate-root
+  // import (`use crate_name::Symbol;`, no submodule path) needs it to read
+  // the target crate's own root file when resolving which specific file
+  // declares `Symbol` -- see `../rust-crate-exports.ts`.
+  return rustCrateMap.size > 0 ? { rustCrateMap, workspaceRoot } : undefined;
 }
 
 function buildJvmManifestRoots(workspaceRoot: string): ManifestRoots | undefined {

--- a/packages/parser/src/ast/extractors/types.ts
+++ b/packages/parser/src/ast/extractors/types.ts
@@ -146,12 +146,19 @@ export interface LanguageImportExtractor {
    * @param node - AST node matching one of importNodeTypes
    * @param rustCrateMap - Rust-only (#903) — see `extractImportPaths`.
    * @param importerFile - Rust-only (#928) — see `extractImportPaths`.
+   * @param workspaceRoot - Rust-only (#1056): absolute project root, needed
+   *   to resolve a bare crate-root import (`use crate_name::Symbol;`, no
+   *   submodule path) to the specific file that declares `Symbol`, via a
+   *   crate-root export lookup (`../../rust-crate-exports.ts`), rather than
+   *   fabricating a match against every file the crate contains. Every
+   *   other language's implementation ignores this parameter.
    * @returns Object with importPath and symbols, or null to skip
    */
   processImportSymbols(
     node: SyntaxNode,
     rustCrateMap?: ReadonlyMap<string, string>,
     importerFile?: string,
+    workspaceRoot?: string,
   ): { importPath: string; symbols: string[] } | null;
 
   /**
@@ -174,12 +181,14 @@ export interface LanguageImportExtractor {
    * @param node - AST node matching one of importNodeTypes
    * @param rustCrateMap - Rust-only (#903) -- see `extractImportPaths`.
    * @param importerFile - Rust-only (#928) -- see `extractImportPaths`.
+   * @param workspaceRoot - Rust-only (#1056) -- see `processImportSymbols`.
    * @returns Every {importPath, symbols} pair declared by this node, in source order (empty if none)
    */
   processImportSymbolsList(
     node: SyntaxNode,
     rustCrateMap?: ReadonlyMap<string, string>,
     importerFile?: string,
+    workspaceRoot?: string,
   ): Array<{ importPath: string; symbols: string[] }>;
 
   /**

--- a/packages/parser/src/ast/languages/rust.test.ts
+++ b/packages/parser/src/ast/languages/rust.test.ts
@@ -1,8 +1,16 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
 import { mustParse } from '../test/helpers/parse-fixture.js';
 import type { SyntaxNode } from '../types.js';
 import { chunkByAST } from '../chunker.js';
-import { markRustModSpecifier } from '../../utils/rust-mod-marker.js';
+import {
+  markRustModSpecifier,
+  hasRustModMarker,
+  stripRustModMarker,
+} from '../../utils/rust-mod-marker.js';
+import { clearRustCrateExportCache } from '../../rust-crate-exports.js';
 import {
   RustTraverser,
   RustExportExtractor,
@@ -340,22 +348,20 @@ pub static COUNTER: i32 = 0;`;
         );
       });
 
-      it('resolves a bare workspace-crate group reference (no module segment before the braces) to the crate dir itself', () => {
+      it('resolves a bare workspace-crate group reference (no module segment before the braces) to null without a workspaceRoot (#1056)', () => {
         // `use tokio_test::{assert_ok, assert_err};` (tokio-test's own repro
         // shape from #903) has no module path between the crate name and the
-        // group -- convertRustModulePath's `rest` is empty, so it resolves to
-        // the crate's src dir itself, same as a bare crate::-relative import
-        // with nothing to strip.
+        // group -- convertRustModulePath's `rest` is empty. Before #1056 this
+        // resolved to the crate's bare `src` dir itself, which fabricated a
+        // match against EVERY file the crate contains (the exact serde/
+        // serde_derive repro -- see the dedicated describe block below).
+        // Without a `workspaceRoot` to attempt a crate-root export lookup
+        // with, the honest answer is now "unresolved", not "the whole crate".
         const code = 'use tokio_test::{assert_ok, assert_err};';
         const root = mustParse(code, 'rust');
         const useNode = root.namedChild(0)!;
-        expect(importExtractor.extractImportPath(useNode, rustCrateMap)).toBe('tokio-test/src');
-
-        const result = importExtractor.processImportSymbols(useNode, rustCrateMap);
-        expect(result).not.toBeNull();
-        expect(result!.importPath).toBe('tokio-test/src');
-        expect(result!.symbols).toContain('assert_ok');
-        expect(result!.symbols).toContain('assert_err');
+        expect(importExtractor.extractImportPath(useNode, rustCrateMap)).toBeNull();
+        expect(importExtractor.processImportSymbols(useNode, rustCrateMap)).toBeNull();
       });
 
       it('still returns null for a genuinely external crate even with a crate map present', () => {
@@ -387,6 +393,138 @@ pub static COUNTER: i32 = 0;`;
         const root = mustParse(code, 'rust');
         const useNode = root.namedChild(0)!;
         expect(importExtractor.extractImportPath(useNode, rustCrateMap)).toBe('auth/AuthService');
+      });
+    });
+
+    // #1056: the serde/serde_derive fabrication bug. `use serde_derive::
+    // Deserialize;` (a cross-crate import naming only the crate + a symbol,
+    // no submodule path) used to resolve to the crate's bare `src` dir,
+    // fabricating an identical dependent list for every file in the crate.
+    // With `workspaceRoot` on hand, it now narrows to the ONE file the
+    // symbol actually comes from via a crate-root export lookup.
+    describe('bare crate-root export lookup (#1056)', () => {
+      let testDir: string;
+      const rustCrateMap = new Map([['serde_derive', 'serde_derive/src']]);
+
+      beforeEach(async () => {
+        testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-rust-export-lookup-'));
+        await fs.mkdir(path.join(testDir, 'serde_derive/src'), { recursive: true });
+        await fs.writeFile(
+          path.join(testDir, 'serde_derive/src/lib.rs'),
+          [
+            '#[proc_macro_derive(Deserialize, attributes(serde))]',
+            'pub fn derive_deserialize(input: TokenStream) -> TokenStream {',
+            '    unimplemented!()',
+            '}',
+            '',
+            '#[proc_macro_derive(Serialize, attributes(serde))]',
+            'pub fn derive_serialize(input: TokenStream) -> TokenStream {',
+            '    unimplemented!()',
+            '}',
+          ].join('\n'),
+        );
+      });
+
+      afterEach(async () => {
+        clearRustCrateExportCache();
+        await fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+      });
+
+      it('resolves a single scoped_identifier import (the 143 test_suite/tests/**/*.rs repro shape)', () => {
+        const code = 'use serde_derive::Deserialize;';
+        const root = mustParse(code, 'rust');
+        const useNode = root.namedChild(0)!;
+
+        const result = importExtractor.processImportSymbols(
+          useNode,
+          rustCrateMap,
+          undefined,
+          testDir,
+        );
+        expect(result).not.toBeNull();
+        expect(hasRustModMarker(result!.importPath)).toBe(true);
+        expect(stripRustModMarker(result!.importPath)).toBe('serde_derive/src/lib');
+        expect(result!.symbols).toEqual(['Deserialize']);
+      });
+
+      it('resolves a scoped_use_list import (the serde/src/lib.rs `pub use serde_derive::{Deserialize, Serialize};` repro shape)', () => {
+        const code = 'pub use serde_derive::{Deserialize, Serialize};';
+        const root = mustParse(code, 'rust');
+        const useNode = root.namedChild(0)!;
+
+        const result = importExtractor.processImportSymbols(
+          useNode,
+          rustCrateMap,
+          undefined,
+          testDir,
+        );
+        expect(result).not.toBeNull();
+        expect(stripRustModMarker(result!.importPath)).toBe('serde_derive/src/lib');
+        expect(result!.symbols).toEqual(['Deserialize', 'Serialize']);
+      });
+
+      it('resolves an aliased import by looking up the PRE-alias name', () => {
+        const code = 'use serde_derive::Deserialize as Deser;';
+        const root = mustParse(code, 'rust');
+        const useNode = root.namedChild(0)!;
+
+        const result = importExtractor.processImportSymbols(
+          useNode,
+          rustCrateMap,
+          undefined,
+          testDir,
+        );
+        expect(result).not.toBeNull();
+        expect(stripRustModMarker(result!.importPath)).toBe('serde_derive/src/lib');
+        expect(result!.symbols).toEqual(['Deser']);
+      });
+
+      it('returns null (honest gap) for a symbol not found in the crate root file', () => {
+        const code = 'use serde_derive::NotReallyThere;';
+        const root = mustParse(code, 'rust');
+        const useNode = root.namedChild(0)!;
+
+        expect(
+          importExtractor.processImportSymbols(useNode, rustCrateMap, undefined, testDir),
+        ).toBeNull();
+      });
+
+      it('converges on the ONE real target file rather than the crate-wide directory the bug used to fabricate', () => {
+        // Both of these importer shapes (a single `use`, and the `pub use`
+        // list form) are real consumers of the SAME symbol, from the SAME
+        // crate, so it's correct for both to resolve to the same real
+        // target (serde_derive/src/lib) -- that's convergence on the truth,
+        // not the bug. The bug this whole fix exists for is the crate-WIDE
+        // directory both used to fall back to instead (`serde_derive/src`),
+        // which would have ALSO matched every unrelated file the crate
+        // contains (`de.rs`, `dummy.rs`, ...) -- see the dependency-level
+        // proof in `real-projects.test.ts` / the PR's own before/after
+        // measurement for the actual distinctness check across unrelated
+        // TARGET files.
+        const codeA = 'use serde_derive::Deserialize;'; // e.g. a test_suite/tests/*.rs file
+        const codeB = 'pub use serde_derive::{Deserialize, Serialize};'; // serde/src/lib.rs itself
+
+        const useNodeA = mustParse(codeA, 'rust').namedChild(0)!;
+        const useNodeB = mustParse(codeB, 'rust').namedChild(0)!;
+
+        const resultA = importExtractor.processImportSymbols(
+          useNodeA,
+          rustCrateMap,
+          undefined,
+          testDir,
+        );
+        const resultB = importExtractor.processImportSymbols(
+          useNodeB,
+          rustCrateMap,
+          undefined,
+          testDir,
+        );
+
+        expect(resultA!.importPath).toBe(resultB!.importPath);
+        // Neither resolves to the bare crate directory -- the fabrication
+        // this whole fix exists to eliminate.
+        expect(stripRustModMarker(resultA!.importPath)).not.toBe('serde_derive/src');
+        expect(hasRustModMarker(resultA!.importPath)).toBe(true);
       });
     });
 

--- a/packages/parser/src/ast/languages/rust.ts
+++ b/packages/parser/src/ast/languages/rust.ts
@@ -580,11 +580,23 @@ function resolveRustRelativeModulePath(
  *   precisely via `resolveRustRelativeModulePath` instead of the old
  *   directory-less/pseudo-relative string. Omitted callers (and any caller
  *   predating #928) keep the exact previous behavior.
+ * @param workspaceRoot - Absolute project root (#1056). Together with
+ *   `symbolName`, lets a bare crate-root import (`tokio_test` from `use
+ *   tokio_test::Symbol;` -- no further path segment for `resolveRustCrateImport`
+ *   to strip) resolve to the ONE file that actually declares `Symbol`,
+ *   instead of falling back to the crate's whole directory. Ignored (and
+ *   harmless) for the `crate::`/`self::`/`super::`-prefixed branches above,
+ *   which never reach `resolveRustCrateImport` in the first place.
+ * @param symbolName - The single symbol actually being imported (#1056),
+ *   when known at the call site. See `resolveRustCrateImport`'s own doc
+ *   comment for exactly when this matters.
  */
 function convertRustModulePath(
   path: string,
   rustCrateMap?: ReadonlyMap<string, string>,
   importerFile?: string,
+  workspaceRoot?: string,
+  symbolName?: string,
 ): string | null {
   // Remove leading `crate::`, `self::`, or `super::`
   if (path.startsWith('crate::')) {
@@ -600,7 +612,7 @@ function convertRustModulePath(
   }
   // Not crate/self/super-relative — resolve against a known workspace crate
   // (#903), or treat as a genuinely external crate (skip) when it isn't one.
-  return resolveRustCrateImport(path, rustCrateMap);
+  return resolveRustCrateImport(path, rustCrateMap, workspaceRoot, symbolName);
 }
 
 /**
@@ -754,6 +766,7 @@ export class RustImportExtractor implements LanguageImportExtractor {
     node: SyntaxNode,
     rustCrateMap?: ReadonlyMap<string, string>,
     importerFile?: string,
+    workspaceRoot?: string,
   ): { importPath: string; symbols: string[] } | null {
     if (node.type === 'mod_item') {
       // A `mod x;` brings the module NAMESPACE into scope (consumers then
@@ -786,35 +799,39 @@ export class RustImportExtractor implements LanguageImportExtractor {
     const argument = node.childForFieldName('argument');
     if (!argument) return null;
 
-    return this.processUseArgument(argument, rustCrateMap, importerFile);
+    return this.processUseArgument(argument, rustCrateMap, importerFile, workspaceRoot);
   }
 
   processImportSymbolsList(
     node: SyntaxNode,
     rustCrateMap?: ReadonlyMap<string, string>,
     importerFile?: string,
+    workspaceRoot?: string,
   ): Array<{ importPath: string; symbols: string[] }> {
-    return toImportSymbolsArray(this.processImportSymbols(node, rustCrateMap, importerFile));
+    return toImportSymbolsArray(
+      this.processImportSymbols(node, rustCrateMap, importerFile, workspaceRoot),
+    );
   }
 
   private processUseArgument(
     node: SyntaxNode,
     rustCrateMap?: ReadonlyMap<string, string>,
     importerFile?: string,
+    workspaceRoot?: string,
   ): { importPath: string; symbols: string[] } | null {
     // Simple: `use crate::auth::AuthService;`
     if (node.type === 'scoped_identifier') {
-      return this.processScopedIdentifier(node, rustCrateMap, importerFile);
+      return this.processScopedIdentifier(node, rustCrateMap, importerFile, workspaceRoot);
     }
 
     // List: `use crate::auth::{AuthService, AuthError};`
     if (node.type === 'scoped_use_list') {
-      return this.processScopedUseList(node, rustCrateMap, importerFile);
+      return this.processScopedUseList(node, rustCrateMap, importerFile, workspaceRoot);
     }
 
     // Alias: `use crate::auth::Service as Auth;`
     if (node.type === 'use_as_clause') {
-      return this.processUseAsClause(node, rustCrateMap, importerFile);
+      return this.processUseAsClause(node, rustCrateMap, importerFile, workspaceRoot);
     }
 
     // Wildcard: `use crate::models::*;`
@@ -834,6 +851,7 @@ export class RustImportExtractor implements LanguageImportExtractor {
     node: SyntaxNode,
     rustCrateMap?: ReadonlyMap<string, string>,
     importerFile?: string,
+    workspaceRoot?: string,
   ): { importPath: string; symbols: string[] } | null {
     const pathNode = node.childForFieldName('path');
     const nameNode = node.childForFieldName('name');
@@ -846,9 +864,26 @@ export class RustImportExtractor implements LanguageImportExtractor {
     // name itself, so combine root + name before converting (mirrors what
     // `resolveFullPath`/`extractImportPath` already derive from the whole
     // node's text for this same statement).
+    //
+    // The non-bare-root branch ALSO passes `nameNode.text` through as
+    // `symbolName` (#1056): when `pathNode.text` is a bare EXTERNAL/workspace
+    // crate name with no submodule segment of its own (e.g. `serde_derive`
+    // from `use serde_derive::Deserialize;`), `convertRustModulePath` has
+    // nothing else to narrow the crate-root export lookup with. Harmless for
+    // every other shape this branch already handles correctly (a genuine
+    // `crate::auth::AuthService` -- `pathNode.text` is `"crate::auth"`, which
+    // short-circuits on the `crate::` prefix before `symbolName` is ever
+    // consulted; or `tokio_util::codec::Framed` -- `rest` is already
+    // non-empty, so `resolveRustCrateImport` ignores `symbolName` too).
     const modulePath = isBareRootToken(pathNode)
       ? convertRustModulePath(`${pathNode.text}::${nameNode.text}`, rustCrateMap, importerFile)
-      : convertRustModulePath(pathNode.text, rustCrateMap, importerFile);
+      : convertRustModulePath(
+          pathNode.text,
+          rustCrateMap,
+          importerFile,
+          workspaceRoot,
+          nameNode.text,
+        );
     if (!modulePath) return null;
 
     return { importPath: modulePath, symbols: [nameNode.text] };
@@ -858,15 +893,34 @@ export class RustImportExtractor implements LanguageImportExtractor {
     node: SyntaxNode,
     rustCrateMap?: ReadonlyMap<string, string>,
     importerFile?: string,
+    workspaceRoot?: string,
   ): { importPath: string; symbols: string[] } | null {
     const scopePath = extractScopePath(node);
     if (!scopePath) return null;
 
-    const modulePath = convertRustModulePath(scopePath, rustCrateMap, importerFile);
-    if (!modulePath) return null;
-
     const useList = node.namedChildren.find(child => child.type === 'use_list');
     if (!useList) return null;
+
+    // First-wins symbol candidate (mirrors `extractScopePath`'s own
+    // "bare-root groups only resolve from the FIRST item" precedent):
+    // used both for a bare `crate`/`self`/`super` root group's existing
+    // behavior below, and now (#1056) as the crate-root export-lookup hint
+    // for a bare EXTERNAL/workspace crate name with no submodule segment of
+    // its own (e.g. `use serde_derive::{Deserialize, Serialize};` --
+    // `scopePath` is just `"serde_derive"`). Harmless for every other shape
+    // (see `processScopedIdentifier`'s doc comment for why
+    // `convertRustModulePath` ignores it there).
+    const firstItem = useList.namedChildren[0];
+    const firstSymbol = firstItem ? extractUseListItemSymbol(firstItem) : null;
+
+    const modulePath = convertRustModulePath(
+      scopePath,
+      rustCrateMap,
+      importerFile,
+      workspaceRoot,
+      firstSymbol ?? undefined,
+    );
+    if (!modulePath) return null;
 
     // Bare-root groups (`use crate::{auth::AuthService, config::Settings}`)
     // only resolved `modulePath` from the FIRST item (see `extractScopePath`),
@@ -875,8 +929,6 @@ export class RustImportExtractor implements LanguageImportExtractor {
     // items (e.g. `Settings`) to the wrong module (`auth`, not `config`).
     const pathNode = node.childForFieldName('path');
     if (pathNode && isBareRootToken(pathNode)) {
-      const firstItem = useList.namedChildren[0];
-      const firstSymbol = firstItem ? extractUseListItemSymbol(firstItem) : null;
       return firstSymbol ? { importPath: modulePath, symbols: [firstSymbol] } : null;
     }
 
@@ -888,6 +940,7 @@ export class RustImportExtractor implements LanguageImportExtractor {
     node: SyntaxNode,
     rustCrateMap?: ReadonlyMap<string, string>,
     importerFile?: string,
+    workspaceRoot?: string,
   ): { importPath: string; symbols: string[] } | null {
     // `use crate::auth::Service as Auth;`
     // The first child is the path (scoped_identifier), alias field has the alias
@@ -898,10 +951,20 @@ export class RustImportExtractor implements LanguageImportExtractor {
     const scopePathNode = pathChild.childForFieldName('path');
     if (!scopePathNode) return null;
 
-    const modulePath = convertRustModulePath(scopePathNode.text, rustCrateMap, importerFile);
+    // The PRE-alias name is what a crate-root export lookup needs to key on
+    // (#1056) -- the alias is a purely local rename, never part of the
+    // exporting crate's own public API.
+    const originalName = pathChild.childForFieldName('name')?.text;
+    const modulePath = convertRustModulePath(
+      scopePathNode.text,
+      rustCrateMap,
+      importerFile,
+      workspaceRoot,
+      originalName,
+    );
     if (!modulePath) return null;
 
-    const symbol = aliasNode?.text || pathChild.childForFieldName('name')?.text;
+    const symbol = aliasNode?.text || originalName;
     if (!symbol) return null;
 
     return { importPath: modulePath, symbols: [symbol] };
@@ -920,6 +983,11 @@ export class RustImportExtractor implements LanguageImportExtractor {
     const scopedId = node.namedChildren.find(child => child.type === 'scoped_identifier');
     if (!scopedId) return null;
 
+    // No single `symbolName` to pass here (#1056): a wildcard names EVERY
+    // export of the target, not one. A bare EXTERNAL crate wildcard (`use
+    // some_crate::*;`, vanishingly rare in practice) simply resolves to
+    // nothing now instead of the old crate-wide directory fabrication --
+    // still a strict improvement.
     const modulePath = convertRustModulePath(scopedId.text, rustCrateMap, importerFile);
     if (!modulePath) return null;
     return { importPath: modulePath, symbols: ['*'] };

--- a/packages/parser/src/ast/symbols.ts
+++ b/packages/parser/src/ast/symbols.ts
@@ -67,6 +67,15 @@ export interface ManifestRoots {
    */
   rustCrateMap?: ReadonlyMap<string, string>;
   /**
+   * NOTE: `workspaceRoot` (declared above, shared with PHP/Python/JVM) is
+   * ALSO threaded to Rust's `processImportSymbolsList` for the same reason
+   * `rustCrateMap` is (#1056): resolving a bare crate-root import (`use
+   * crate_name::Symbol;`) needs the absolute project root to read the
+   * target crate's own root file (`../rust-crate-exports.ts`'s
+   * `resolveRustCrateRootExport`) when deciding which specific file declares
+   * `Symbol`, rather than fabricating a match against the whole crate.
+   */
+  /**
    * Java/Kotlin conventional Maven/Gradle source-set directories (#1046 /
    * #1005 Mechanism 1) — e.g. `src/main/java`, `klaxon/src/main/kotlin` for a
    * multi-module build. See `../jvm-source-root.ts`. Consumed by
@@ -379,6 +388,7 @@ function extractSymbolsWithExtractor(
       node,
       manifestRoots?.rustCrateMap,
       rustImporterFile,
+      manifestRoots?.workspaceRoot,
     );
     for (const result of results) {
       const key = resolveImportSpecifier(

--- a/packages/parser/src/dependency-analyzer.test.ts
+++ b/packages/parser/src/dependency-analyzer.test.ts
@@ -1,16 +1,19 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs/promises';
+import fsSync from 'fs';
 import os from 'os';
 import path from 'path';
 import {
   analyzeDependencies,
+  findDependents,
   findReExportedSymbolsForFile,
   chunkImportsFrom,
-  findDependents,
   COMPLEXITY_THRESHOLDS,
 } from './dependency-analyzer.js';
 import { chunkByAST } from './ast/chunker.js';
 import { clearGoModuleCache } from './go-module.js';
+import { clearRustCrateMapCache } from './rust-crate-map.js';
+import { clearRustCrateExportCache } from './rust-crate-exports.js';
 import type { CodeChunk, ChunkMetadata } from './types.js';
 
 describe('analyzeDependencies', () => {
@@ -1326,5 +1329,173 @@ describe('findDependents (Go root-package export-lookup recovery, #1039)', () =>
 
     const result = findDependents(chunks, 'src/context.ts', noopLog, workspaceRoot);
     expect(result.dependentAttributionPartial).toBeUndefined();
+  });
+});
+
+describe('bare crate-root `use` edges end-to-end (#1056 regression)', () => {
+  // The real serde/serde_derive repro: `use serde_derive::Deserialize;` (a
+  // cross-crate import naming only the crate + a symbol, no submodule path)
+  // resolved to the crate's bare `src/` directory, which -- because
+  // `crateDir` for a WORKSPACE MEMBER crate is a multi-segment path
+  // (`serde_derive/src`, not the single-segment `src` a non-workspace
+  // project's own crate gets) -- fuzzy-matched every file the crate
+  // contains via `matchesFile`'s Go-style package-directory leniency.
+  // Confirmed on a real clone: two unrelated files (`serde_derive/src/de.rs`,
+  // `serde_derive/src/dummy.rs`) returned an IDENTICAL 144-file dependent
+  // list. This needs a REAL Cargo workspace on disk (`resolveRustCrateMap`
+  // reads `Cargo.toml` from the filesystem, not from synthetic chunks), so
+  // -- unlike #1021/#1028's in-memory fixtures above -- this writes actual
+  // files to a temp directory and parses them via `chunkByAST`'s
+  // `workspaceRoot` option.
+  //
+  // Uses `findDependents` (not `analyzeDependencies`, used by the fixtures
+  // above): `get_dependents` -- this bug's actual symptom -- is a thin
+  // wrapper over `findDependents`, and only `findDependents`'s import index
+  // (`addChunkToImportIndex`) indexes `chunk.metadata.importedSymbols` keys
+  // alongside the raw `imports` array; `analyzeDependencies`'s own index
+  // (`buildImportIndex`, used for complexity-report risk analysis) only
+  // reads `imports` and would not exercise this fix at all.
+  function noopLog(): void {
+    // Intentionally empty -- this suite only cares about resolved counts.
+  }
+
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = fsSync.mkdtempSync(path.join(os.tmpdir(), 'lien-test-dep-analyzer-rust-1056-'));
+  });
+
+  afterEach(() => {
+    clearRustCrateMapCache();
+    clearRustCrateExportCache();
+    fsSync.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  /** Parse `content` as `relPath` within `testDir`'s Cargo workspace (writes it to disk first — `resolveRustCrateMap` needs a real `Cargo.toml` to read). */
+  function chunkInWorkspace(relPath: string, content: string) {
+    const abs = path.join(testDir, relPath);
+    fsSync.mkdirSync(path.dirname(abs), { recursive: true });
+    fsSync.writeFileSync(abs, content);
+    return chunkByAST(relPath, content, { workspaceRoot: testDir });
+  }
+
+  function setUpWorkspace(): void {
+    fsSync.writeFileSync(
+      path.join(testDir, 'Cargo.toml'),
+      '[workspace]\nmembers = ["main_crate", "lib_macro"]\n',
+    );
+    fsSync.mkdirSync(path.join(testDir, 'main_crate'), { recursive: true });
+    fsSync.writeFileSync(
+      path.join(testDir, 'main_crate/Cargo.toml'),
+      '[package]\nname = "main_crate"\nversion = "0.1.0"\n',
+    );
+    fsSync.mkdirSync(path.join(testDir, 'lib_macro'), { recursive: true });
+    fsSync.writeFileSync(
+      path.join(testDir, 'lib_macro/Cargo.toml'),
+      '[package]\nname = "lib_macro"\nversion = "0.1.0"\n',
+    );
+  }
+
+  it('DISTINCTNESS: two unrelated files in the same crate do not share a fabricated crate-wide dependent list', () => {
+    setUpWorkspace();
+
+    const chunks = [
+      // lib_macro's own crate root: `Symbol` is a proc-macro-derive name
+      // declared directly here, exactly like serde_derive's real shape.
+      ...chunkInWorkspace(
+        'lib_macro/src/lib.rs',
+        [
+          'mod helper_a;',
+          'mod helper_b;',
+          '',
+          '#[proc_macro_derive(Symbol)]',
+          'pub fn derive_symbol(input: TokenStream) -> TokenStream {',
+          '    unimplemented!()',
+          '}',
+        ].join('\n'),
+      ),
+      // Two UNRELATED files inside lib_macro -- neither declares or
+      // re-exports `Symbol`, and they have nothing to do with each other.
+      ...chunkInWorkspace('lib_macro/src/helper_a.rs', 'pub fn a_helper() -> u32 { 1 }\n'),
+      ...chunkInWorkspace('lib_macro/src/helper_b.rs', 'pub fn b_helper() -> u32 { 2 }\n'),
+      // main_crate consumes lib_macro by its published name (the ordinary
+      // shape for a workspace member consuming another member's public API).
+      ...chunkInWorkspace(
+        'main_crate/src/lib.rs',
+        'use lib_macro::Symbol;\n\n#[derive(Symbol)]\npub struct Thing;\n',
+      ),
+    ];
+
+    const depsA = findDependents(
+      chunks,
+      'lib_macro/src/helper_a.rs',
+      noopLog,
+      testDir,
+    ).dependents.map(d => d.filepath);
+    const depsB = findDependents(
+      chunks,
+      'lib_macro/src/helper_b.rs',
+      noopLog,
+      testDir,
+    ).dependents.map(d => d.filepath);
+    const depsLib = findDependents(chunks, 'lib_macro/src/lib.rs', noopLog, testDir).dependents.map(
+      d => d.filepath,
+    );
+
+    // Each helper's only REAL dependent is `lib.rs` itself (via its own
+    // `mod helper_a;`/`mod helper_b;` declaration) -- neither actually
+    // declares or re-exports `Symbol`. The core #1056 bug shape: before the
+    // fix, BOTH helpers additionally fabricated `main_crate/src/lib.rs` as a
+    // dependent too, via the bare crate-wide directory match.
+    expect(depsA).toEqual(['lib_macro/src/lib.rs']);
+    expect(depsB).toEqual(['lib_macro/src/lib.rs']);
+    // The ONE real edge for lib.rs itself: main_crate consumes what
+    // lib_macro's OWN root file declares.
+    expect(depsLib).toEqual(['main_crate/src/lib.rs']);
+  });
+
+  it('still resolves the real edge when the bare crate-root symbol truly is a top-level pub item', () => {
+    setUpWorkspace();
+
+    const chunks = [
+      ...chunkInWorkspace('lib_macro/src/lib.rs', 'pub fn helper() -> u32 {\n    42\n}\n'),
+      ...chunkInWorkspace(
+        'main_crate/src/lib.rs',
+        'use lib_macro::helper;\n\npub fn run() -> u32 {\n    helper()\n}\n',
+      ),
+    ];
+
+    expect(
+      findDependents(chunks, 'lib_macro/src/lib.rs', noopLog, testDir).dependents.map(
+        d => d.filepath,
+      ),
+    ).toEqual(['main_crate/src/lib.rs']);
+  });
+
+  it('emits nothing (honest gap) rather than fabricating when the symbol cannot be found in the crate root file', () => {
+    setUpWorkspace();
+
+    const chunks = [
+      ...chunkInWorkspace('lib_macro/src/lib.rs', 'mod helper_a;\n'),
+      ...chunkInWorkspace('lib_macro/src/helper_a.rs', 'pub fn a_helper() -> u32 { 1 }\n'),
+      // `a_helper` is real, but only reachable via `helper_a::a_helper()`,
+      // not re-exported from the crate root -- this v1 export lookup
+      // deliberately doesn't trace that chain (see rust-crate-exports.ts).
+      ...chunkInWorkspace(
+        'main_crate/src/lib.rs',
+        'use lib_macro::a_helper;\n\npub fn run() -> u32 {\n    a_helper()\n}\n',
+      ),
+    ];
+
+    // lib.rs has no dependents of its own (nothing imports IT bare); the
+    // real `mod helper_a;` edge is the only relationship in this fixture,
+    // and main_crate's unresolvable `a_helper` import must not fabricate a
+    // second one onto either file.
+    expect(findDependents(chunks, 'lib_macro/src/lib.rs', noopLog, testDir).dependents).toEqual([]);
+    expect(
+      findDependents(chunks, 'lib_macro/src/helper_a.rs', noopLog, testDir).dependents.map(
+        d => d.filepath,
+      ),
+    ).toEqual(['lib_macro/src/lib.rs']);
   });
 });

--- a/packages/parser/src/rust-crate-exports.test.ts
+++ b/packages/parser/src/rust-crate-exports.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { resolveRustCrateRootExport, clearRustCrateExportCache } from './rust-crate-exports.js';
+import { hasRustModMarker, stripRustModMarker } from './utils/rust-mod-marker.js';
+
+describe('resolveRustCrateRootExport', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-rust-crate-exports-'));
+  });
+
+  afterEach(async () => {
+    clearRustCrateExportCache();
+    await fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  async function writeFile(relPath: string, content: string): Promise<void> {
+    const abs = path.join(testDir, relPath);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, content);
+  }
+
+  function resolveAndStrip(crateDir: string, symbolName: string): string | null {
+    const resolved = resolveRustCrateRootExport(testDir, crateDir, symbolName);
+    if (resolved === null) return null;
+    expect(hasRustModMarker(resolved)).toBe(true);
+    return stripRustModMarker(resolved);
+  }
+
+  it('resolves a proc-macro-derive name declared directly in the crate root (the serde_derive repro)', async () => {
+    await writeFile(
+      'my_crate/src/lib.rs',
+      [
+        '#[proc_macro_derive(Deserialize, attributes(serde))]',
+        'pub fn derive_deserialize(input: TokenStream) -> TokenStream {',
+        '    unimplemented!()',
+        '}',
+      ].join('\n'),
+    );
+
+    expect(resolveAndStrip('my_crate/src', 'Deserialize')).toBe('my_crate/src/lib');
+  });
+
+  it('resolves a plain top-level pub fn/struct/enum/trait/type/const/static/mod', async () => {
+    await writeFile(
+      'my_crate/src/lib.rs',
+      [
+        'pub fn helper() {}',
+        'pub struct Config {}',
+        'pub enum Status {}',
+        'pub trait Doer {}',
+        'pub type Alias = u32;',
+        'pub const VALUE: u32 = 1;',
+        'pub static GLOBAL: u32 = 2;',
+        'pub mod submodule;',
+      ].join('\n'),
+    );
+
+    for (const name of [
+      'helper',
+      'Config',
+      'Status',
+      'Doer',
+      'Alias',
+      'VALUE',
+      'GLOBAL',
+      'submodule',
+    ]) {
+      expect(resolveAndStrip('my_crate/src', name)).toBe('my_crate/src/lib');
+    }
+  });
+
+  // Lien Review finding (PR #1065): the original regex required `fn`/`trait`/
+  // etc. immediately after the visibility modifier, so `pub async fn`/`pub
+  // const fn`/`pub unsafe fn`/`pub unsafe trait` silently failed to match at
+  // all -- an honest gap, but a wrong one for a common Rust shape.
+  it('resolves pub items with async/const/unsafe/extern modifiers between `pub` and the declaration keyword', async () => {
+    await writeFile(
+      'my_crate/src/lib.rs',
+      [
+        'pub async fn fetch() {}',
+        'pub const fn compute() -> u32 { 1 }',
+        'pub unsafe fn danger() {}',
+        'pub unsafe trait Marker {}',
+        'pub const unsafe fn both() -> u32 { 2 }',
+        'pub unsafe extern "C" fn ffi_call() {}',
+      ].join('\n'),
+    );
+
+    expect(resolveAndStrip('my_crate/src', 'fetch')).toBe('my_crate/src/lib');
+    expect(resolveAndStrip('my_crate/src', 'compute')).toBe('my_crate/src/lib');
+    expect(resolveAndStrip('my_crate/src', 'danger')).toBe('my_crate/src/lib');
+    expect(resolveAndStrip('my_crate/src', 'Marker')).toBe('my_crate/src/lib');
+    expect(resolveAndStrip('my_crate/src', 'both')).toBe('my_crate/src/lib');
+    expect(resolveAndStrip('my_crate/src', 'ffi_call')).toBe('my_crate/src/lib');
+  });
+
+  it('still resolves a plain `pub const NAME: T = ...;` item despite `const` also being a valid modifier keyword', async () => {
+    await writeFile('my_crate/src/lib.rs', 'pub const VALUE: u32 = 42;\n');
+
+    expect(resolveAndStrip('my_crate/src', 'VALUE')).toBe('my_crate/src/lib');
+  });
+
+  it('does not misattribute a same-named item nested inside an impl block (column-0 anchoring)', async () => {
+    await writeFile(
+      'my_crate/src/lib.rs',
+      ['pub struct Thing;', '', 'impl Thing {', '    pub fn helper() {}', '}'].join('\n'),
+    );
+
+    // "helper" is only ever declared INSIDE the impl block (indented), so a
+    // column-0-anchored scan must not find it as a crate-root export.
+    expect(resolveRustCrateRootExport(testDir, 'my_crate/src', 'helper')).toBeNull();
+  });
+
+  it('falls back to main.rs when there is no lib.rs', async () => {
+    await writeFile('my_bin/src/main.rs', 'pub fn run() {}\n');
+
+    expect(resolveAndStrip('my_bin/src', 'run')).toBe('my_bin/src/main');
+  });
+
+  it('returns null (honest gap) when the symbol is not found in the crate root file', async () => {
+    await writeFile('my_crate/src/lib.rs', 'pub fn helper() {}\n');
+
+    // "helper" is real; "somethingElse" is not declared anywhere in the
+    // crate root file (e.g. only reachable via a re-export chain this v1
+    // lookup deliberately doesn't trace).
+    expect(resolveRustCrateRootExport(testDir, 'my_crate/src', 'somethingElse')).toBeNull();
+  });
+
+  it('returns null when the crate has neither lib.rs nor main.rs', () => {
+    expect(resolveRustCrateRootExport(testDir, 'ghost_crate/src', 'Anything')).toBeNull();
+  });
+
+  it('DISTINCTNESS: two unrelated crates resolve the same symbol name to their OWN different root files', async () => {
+    await writeFile('crate_a/src/lib.rs', 'pub fn shared_name() {}\n');
+    await writeFile('crate_b/src/lib.rs', 'pub fn shared_name() {}\n');
+
+    const fromA = resolveAndStrip('crate_a/src', 'shared_name');
+    const fromB = resolveAndStrip('crate_b/src', 'shared_name');
+
+    expect(fromA).toBe('crate_a/src/lib');
+    expect(fromB).toBe('crate_b/src/lib');
+    expect(fromA).not.toBe(fromB);
+  });
+
+  it('caches the export map per (workspaceRoot, crateDir)', async () => {
+    await writeFile('my_crate/src/lib.rs', 'pub fn helper() {}\n');
+
+    const first = resolveRustCrateRootExport(testDir, 'my_crate/src', 'helper');
+    // Rewrite the file after the first lookup -- a cached result should be
+    // unaffected (mirrors resolveRustCrateMap's own caching contract).
+    await writeFile('my_crate/src/lib.rs', 'pub fn renamed() {}\n');
+    const second = resolveRustCrateRootExport(testDir, 'my_crate/src', 'helper');
+
+    expect(second).toBe(first);
+    expect(resolveRustCrateRootExport(testDir, 'my_crate/src', 'renamed')).toBeNull();
+  });
+});

--- a/packages/parser/src/rust-crate-exports.ts
+++ b/packages/parser/src/rust-crate-exports.ts
@@ -1,0 +1,169 @@
+import fs from 'fs';
+import path from 'path';
+
+import { markRustModSpecifier } from './utils/rust-mod-marker.js';
+
+/**
+ * Resolves a symbol name to the ONE file, within a known workspace crate,
+ * that actually declares/exports it -- read directly from the crate's own
+ * root file (`lib.rs`/`main.rs`), rather than crediting the whole crate
+ * directory (#1056).
+ *
+ * Why this exists: `use serde_derive::Deserialize;` (a cross-crate import
+ * naming only the crate + a symbol, no submodule path -- the ordinary shape
+ * for consuming what a crate's `lib.rs` re-exports) gives
+ * `resolveRustCrateImport` (`./rust-crate-map.ts`) a module path with nothing
+ * left to strip after the crate name (`rest === ''`). Falling back to the
+ * bare `crateDir` there -- as this codebase did before #1056 -- turns "which
+ * ONE file exports this symbol" into "every file in the crate", via
+ * `matchesFile`'s Go-style package-directory leniency (`singleFileImports:
+ * false` on Rust's `LanguageDefinition`, needed elsewhere for legitimate
+ * `crate::`-relative imports): a bare multi-segment specifier like
+ * `serde_derive/src` matches ANY target continuing past it at a `/`
+ * boundary, i.e. literally every file the crate contains. Confirmed on a
+ * real `serde-rs/serde` clone: `serde_derive/src/de.rs` and
+ * `serde_derive/src/dummy.rs` -- two unrelated files with nothing to do with
+ * each other -- returned the IDENTICAL 144-file dependent list, because
+ * every consumer of `serde_derive::{Deserialize, Serialize}` (`serde/src/
+ * lib.rs`'s own re-export, plus 143 `test_suite/tests/**` fixtures) resolved
+ * to that one bare crate-wide specifier.
+ *
+ * v1 scope (deliberately KISS/YAGNI, matching #903's precedent for this same
+ * file): only ONE hop, read directly off the crate's own root file text --
+ * no re-export CHAIN tracing (`pub use` in `lib.rs` pointing at a symbol
+ * that's itself only re-exported ANOTHER level down). Two shapes resolve:
+ *
+ * 1. A top-level (column-0, i.e. not nested inside an `impl`/`fn`/`mod`
+ *    body) `pub` item -- `fn`/`struct`/`enum`/`trait`/`type`/`const`/
+ *    `static`/`mod` -- declared BY NAME directly in the root file. Anchoring
+ *    to column 0 is a deliberate, cheap way to avoid a same-named nested
+ *    item (e.g. a method inside an `impl` block) being misread as a crate-
+ *    root export -- idiomatic (`cargo fmt`-formatted) Rust never indents a
+ *    top-level item, so this is a safe, high-precision heuristic rather than
+ *    a full parse.
+ * 2. A `#[proc_macro_derive(Name, ...)]`-annotated function -- the derive
+ *    macro's PUBLIC name is the identifier inside the attribute, not the
+ *    underlying function's own name, and the Rust compiler requires these to
+ *    be declared at the crate root (E0725), so this is unconditionally safe
+ *    to treat as a root-level export regardless of indentation. This is the
+ *    EXACT shape that resolves the serde/serde_derive repro above: `serde_
+ *    derive::Deserialize`/`Serialize` are proc-macro-derive names declared
+ *    directly in `serde_derive/src/lib.rs`, not re-exported from anywhere
+ *    else in the crate.
+ *
+ * Anything else -- most commonly a symbol that's only reachable via a `pub
+ * use` re-export chain through an intermediate module -- returns `null`
+ * (`resolveRustCrateImport`'s caller then emits nothing for that specifier,
+ * rather than a fabricated match): an honest gap beats a fabricated one, per
+ * this codebase's index-state-honesty policy. A future enhancement could
+ * trace ONE level of `pub use crate::x::Name;`/`pub use self::x::{A, B}`
+ * re-exports too; deliberately out of scope here since the reported bug's
+ * exact repro (proc-macro-derive names) doesn't need it and a half-traced
+ * re-export chain is its own new fabrication risk to get right.
+ *
+ * The resolved path is tagged with `markRustModSpecifier` (reused from
+ * #1021's `mod x;` fix -- see `./utils/rust-mod-marker.ts`'s doc comment):
+ * it names EXACTLY one file (never a directory whose children should also
+ * match), the identical guarantee `mod x;` resolution already relies on that
+ * marker for, so `matchesRustModSpecifier`'s exact-or-`/mod`-suffix matching
+ * is the correct (and only safe) way to resolve it downstream too.
+ */
+
+/**
+ * Per-workspace-root cache of per-crate-directory export maps (symbol name ->
+ * resolved file). Nested (rather than a single Map with a concatenated
+ * string key) to sidestep needing a separator character that's guaranteed
+ * never to collide between a `workspaceRoot` and a `crateDir`.
+ */
+const rootExportCache = new Map<string, Map<string, Map<string, string> | null>>();
+
+/** Clears the cached crate-root export maps. Exported for test isolation. */
+export function clearRustCrateExportCache(): void {
+  rootExportCache.clear();
+}
+
+/** A `#[proc_macro_derive(Name` (optionally followed by `, attributes(...)`) attribute's `Name`. */
+const PROC_MACRO_DERIVE_RE = /^\s*#\s*\[\s*proc_macro_derive\s*\(\s*([A-Za-z_]\w*)/gm;
+
+/**
+ * A top-level (column-0, i.e. un-indented) `pub` item declaration --
+ * `pub fn foo`, `pub(crate) struct Bar`, etc. Anchored to the start of the
+ * line (no leading whitespace) so a same-named item nested inside an
+ * `impl`/`fn`/`mod` body -- always indented in idiomatic Rust -- isn't
+ * mistaken for a crate-root export (see this file's doc comment).
+ */
+const TOP_LEVEL_PUB_ITEM_RE =
+  /^pub(?:\([^)]*\))?\s+(?:fn|struct|enum|trait|type|const|static|mod)\s+([A-Za-z_]\w*)/gm;
+
+/** Every name this crate root file exports directly (see the two shapes in the file's doc comment). */
+function collectRootExportNames(content: string): Set<string> {
+  const names = new Set<string>();
+  for (const match of content.matchAll(PROC_MACRO_DERIVE_RE)) names.add(match[1]);
+  for (const match of content.matchAll(TOP_LEVEL_PUB_ITEM_RE)) names.add(match[1]);
+  return names;
+}
+
+/** The crate's root file (`lib.rs`, else `main.rs`) — its content and its own extensionless, workspace-relative path — or `null` if neither exists. */
+function readCrateRootFile(
+  workspaceRoot: string,
+  crateDir: string,
+): { relPath: string; content: string } | null {
+  for (const rootBasename of ['lib.rs', 'main.rs']) {
+    const relPath = `${crateDir}/${rootBasename}`;
+    try {
+      const content = fs.readFileSync(path.join(workspaceRoot, relPath), 'utf-8');
+      return { relPath: relPath.replace(/\.rs$/, ''), content };
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+/** Build (uncached) the symbol -> resolved-file map for one crate's root file. */
+function buildRootExportMap(workspaceRoot: string, crateDir: string): Map<string, string> | null {
+  const rootFile = readCrateRootFile(workspaceRoot, crateDir);
+  if (!rootFile) return null;
+
+  const names = collectRootExportNames(rootFile.content);
+  if (names.size === 0) return null;
+
+  const map = new Map<string, string>();
+  for (const name of names) map.set(name, rootFile.relPath);
+  return map;
+}
+
+/** The cached (or newly-built) export map for one `(workspaceRoot, crateDir)` pair. */
+function getRootExportMap(workspaceRoot: string, crateDir: string): Map<string, string> | null {
+  let byCrateDir = rootExportCache.get(workspaceRoot);
+  if (!byCrateDir) {
+    byCrateDir = new Map();
+    rootExportCache.set(workspaceRoot, byCrateDir);
+  }
+
+  let exportMap = byCrateDir.get(crateDir);
+  if (exportMap === undefined) {
+    exportMap = buildRootExportMap(workspaceRoot, crateDir);
+    byCrateDir.set(crateDir, exportMap);
+  }
+  return exportMap;
+}
+
+/**
+ * Resolve `symbolName` to the specific (marked, exact-match-only) file that
+ * declares it in `crateDir`'s own root file, or `null` when it can't be
+ * determined from that file alone.
+ *
+ * @param workspaceRoot - Absolute path to the project root.
+ * @param crateDir - The crate's `src/`-relative directory, from
+ *   `resolveRustCrateMap` (e.g. `serde_derive/src`).
+ * @param symbolName - The symbol being imported (e.g. `Deserialize`).
+ */
+export function resolveRustCrateRootExport(
+  workspaceRoot: string,
+  crateDir: string,
+  symbolName: string,
+): string | null {
+  const resolved = getRootExportMap(workspaceRoot, crateDir)?.get(symbolName);
+  return resolved ? markRustModSpecifier(resolved) : null;
+}

--- a/packages/parser/src/rust-crate-exports.ts
+++ b/packages/parser/src/rust-crate-exports.ts
@@ -87,13 +87,27 @@ const PROC_MACRO_DERIVE_RE = /^\s*#\s*\[\s*proc_macro_derive\s*\(\s*([A-Za-z_]\w
 
 /**
  * A top-level (column-0, i.e. un-indented) `pub` item declaration --
- * `pub fn foo`, `pub(crate) struct Bar`, etc. Anchored to the start of the
- * line (no leading whitespace) so a same-named item nested inside an
- * `impl`/`fn`/`mod` body -- always indented in idiomatic Rust -- isn't
- * mistaken for a crate-root export (see this file's doc comment).
+ * `pub fn foo`, `pub(crate) struct Bar`, `pub async fn foo`, `pub unsafe
+ * extern "C" fn foo`, etc. Anchored to the start of the line (no leading
+ * whitespace) so a same-named item nested inside an `impl`/`fn`/`mod` body --
+ * always indented in idiomatic Rust -- isn't mistaken for a crate-root
+ * export (see this file's doc comment).
+ *
+ * Allows any of `async`/`const`/`unsafe`/`extern "ABI"` between the
+ * visibility modifier and the declaration keyword (Rust lets these combine,
+ * e.g. `pub const unsafe fn`, `pub unsafe extern "C" fn`) -- without this,
+ * `pub async fn helper()` failed to match at all (`async` isn't itself one
+ * of the declaration keywords), silently dropping `helper` from the export
+ * map and resolving `use my_crate::helper;` to `null` instead of the crate
+ * root file. `const` doing double duty (both a modifier, `pub const fn`, and
+ * a standalone item keyword, `pub const NAME: T = ...;`) is resolved by
+ * ordinary regex backtracking: greedily consuming it as a modifier fails the
+ * mandatory keyword alternation for a plain const item (no `fn`/`struct`/...
+ * follows), so the engine backs off to zero modifiers and matches `const`
+ * itself as the item keyword instead.
  */
 const TOP_LEVEL_PUB_ITEM_RE =
-  /^pub(?:\([^)]*\))?\s+(?:fn|struct|enum|trait|type|const|static|mod)\s+([A-Za-z_]\w*)/gm;
+  /^pub(?:\([^)]*\))?\s+(?:(?:async|const|unsafe|extern(?:\s+"[^"]*")?)\s+)*(?:fn|struct|enum|trait|type|const|static|mod)\s+([A-Za-z_]\w*)/gm;
 
 /** Every name this crate root file exports directly (see the two shapes in the file's doc comment). */
 function collectRootExportNames(content: string): Set<string> {

--- a/packages/parser/src/rust-crate-map.test.ts
+++ b/packages/parser/src/rust-crate-map.test.ts
@@ -7,6 +7,8 @@ import {
   resolveRustCrateImport,
   clearRustCrateMapCache,
 } from './rust-crate-map.js';
+import { clearRustCrateExportCache } from './rust-crate-exports.js';
+import { hasRustModMarker, stripRustModMarker } from './utils/rust-mod-marker.js';
 
 describe('resolveRustCrateMap', () => {
   let testDir: string;
@@ -164,9 +166,15 @@ describe('resolveRustCrateImport', () => {
     );
   });
 
-  it('resolves a bare crate-root import (no further path) to the crate dir itself', () => {
+  it('returns null for a bare crate-root import when there is no workspaceRoot/symbolName to look up an export with (#1056)', () => {
+    // Before #1056 this resolved to the crate's bare `src` dir itself,
+    // which fabricated a match against EVERY file the crate contains (see
+    // resolveRustCrateImport's own doc comment, and the describe block
+    // below for the real serde/serde_derive repro). Without a
+    // workspaceRoot/symbolName to attempt a crate-root export lookup with,
+    // the honest answer is "unresolved", not "the whole crate".
     const crateMap = new Map([['tokio_test', 'tokio-test/src']]);
-    expect(resolveRustCrateImport('tokio_test', crateMap)).toBe('tokio-test/src');
+    expect(resolveRustCrateImport('tokio_test', crateMap)).toBeNull();
   });
 
   it('leaves a genuinely external crate unresolved (returns null) -- no guessing, #868 precedent', () => {
@@ -179,5 +187,125 @@ describe('resolveRustCrateImport', () => {
     // "tokio_util_extra" must not be treated as the "tokio_util" crate.
     const crateMap = new Map([['tokio_util', 'tokio-util/src']]);
     expect(resolveRustCrateImport('tokio_util_extra::foo', crateMap)).toBeNull();
+  });
+
+  // #1056: a bare crate-root import (`use serde_derive::Deserialize;` -- no
+  // submodule path between the crate name and the symbol) used to resolve
+  // to the crate's bare `src` directory, fabricating an identical dependent
+  // list for every file the crate contains. With a `workspaceRoot` on hand,
+  // it now narrows to the ONE file that actually declares the symbol, via a
+  // crate-root export lookup (`resolveRustCrateRootExport`), or emits
+  // nothing when that can't be determined.
+  describe('bare crate-root export lookup (#1056)', () => {
+    let testDir: string;
+
+    beforeEach(async () => {
+      testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-rust-crate-exports-'));
+    });
+
+    afterEach(async () => {
+      clearRustCrateExportCache();
+      await fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+    });
+
+    async function writeFile(relPath: string, content: string): Promise<void> {
+      const abs = path.join(testDir, relPath);
+      await fs.mkdir(path.dirname(abs), { recursive: true });
+      await fs.writeFile(abs, content);
+    }
+
+    it('resolves the serde/serde_derive repro: a proc-macro-derive name declared directly in the crate root', async () => {
+      // The exact real-world shape from the issue: `Deserialize`/`Serialize`
+      // are proc-macro-derive names declared directly in
+      // `serde_derive/src/lib.rs` (`#[proc_macro_derive(Deserialize, ...)]`),
+      // not re-exported from anywhere else in the crate.
+      await writeFile(
+        'serde_derive/src/lib.rs',
+        [
+          '#[proc_macro_derive(Deserialize, attributes(serde))]',
+          'pub fn derive_deserialize(input: TokenStream) -> TokenStream {',
+          '    unimplemented!()',
+          '}',
+          '',
+          '#[proc_macro_derive(Serialize, attributes(serde))]',
+          'pub fn derive_serialize(input: TokenStream) -> TokenStream {',
+          '    unimplemented!()',
+          '}',
+        ].join('\n'),
+      );
+      const crateMap = new Map([['serde_derive', 'serde_derive/src']]);
+
+      const resolved = resolveRustCrateImport('serde_derive', crateMap, testDir, 'Deserialize');
+      expect(resolved).not.toBeNull();
+      expect(hasRustModMarker(resolved!)).toBe(true);
+      expect(stripRustModMarker(resolved!)).toBe('serde_derive/src/lib');
+    });
+
+    it('resolves a plain top-level pub item declared directly in the crate root', async () => {
+      await writeFile('my_crate/src/lib.rs', 'pub fn helper() {}\n\npub struct Config {}\n');
+      const crateMap = new Map([['my_crate', 'my_crate/src']]);
+
+      expect(resolveRustCrateImport('my_crate', crateMap, testDir, 'helper')).not.toBeNull();
+      expect(
+        stripRustModMarker(resolveRustCrateImport('my_crate', crateMap, testDir, 'Config')!),
+      ).toBe('my_crate/src/lib');
+    });
+
+    it('does not misattribute a same-named item nested inside an impl block (column-0 anchoring)', async () => {
+      await writeFile(
+        'my_crate/src/lib.rs',
+        ['pub struct Thing;', '', 'impl Thing {', '    pub fn helper() {}', '}'].join('\n'),
+      );
+      const crateMap = new Map([['my_crate', 'my_crate/src']]);
+
+      // "helper" is only ever declared INSIDE the impl block (indented), so
+      // a column-0-anchored scan must not find it as a crate-root export.
+      expect(resolveRustCrateImport('my_crate', crateMap, testDir, 'helper')).toBeNull();
+    });
+
+    it('falls back to main.rs when there is no lib.rs', async () => {
+      await writeFile('my_bin/src/main.rs', 'pub fn run() {}\n');
+      const crateMap = new Map([['my_bin', 'my_bin/src']]);
+
+      expect(stripRustModMarker(resolveRustCrateImport('my_bin', crateMap, testDir, 'run')!)).toBe(
+        'my_bin/src/main',
+      );
+    });
+
+    it('returns null (honest gap) when the symbol is not found in the crate root file', async () => {
+      await writeFile('my_crate/src/lib.rs', 'pub fn helper() {}\n');
+      const crateMap = new Map([['my_crate', 'my_crate/src']]);
+
+      // "helper" is real; "somethingElse" is not declared anywhere in the
+      // crate root file (e.g. it's only reachable via a re-export chain
+      // this v1 lookup deliberately doesn't trace -- see
+      // rust-crate-exports.ts's doc comment).
+      expect(resolveRustCrateImport('my_crate', crateMap, testDir, 'somethingElse')).toBeNull();
+    });
+
+    it('returns null when the crate has neither lib.rs nor main.rs', async () => {
+      const crateMap = new Map([['ghost_crate', 'ghost_crate/src']]);
+      expect(resolveRustCrateImport('ghost_crate', crateMap, testDir, 'Anything')).toBeNull();
+    });
+
+    it('DISTINCTNESS: two unrelated crates resolve the same symbol name to their OWN different root files', async () => {
+      // The core #1056 regression check: the bug was never "wrong file",
+      // it was "every file in the crate, identically" -- so the fix must
+      // prove two different crates (each merely happening to export a
+      // same-named symbol) resolve to their OWN distinct files, not a
+      // shared fabricated answer.
+      await writeFile('crate_a/src/lib.rs', 'pub fn shared_name() {}\n');
+      await writeFile('crate_b/src/lib.rs', 'pub fn shared_name() {}\n');
+      const crateMap = new Map([
+        ['crate_a', 'crate_a/src'],
+        ['crate_b', 'crate_b/src'],
+      ]);
+
+      const fromA = resolveRustCrateImport('crate_a', crateMap, testDir, 'shared_name');
+      const fromB = resolveRustCrateImport('crate_b', crateMap, testDir, 'shared_name');
+      expect(stripRustModMarker(fromA!)).toBe('crate_a/src/lib');
+      expect(stripRustModMarker(fromB!)).toBe('crate_b/src/lib');
+      expect(fromA).not.toBe(fromB);
+    });
   });
 });

--- a/packages/parser/src/rust-crate-map.ts
+++ b/packages/parser/src/rust-crate-map.ts
@@ -2,6 +2,8 @@ import fs from 'fs';
 import path from 'path';
 import { globSync } from 'glob';
 
+import { resolveRustCrateRootExport } from './rust-crate-exports.js';
+
 /**
  * Resolves Rust Cargo workspace member crate names to their source
  * directories, building a `Map<crateName (underscore form), crateSrcDir>`
@@ -186,12 +188,43 @@ export function resolveRustCrateMap(workspaceRoot: string): Map<string, string> 
  * in the map, so it's dropped exactly as it was before this fix (#868's "no
  * guessing" precedent: only real workspace members ever resolve).
  *
+ * When `modulePath` is a BARE crate name with no further path segment (`rest`
+ * is empty -- e.g. `serde_derive` from `use serde_derive::Deserialize;`,
+ * once `convertRustModulePath`'s callers have stripped the imported symbol
+ * off into `symbolName`), this used to return the crate's bare `crateDir`
+ * directly. That fabricated an identical, crate-WIDE dependent list for
+ * every file the crate contains (#1056): `matchesFile`'s Go-style package-
+ * directory leniency (`singleFileImports: false` on Rust, needed elsewhere
+ * for legitimate `crate::`-relative imports) treats a bare multi-segment
+ * specifier like `serde_derive/src` as matching ANY target continuing past
+ * it at a `/` boundary -- confirmed on a real `serde-rs/serde` clone, where
+ * two unrelated files in `serde_derive` (`de.rs`, `dummy.rs`) both reported
+ * the identical 144-file "dependent" list, sourced from every consumer of
+ * `serde_derive::{Deserialize, Serialize}` (a bare crate-root import with no
+ * submodule path -- the common shape for consuming what a crate's `lib.rs`
+ * re-exports). Now this narrows to the ONE file that actually declares
+ * `symbolName`, via `resolveRustCrateRootExport` (see `./rust-crate-exports.ts`),
+ * or emits nothing (`null`) when that can't be determined from the crate's
+ * own root file alone -- an honest gap beats a fabricated crate-wide match,
+ * per this codebase's index-state-honesty policy.
+ *
  * @param modulePath - The raw (non-crate/self/super) `use` path.
  * @param crateMap - Map of crate name (underscore form) -> crate `src/` dir, from `resolveRustCrateMap`.
+ * @param workspaceRoot - Absolute project root, needed (alongside `symbolName`)
+ *   to attempt the #1056 bare-crate-root export lookup. Omitted callers (or
+ *   any caller with no single `symbolName` to look up, e.g. a wildcard
+ *   `use crate_name::*;`) simply get `null` for this case instead -- still a
+ *   strict improvement over the old crate-wide fabrication.
+ * @param symbolName - The single symbol actually being imported, when
+ *   `modulePath` is a bare crate name (#1056). Ignored (harmlessly) when
+ *   `modulePath` has further path segments of its own (`rest` is non-empty),
+ *   since those already resolve to a specific-enough path without it.
  */
 export function resolveRustCrateImport(
   modulePath: string,
   crateMap: ReadonlyMap<string, string> | undefined,
+  workspaceRoot?: string,
+  symbolName?: string,
 ): string | null {
   if (!crateMap || crateMap.size === 0) return null;
 
@@ -201,5 +234,10 @@ export function resolveRustCrateImport(
   if (!crateDir) return null;
 
   const rest = sepIndex === -1 ? '' : modulePath.slice(sepIndex + 2).replace(/::/g, '/');
-  return rest ? `${crateDir}/${rest}` : crateDir;
+  if (rest) return `${crateDir}/${rest}`;
+
+  if (workspaceRoot && symbolName) {
+    return resolveRustCrateRootExport(workspaceRoot, crateDir, symbolName);
+  }
+  return null;
 }

--- a/packages/parser/src/utils/path-matching.ts
+++ b/packages/parser/src/utils/path-matching.ts
@@ -390,30 +390,38 @@ export function matchesFile(
 }
 
 /**
- * Rust `mod x;` resolution semantics (#1021): the specifier names EXACTLY
- * one of two files -- `x.rs` (exact match) or `x/mod.rs` (the sole
+ * Rust exact-single-file resolution semantics: the specifier names EXACTLY
+ * one of two files -- itself (exact match) or `<specifier>/mod.rs` (the sole
  * directory-module alternative Rust's file-to-module convention allows) --
- * never a grandchild, an unrelated sibling, or the declaring file itself.
+ * never a grandchild, an unrelated sibling, or (for the #1021 `mod x;`
+ * producer specifically) the declaring file itself. Two producers currently
+ * mark a specifier for this treatment -- see `rust-mod-marker.ts`'s doc
+ * comment: a `mod x;` declaration (#1021, `rustModOwningDirectory` in
+ * `../ast/languages/rust.ts`) and a bare crate-root import resolved via
+ * crate-root export lookup (#1056, `resolveRustCrateRootExport` in
+ * `../rust-crate-exports.ts`).
  *
  * Deliberately bypasses every `matchesFile` strategy: those exist to resolve
- * AMBIGUOUS bare/relative specifiers, but a `mod`-derived specifier (see
- * `rustModOwningDirectory` in `../ast/languages/rust.ts`) is already a fully
- * resolved, directory-anchored path with no remaining ambiguity for a
+ * AMBIGUOUS bare/relative specifiers, but a marked specifier is already a
+ * fully resolved, single-file path with no remaining ambiguity for a
  * boundary-matching heuristic to add. That's exactly what let `matchesFile`
  * fabricate edges to any file continuing past the specifier -- Go
- * package-directory semantics wrongly applied to a Rust `mod`, in BOTH
- * directions: Strategy 2's `requireExactTailForMultiSegment` leniency let
- * `src/thing` (from `mod thing;`) match every file under `src/thing/`, not
- * just `src/thing/mod.rs`; and Strategy 1 -- hardcoded to the same
+ * package-directory semantics wrongly applied to a Rust `mod` (#1021), in
+ * BOTH directions: Strategy 2's `requireExactTailForMultiSegment` leniency
+ * let `src/thing` (from `mod thing;`) match every file under `src/thing/`,
+ * not just `src/thing/mod.rs`; and Strategy 1 -- hardcoded to the same
  * leniency regardless of caller/language, since its `pattern` position is
  * normally a concrete target file, never a package name -- let a LEAF
  * file's own `mod helpers;` specifier (`src/engine/helpers`, longer than
  * the file's own path) match back against `src/engine` itself, fabricating
- * a self-edge.
+ * a self-edge. The #1056 producer guards against the same class of bug for
+ * a bare crate-root import (`use crate_name::Symbol;`): resolving it to the
+ * crate's bare directory (rather than the one file that actually declares
+ * `Symbol`) let it match every file the crate contains.
  *
- * Only called for specifiers carrying the #1021 marker (see
- * `rust-mod-marker.ts`) -- i.e. never for `use crate::...`/`self::`/`super::`
- * specifiers, which keep resolving through `matchesFile` exactly as before.
+ * Only called for specifiers carrying the marker (see `rust-mod-marker.ts`)
+ * -- i.e. never for `use crate::...`/`self::`/`super::` specifiers, which
+ * keep resolving through `matchesFile` exactly as before.
  */
 function matchesRustModSpecifier(normalizedImport: string, normalizedTarget: string): boolean {
   return normalizedImport === normalizedTarget || normalizedTarget === `${normalizedImport}/mod`;
@@ -449,15 +457,15 @@ function matchesRustModSpecifier(normalizedImport: string, normalizedTarget: str
  *   doc comment for the real `dtolnay/anyhow` Rust self-edge repro). Derived
  *   from the importer's language via `hasNamespaceMatchingSemantics`, the
  *   same way as the #887/#929 guards, at this same call site.
- * - The #1021 Rust-mod single-file guard (`hasRustModMarker`) -- unlike the
- *   other four, this is derived from the SPECIFIER, not the importer's
- *   language: a single Rust file can have both a `mod x;` (needs
- *   `matchesRustModSpecifier`'s strict semantics) and a `use crate::y;`
- *   (needs `matchesFile`'s existing leniency) among its own imports, so a
- *   per-language flag can't disambiguate between two entries in the same
- *   file's import list the way it can for #887/#929/#1028. When present,
- *   this guard short-circuits entirely -- `matchesFile` never runs at all
- *   for a marked specifier.
+ * - The #1021/#1056 Rust exact-single-file guard (`hasRustModMarker`) --
+ *   unlike the other four, this is derived from the SPECIFIER, not the
+ *   importer's language: a single Rust file can have both a `mod x;` or a
+ *   bare crate-root import (each needing `matchesRustModSpecifier`'s strict
+ *   semantics) and a `use crate::y;` (needing `matchesFile`'s existing
+ *   leniency) among its own imports, so a per-language flag can't
+ *   disambiguate between two entries in the same file's import list the way
+ *   it can for #887/#929/#1028. When present, this guard short-circuits
+ *   entirely -- `matchesFile` never runs at all for a marked specifier.
  *
  * Every match-side reverse-dependency call path that used to open-code
  * `!isUnresolvableWholeModuleImport(imp, f) && matchesFile(normalize(imp), t)`

--- a/packages/parser/src/utils/rust-mod-marker.ts
+++ b/packages/parser/src/utils/rust-mod-marker.ts
@@ -1,24 +1,35 @@
 /**
- * Marker distinguishing a Rust `mod x;` (or `pub mod x;`)-DERIVED import
- * specifier -- produced only by `../ast/languages/rust.ts`'s
- * `extractModImportPath` -- from every other Rust import (`use crate::...`,
- * `self::`/`super::`, all produced by `convertRustModulePath`) (#1021).
+ * Marker for a Rust import specifier that's already been resolved to EXACTLY
+ * one file -- never a directory whose children should also match -- so it
+ * needs `matchesRustModSpecifier`'s (`path-matching.ts`) stricter exact-or-
+ * `/mod`-suffix matching instead of `matchesFile`'s ordinary interior-hit-
+ * tolerant (package-directory-style) leniency. Two current producers:
  *
- * Why this distinction has to exist: a `mod x;` declaration resolves to
- * EXACTLY one of `x.rs` / `x/mod.rs` -- it can never legally refer to a
- * grandchild file, a sibling under an unrelated name, or its own declaring
- * file. A `use` path doesn't carry that guarantee: after its `crate::`/
- * `self::`/`super::` prefix is stripped it's crate-root-relative (missing the
- * real `src/`-style directory prefix -- see `matchesAtBoundaryPrecise`'s
- * `maxLeadingSegments` leniency for that convention), and for several `use`
- * shapes (`use crate::thing::sibling::Thing;`) `extractImportPath`'s raw
- * "imports" list variant keeps the imported item's own name glued onto the
- * module path (`thing/sibling/Thing`) rather than isolating the module path
- * alone. `use` specifiers -- ordinary or `self::`/`super::`-relative alike --
- * therefore still need `matchesFile`'s existing interior-hit-tolerant
- * (package-directory-style) matching to resolve at all; only `mod`-derived
- * specifiers get the stricter treatment (`matchesRustModSpecifier` in
- * `path-matching.ts`).
+ * - A `mod x;` (or `pub mod x;`) declaration -- `../ast/languages/rust.ts`'s
+ *   `extractModImportPath` (#1021). Resolves to EXACTLY one of `x.rs` /
+ *   `x/mod.rs`; it can never legally refer to a grandchild file, a sibling
+ *   under an unrelated name, or its own declaring file.
+ * - A bare crate-root import (`use crate_name::Symbol;`, no submodule path)
+ *   resolved via crate-root export lookup -- `../rust-crate-exports.ts`'s
+ *   `resolveRustCrateRootExport` (#1056). Names the ONE file (typically
+ *   `lib.rs`) that the lookup determined actually declares `Symbol`; the
+ *   same "not a directory" guarantee applies, just reached via a different
+ *   mechanism (reading the crate's own root file rather than parsing a `mod`
+ *   declaration).
+ *
+ * Why this distinction has to exist: every OTHER Rust `use` specifier
+ * (`use crate::...`, `self::`/`super::`, all produced by
+ * `convertRustModulePath`'s crate/self/super-prefix stripping) doesn't carry
+ * that same guarantee -- after its prefix is stripped it's crate-root-
+ * relative (missing the real `src/`-style directory prefix -- see
+ * `matchesAtBoundaryPrecise`'s `maxLeadingSegments` leniency for that
+ * convention), and for several `use` shapes (`use crate::thing::sibling::
+ * Thing;`) `extractImportPath`'s raw "imports" list variant keeps the
+ * imported item's own name glued onto the module path (`thing/sibling/
+ * Thing`) rather than isolating the module path alone. Those specifiers
+ * therefore still need `matchesFile`'s existing leniency to resolve at all;
+ * only a specifier ALREADY narrowed to one file by one of the two producers
+ * above gets the stricter treatment.
  *
  * Why a string marker rather than a richer per-import data shape:
  * `chunk.metadata.imports` is a flat `string[]` (see `dependency-analyzer.ts`'s
@@ -32,9 +43,10 @@
  * ripple through the scanner, the SQLite row mapping, and every one of those
  * consumers -- exactly the repo-wide blast radius `path-matching.ts`'s own
  * conservatism (it's imported by every supported language) argues against.
- * Tagging the specifier string itself confines the change to its producer
- * (`extractModImportPath`, via `markRustModSpecifier`) and its one consumer
- * (`path-matching.ts`, via `hasRustModMarker`/`stripRustModMarker`).
+ * Tagging the specifier string itself confines the change to its producers
+ * (`extractModImportPath` and `resolveRustCrateRootExport`, both via
+ * `markRustModSpecifier`) and its one consumer (`path-matching.ts`, via
+ * `hasRustModMarker`/`stripRustModMarker`).
  *
  * Why this is safe to embed directly in the string: the marker is a single
  * Private-Use-Area code point, never producible by any real source file's
@@ -53,25 +65,25 @@
  * `importMatchesTarget` -- gets a clean, comparable value for free, with no
  * changes needed at those call sites.
  *
- * This module deliberately has NO imports of its own: `rust.ts` needs
- * `markRustModSpecifier`, and `path-matching.ts` needs the other two.
- * Routing either direction through the other file would create an import
- * cycle -- `registry.ts` already imports `rust.ts` to register
- * `rustDefinition`, and `path-matching.ts` already imports `registry.ts`, so
- * `rust.ts` importing directly from `path-matching.ts` would close the loop
- * (`rust.ts` -> `path-matching.ts` -> `registry.ts` -> `rust.ts`), and
- * `path-matching.ts` importing directly from `rust.ts` would break its own
- * "generic, language-agnostic" architecture (every other per-language fact it
- * consumes is threaded through `registry.ts`'s abstractions, never a specific
- * language file). A standalone module with no dependencies sidesteps both
- * problems.
+ * This module deliberately has NO imports of its own: `rust.ts` and
+ * `rust-crate-exports.ts` both need `markRustModSpecifier`, and
+ * `path-matching.ts` needs the other two. Routing either direction through
+ * the other file would create an import cycle -- `registry.ts` already
+ * imports `rust.ts` to register `rustDefinition`, and `path-matching.ts`
+ * already imports `registry.ts`, so `rust.ts` importing directly from
+ * `path-matching.ts` would close the loop (`rust.ts` -> `path-matching.ts` ->
+ * `registry.ts` -> `rust.ts`), and `path-matching.ts` importing directly from
+ * `rust.ts` would break its own "generic, language-agnostic" architecture
+ * (every other per-language fact it consumes is threaded through
+ * `registry.ts`'s abstractions, never a specific language file). A
+ * standalone module with no dependencies sidesteps both problems.
  */
 // Spelled via fromCharCode, not embedded as a literal character in a string
 // -- a raw Private-Use-Area code point renders as an invisible glyph in most
 // editors/diff tools, so the numeric form keeps the source legible.
 const RUST_MOD_SPECIFIER_MARKER = String.fromCharCode(0xe000);
 
-/** Prefix `specifier` (a `mod`-derived resolved path) with the marker. */
+/** Prefix `specifier` (a Rust import resolved to exactly one file) with the marker. */
 export function markRustModSpecifier(specifier: string): string {
   return RUST_MOD_SPECIFIER_MARKER + specifier;
 }


### PR DESCRIPTION
## Summary

- Fixes #1056: `use crate_name::Symbol;` (a cross-crate import naming only the crate + a symbol, no submodule path) resolved to the crate's bare `src/` directory, which fabricated an **identical dependent list for every file the crate contains** once matched via `matchesFile`'s Go-style package-directory leniency (Rust's `singleFileImports: false`). Confirmed on a real `serde-rs/serde` clone: `serde_derive/src/de.rs` and `serde_derive/src/dummy.rs` — two unrelated files — both returned the identical 144-file "dependent" list.
- This is the third instance of the `#928` fabrication family (`#1008`→`#1020` was the second, a self-edge guard). Same underlying mechanism as before (a bare, under-specified specifier fuzzy-matching a whole directory tree), different producer: this time it's `resolveRustCrateImport`'s bare-crate-root fallback, not `mod x;` resolution.
- **Fix shape**: when a `use` resolves to a bare crate name with no further path segment (`rest === ''`), narrow to the ONE file that actually declares the imported symbol via a new crate-root export lookup (`packages/parser/src/rust-crate-exports.ts`) — reads the crate's own `lib.rs`/`main.rs` directly for (a) top-level `pub` items and (b) `#[proc_macro_derive(Name)]` names (the exact serde/serde_derive repro shape). When the symbol can't be found there, **emit nothing** — an honest gap, not a fabricated crate-wide match.
- Reuses the existing `#1021` mod-marker mechanism (`markRustModSpecifier`/`matchesRustModSpecifier`) for the resolved specifier, since the guarantee is identical: names exactly one file, never a directory whose children should also match.

## Distinctness check (the actual bug symptom) — verbatim before/after

Reproduced on a fresh shallow clone of `serde-rs/serde` (HEAD at time of testing), using the real `findDependents` engine `get_dependents` runs (`@liendev/parser`'s exported function), isolated `LIEN_HOME` per measurement, no shared index.

**Before (pre-#1056, i.e. current `main`/cc1fccba):**
```
=== serde_derive/src/de.rs ===
dependents: 144
=== serde_derive/src/dummy.rs ===
dependents: 144
IDENTICAL LISTS: true
```
Both lists are the SAME 144 files: `serde/src/lib.rs` + 143 `test_suite/**` files that consume `serde_derive::{Deserialize, Serialize}` — none of which have anything to do with `de.rs` or `dummy.rs` specifically.

**After (this PR):**
```
=== serde_derive/src/de.rs ===
dependents: 1   -> ["serde_derive/src/lib.rs"]
=== serde_derive/src/dummy.rs ===
dependents: 1   -> ["serde_derive/src/lib.rs"]
=== serde_derive/src/internals/ast.rs ===
dependents: 15  -> real internal consumers only (bound.rs, de.rs, de/*.rs, internals/check.rs, internals/mod.rs, pretend.rs, ser.rs, this.rs)
=== serde_derive/src/lib.rs ===
dependents: 143 -> serde/src/lib.rs + 142 test_suite/**.rs files (UNCHANGED from before — this is the ONE file that genuinely declares Deserialize/Serialize)
```

This is the actual proof of the fix: `de.rs`/`dummy.rs` now correctly show their ONE real dependent (`lib.rs`, via its own `mod de;`/`mod dummy;` declaration — a pre-existing, correct edge, unrelated to this bug). `internals/ast.rs` shows a genuinely DIFFERENT, much smaller list (its own real internal consumers). Critically: **158 (ast.rs's old count) − 15 (ast.rs's new, real count) = 143 = exactly lib.rs's real dependent count** — confirming the SAME 143 fabricated entries were glued onto every file in the crate, and are now attributed correctly to only the ONE file responsible for them.

Repeated 3× (fresh re-index each time, isolated `LIEN_HOME`) — fully deterministic, no variance (the `#1044` re-export-order nondeterminism this repo just fixed doesn't apply here; rebased onto `7160546e`).

## Edge-count changes and why

- **serde** (not an existing E2E corpus, used only for manual verification above): counts drop sharply for every file inside `serde_derive`/`serde_derive_internals`, as expected — this is the whole point. No floor change needed (serde isn't in the standard 11-corpus E2E suite).
- **`dtolnay/anyhow`** (the E2E suite's named Rust corpus): **27 → ~32 edges, an INCREASE, not a decrease.** This is correct, not a regression: Anyhow is a single-crate (non-workspace) project, so its own `crateDir` is the single-segment `src` (not the multi-segment `<member>/src` shape a Cargo workspace member gets) — a single-segment bare specifier requires an exact match to resolve at all (`matchesAtBoundaryPrecise`'s `matchesSingleSegmentTail`), so it never hit the severe crate-wide fabrication serde_derive did. Instead, Anyhow's own `tests/*.rs` integration tests (`use anyhow::Error;` etc.) previously resolved to **nothing** (a bare `src` specifier only exact-matches a file literally named `src`). Now they correctly resolve via the crate-root export lookup: `src/lib.rs` gains 5 real test-file dependents that resolved to zero before; every other `src/*.rs` file's dependent set is unchanged. Full E2E suite (all 11 corpora) passes; `test:e2e:rust` (Anyhow) passes.
- **Floor**: `expectedMinDependencyEdges: 1` for Anyhow is left unchanged — it was already a conservative "hasn't collapsed to zero" floor (not a precision target, per `#1004`), and the measured number only went UP, so there's no fabricated-edge floor to lower here. Comment updated with the current measurement chain (`~39 pre-#1021 → 27 post-#1021/pre-#1056 → ~32 post-#1056`) and why.

## Other 9 E2E corpora

Full `npm run test:e2e` (all 11 corpora, unfiltered) passes: 198/198. The change is entirely confined to Rust-specific code paths (`rust.ts`, `rust-crate-map.ts`, new `rust-crate-exports.ts`); the generic plumbing added to `extractors/types.ts`/`ast/symbols.ts`/`ast/chunker.ts` is a new, optional, trailing parameter every other language's extractor ignores (verified: no other language file needed any change).

## Tests added

- `packages/parser/src/rust-crate-map.test.ts`: unit tests for `resolveRustCrateImport`'s new `workspaceRoot`/`symbolName` params, plus a dedicated `resolveRustCrateRootExport` describe block (proc-macro-derive resolution, plain pub items, column-0 anchoring against nested false positives, `main.rs` fallback, honest-null on a miss, and a same-symbol-different-crates distinctness check).
- `packages/parser/src/ast/languages/rust.ts` tests: end-to-end extractor-level tests for the serde/serde_derive repro shape (single import, list import, aliased import, miss → null).
- `packages/parser/src/dependency-analyzer.test.ts`: a new `findDependents`-level (the actual `get_dependents` engine) end-to-end regression using a real temp Cargo workspace on disk — a DISTINCTNESS test (two unrelated files no longer share a fabricated crate-wide list), a positive-resolution test, and an honest-gap test. **2 of the 3 new cases fail against pre-fix code and pass after** (verified directly against a separate pre-fix worktree checkout).

## Coordination note (#1039)

A concurrent agent fixed `#1039` (the structurally identical bug in Go — a bare root-module import that must resolve via export lookup rather than crediting the whole package) and merged first (#1064, `go-module.ts`/`ast/symbols.ts`/`dependency-analyzer.ts`). I did not touch any of those files. There's a real shared mechanism here (both bugs are "bare-root-import credits a whole directory/package instead of doing export lookup"), and interestingly its own test comments cross-reference this issue (`"the #1056 failure shape, checked explicitly"`) — but I did not attempt a cross-language extraction; flagging as a candidate follow-up issue instead. Rebasing onto their merge produced only a mechanical test-file conflict in `dependency-analyzer.test.ts` (both PRs appended a new `describe` block to the same file, plus overlapping `import` lines) — resolved by keeping both blocks and renaming one's `fs` import to `fsSync` to avoid a naming collision; no production-code conflict (their fix lives in a Go-specific fallback layer inside `findDependents`, mine lives entirely in the Rust extractor).

## Gates

- `npm run format:check` — pass
- `npm run lint` — 0 errors (40 pre-existing warnings, none in touched files)
- `npm run typecheck` — pass
- `npm run build` — pass
- `npm test` — pass (parser 1725/1725, cli 1637/1637 excl. e2e, action 41/41)
- `lien delta` — exit 0 (advisory "worsened" timing notes only on the touched Rust functions; no new-over-threshold crossings)
- `npm run test:e2e:rust -w packages/cli` — pass
- `npm run test:e2e -w packages/cli` (full 11-corpora suite) — pass (198/198)

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 1 pre-existing issue in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🧠 mental load | 1 | +0 |

> [!NOTE]
> **Low Risk**
>
> This PR fixes a severe Rust dependency-graph fabrication bug where bare crate-root imports (`use crate_name::Symbol;`) previously resolved to the crate's entire `src/` directory, causing every file in the crate to share an identical fabricated dependent list. The fix introduces a crate-root export lookup (`rust-crate-exports.ts`) that reads `lib.rs`/`main.rs` to narrow the import to the single file declaring the symbol, and tags the resolved specifier with the existing Rust mod-marker for exact-single-file matching. The change is well-isolated to Rust code paths, extensively tested (including the reported serde/serde_derive proc-macro-derive shape), and preserves honest-gap behavior when a symbol cannot be found. No new bugs were identified in the changed code.
>
> - Added `rust-crate-exports.ts` to scan crate root files for top-level `pub` items and `#[proc_macro_derive(Name)]` names.
> - Updated `resolveRustCrateImport` to use export lookup for bare crate-name imports instead of returning the whole crate directory.
> - Threaded `workspaceRoot` through `ManifestRoots`, `LanguageImportExtractor.processImportSymbols`, and Rust extractor call sites.
> - Tagged resolved bare crate-root specifiers with `markRustModSpecifier` so downstream matching is exact.

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 7152757. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

