### PR TITLE
fix(parser): clamp PHP require-target resolution to workspaceRoot (#1009)

### DIFF
--- a/.changeset/fix-1009-followup-path-traversal.md
+++ b/.changeset/fix-1009-followup-path-traversal.md
@@ -1,0 +1,5 @@
+---
+"@liendev/parser": patch
+---
+
+Clamp PHP require-target resolution (`php-require.ts`'s `requireTargetExists`, added in #1009/#1063) to `workspaceRoot`. Previously `path.join(workspaceRoot, specifier)` resolved `..` segments without clamping the result, so a statically-resolvable specifier like `require __DIR__ . '/../../../../etc/passwd';` could `fs.statSync` a real file entirely outside the indexed project and get trusted as a genuine require/include dependency edge. Now rejected before the existence check ever runs: the candidate path's relative path back to `workspaceRoot` must not escape (start with `..`) or be absolute (the cross-drive case on Windows).

--- a/packages/parser/src/php-require.test.ts
+++ b/packages/parser/src/php-require.test.ts
@@ -63,4 +63,27 @@ describe('requireTargetExists', () => {
       await fs.rm(siblingDir, { recursive: true, force: true }).catch(() => {});
     }
   });
+
+  it('is true for a nested, multi-level legitimate specifier (WordPress-shaped fixture, regression guard for the boundary check)', async () => {
+    // The boundary check must not over-reject a real, deeply-nested path --
+    // #1063's WordPress measurement (336 edges, 175 statically-resolved
+    // sites) depends on this still holding. `wp-admin/includes/admin.php`
+    // mirrors the real corpus shape (dependent files sit two directories
+    // below the project root).
+    await writeFile('wp-admin/includes/admin.php', '<?php\n');
+    expect(requireTargetExists('wp-admin/includes/admin.php', testDir)).toBe(true);
+  });
+
+  it('is true for a specifier containing internal .. segments that net out INSIDE workspaceRoot (dirname(__DIR__)-shaped, not yet fully normalized)', async () => {
+    // resolveRelativeImport normalizes a resolved specifier before it ever
+    // reaches this function, so in practice a clean already-normalized path
+    // arrives here (see the test above). This test exists to independently
+    // confirm the boundary check itself -- path.relative + startsWith('..')
+    // -- judges by the NET result of a traversal, not by the mere presence
+    // of a `..` segment in the input string: a `dirname(__DIR__)`-shaped
+    // specifier that climbs out of a subdirectory and back into a sibling
+    // one, while never leaving workspaceRoot overall, must still resolve.
+    await writeFile('wp-admin/wp-load.php', '<?php\n');
+    expect(requireTargetExists('wp-admin/maint/../wp-load.php', testDir)).toBe(true);
+  });
 });

--- a/packages/parser/src/php-require.test.ts
+++ b/packages/parser/src/php-require.test.ts
@@ -47,4 +47,20 @@ describe('requireTargetExists', () => {
     await writeFile('vendor/autoload.php', '<?php\n');
     expect(requireTargetExists('vendor', testDir)).toBe(false);
   });
+
+  it('is false when the specifier climbs outside workspaceRoot via .. segments, even if the target exists on disk (CodeRabbit path-traversal finding)', async () => {
+    // A sibling directory of testDir (both directly under os.tmpdir()) with
+    // a real file in it -- proving the escape would otherwise succeed, since
+    // path.join alone doesn't clamp the result to stay inside workspaceRoot.
+    const siblingDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-php-require-outside-'));
+    try {
+      const siblingFile = path.join(siblingDir, 'secret.php');
+      await fs.writeFile(siblingFile, '<?php\n');
+
+      const escaped = `../${path.basename(siblingDir)}/secret.php`;
+      expect(requireTargetExists(escaped, testDir)).toBe(false);
+    } finally {
+      await fs.rm(siblingDir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
 });

--- a/packages/parser/src/php-require.test.ts
+++ b/packages/parser/src/php-require.test.ts
@@ -64,6 +64,17 @@ describe('requireTargetExists', () => {
     }
   });
 
+  it('is true for a real file whose NAME starts with two dots, not a parent-directory escape (Lien Review finding)', async () => {
+    // path.relative('/project', '/project/..foo.php') returns the literal
+    // string '..foo.php' -- it starts with '..' as a substring without
+    // being a parent-directory escape at all. A naive `startsWith('..')`
+    // check would wrongly reject this real, in-project file; the boundary
+    // check must test for an actual parent SEGMENT (`..` + path.sep, or the
+    // bare '..' itself), not merely a leading '..' substring.
+    await writeFile('..foo.php', '<?php\n');
+    expect(requireTargetExists('..foo.php', testDir)).toBe(true);
+  });
+
   it('is true for a nested, multi-level legitimate specifier (WordPress-shaped fixture, regression guard for the boundary check)', async () => {
     // The boundary check must not over-reject a real, deeply-nested path --
     // #1063's WordPress measurement (336 edges, 175 statically-resolved

--- a/packages/parser/src/php-require.ts
+++ b/packages/parser/src/php-require.ts
@@ -22,7 +22,17 @@ import path from 'path';
  * merely LOOKS resolvable — applied to PHP's own file-inclusion mechanism.
  *
  * @param specifier - The already relative-resolved (workspace-relative)
- *   candidate path, as produced by `resolveImportSpecifier`.
+ *   candidate path, as produced by `resolveImportSpecifier`. `resolveRelativeImport`
+ *   permits a `../`-heavy specifier to climb above `workspaceRoot` (accepted,
+ *   tested behavior shared with JS/TS/Python's own relative-import
+ *   resolution — see `path-matching.test.ts`'s `'../../../../outside/thing'`
+ *   case), but unlike those languages' resolution, THIS function is the only
+ *   place in that whole pipeline that touches the real filesystem for the
+ *   resolved result. A CodeRabbit finding (#1009) correctly flagged that
+ *   without a boundary check, a crafted `require __DIR__ . '/../../../../etc/passwd'`
+ *   could `statSync` a real file outside the project entirely. Rejected
+ *   below via a relative-path escape check before the existence check ever
+ *   runs, rather than trusting `path.join`'s result as-is.
  * @param workspaceRoot - Absolute project root. Returns `false` when absent
  *   (nothing to check against) — callers with no workspace root in scope
  *   (most unit tests, and any indexing run that never provided one)
@@ -30,8 +40,17 @@ import path from 'path';
  */
 export function requireTargetExists(specifier: string, workspaceRoot: string | undefined): boolean {
   if (!workspaceRoot) return false;
+
+  const resolvedRoot = path.resolve(workspaceRoot);
+  const candidate = path.resolve(resolvedRoot, specifier);
+  const relativeToRoot = path.relative(resolvedRoot, candidate);
+  // A specifier that resolves outside workspaceRoot produces a relative path
+  // starting with '..' (or, if the two are on different Windows drives, an
+  // absolute path) -- either way, never trust it as a real project file.
+  if (relativeToRoot.startsWith('..') || path.isAbsolute(relativeToRoot)) return false;
+
   try {
-    return fs.statSync(path.join(workspaceRoot, specifier)).isFile();
+    return fs.statSync(candidate).isFile();
   } catch {
     return false;
   }

--- a/packages/parser/src/php-require.ts
+++ b/packages/parser/src/php-require.ts
@@ -45,9 +45,21 @@ export function requireTargetExists(specifier: string, workspaceRoot: string | u
   const candidate = path.resolve(resolvedRoot, specifier);
   const relativeToRoot = path.relative(resolvedRoot, candidate);
   // A specifier that resolves outside workspaceRoot produces a relative path
-  // starting with '..' (or, if the two are on different Windows drives, an
-  // absolute path) -- either way, never trust it as a real project file.
-  if (relativeToRoot.startsWith('..') || path.isAbsolute(relativeToRoot)) return false;
+  // that IS '..' (candidate is the parent itself) or starts with a '..'
+  // PARENT SEGMENT (`..` + the path separator) -- or, on Windows, an
+  // absolute path when the two are on different drives. Either way, never
+  // trust it as a real project file.
+  //
+  // Deliberately NOT `relativeToRoot.startsWith('..')`: that also matches a
+  // legitimate in-project file whose own NAME happens to start with two
+  // dots (e.g. `..foo.php`) -- `path.relative('/project', '/project/..foo.php')`
+  // returns the literal string `'..foo.php'`, which starts with `'..'` as a
+  // substring without being a parent-directory escape at all. That shape
+  // over-rejects a real file (a correctness bug in the safe direction for a
+  // security check, but still a regression from this function's own
+  // pre-boundary-check behavior, which resolved such a file correctly).
+  const escaped = relativeToRoot === '..' || relativeToRoot.startsWith(`..${path.sep}`);
+  if (escaped || path.isAbsolute(relativeToRoot)) return false;
 
   try {
     return fs.statSync(candidate).isFile();


### PR DESCRIPTION
## Summary

Small follow-up to #1063 (merged). CodeRabbit's review on that PR landed a valid finding just after the merge went through — reported here rather than left unaddressed.

`requireTargetExists` (`packages/parser/src/php-require.ts`) used `path.join(workspaceRoot, specifier)` to check whether a statically-resolved PHP `require`/`include` target exists on disk. `path.join` resolves `..` segments but does **not** clamp the result to stay inside `workspaceRoot` — so a specifier like `require __DIR__ . '/../../../../etc/passwd';` (statically resolvable by #1063's own rules) could `fs.statSync` a real file entirely outside the indexed project and get trusted as a genuine require target.

Note this is *not* a new category of behavior for the codebase: JS/TS/Python's own `resolveRelativeImport` already permits a specifier to climb outside `workspaceRoot` as a plain string (accepted, tested — see `path-matching.test.ts`'s `'../../../../outside/thing'` case). What's different here is that `requireTargetExists` is the only place in that whole resolution pipeline that actually touches the real filesystem for the resolved result, which is what makes the boundary escape observable (a real `stat` call against a path outside the project) rather than just an inert string that never matches anything.

## Fix

`requireTargetExists` now resolves the candidate path, computes its relative path back to `workspaceRoot`, and rejects (returns `false`) if that relative path escapes (starts with `..`, or is itself absolute — the cross-drive case on Windows) *before* ever calling `fs.statSync`.

## Test

Added a regression test: creates a sibling directory under `os.tmpdir()` (alongside the test's own `workspaceRoot` temp dir) with a real file in it, then asserts a `../<sibling>/secret.php`-shaped specifier returns `false` even though the file genuinely exists. Verified this test fails without the boundary check (reproduces the exact escape) and passes with it.

## Gates

- `npm run format:check` — pass
- `npm run lint` — 0 errors
- `npm run typecheck` — pass
- `npm run build` — pass
- `npm test` — pass (full monorepo suite, 3745 tests across all packages)
- `lien delta --base origin/main` — exit 0 (`requireTargetExists` cognitive complexity 2 → 4, well under threshold)

Scope: touches only `php-require.ts`/`php-require.test.ts`, both introduced by #1063. No behavior change for any specifier that resolves inside `workspaceRoot` (the overwhelming common case).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR clamps PHP require-target resolution to workspaceRoot, preventing path-traversal stat calls outside the project. The fix correctly uses path.resolve + path.relative and checks for an actual parent-segment escape (`..` or `..${path.sep}`) rather than a naive `startsWith('..')` substring match, avoiding the over-rejection of legitimate files whose names begin with two dots. The added regression tests cover the escape case, the `..foo.php` edge case, nested legitimate paths, and internal `..` segments that net inside workspaceRoot. Callers in ast/symbols.ts pass workspaceRoot consistently and are unaffected for in-project specifiers.
>
> - requireTargetExists now resolves and boundary-checks the candidate path before calling fs.statSync
> - Boundary check correctly distinguishes parent-directory escapes from filenames starting with `..`
> - Added regression tests for traversal escape and legitimate in-project edge cases

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 1bce32f. Updates automatically on new commits.</sup>
<!-- /lien-stats -->