### PR TITLE
fix(parser): stop get_dependents re-scanning the whole import index per dependent (#1075)

### DIFF
--- a/.changeset/get-dependents-uncovered-count-quadratic.md
+++ b/.changeset/get-dependents-uncovered-count-quadratic.md
@@ -1,0 +1,48 @@
+---
+'@liendev/parser': patch
+'@liendev/lien': patch
+---
+
+fix(parser): stop `get_dependents` re-scanning the whole import index once per dependent (#1075)
+
+A single `get_dependents` call on a high-fan-out file in a 6,356-file C# corpus
+(OrchardCore, `OrchardCoreConstants.cs`) took **166 seconds** — roughly 100x the
+documented per-call floor. Two minutes is a timeout in practice, not
+slow-but-usable, on the MCP tool the whole agent contract is built around.
+
+A CPU profile put 95.4% of that in one place, and it was not the re-export graph
+the issue suspected (`buildReExportGraph` accounted for 0.14%):
+`uncoveredProductionDependents` asks "does any test file import this?" once per
+production dependent, and answered it by re-running a full `findDependentChunks`
+scan of the **entire** import index each time. That is O(dependents x every
+indexed import): 1,131 dependents x 119k+ entries ≈ 135M `importMatchesTarget`
+calls, of which all but the test-file importers were discarded the instant they
+matched.
+
+Two fixes, both build-once/resolve-many, neither changing a matching decision:
+
+- The import index is projected once per call down to its **test-file
+  importers**, deduplicated by (importer file, raw specifier) — 15,339 entries
+  become 1,026 on OrchardCore. Each dependent then resolves against that, in the
+  same two-branch (exact bucket, then fuzzy `importMatchesTarget`) order, and
+  returns on the first hit instead of materializing every importer.
+- The four per-importer-file language decisions `importMatchesTarget` derives
+  (#884 whole-module, #887 single-file, #929 Python bare-module, #1028 PHP
+  namespace) are memoized per file path instead of re-running
+  `detectLanguage` — and therefore `node:path`'s `extname` — four times for the
+  same path on every single comparison. That derivation alone was 42% of the
+  profile (`detectLanguage` 32.5% self, `extname` 10.2%). The registry it reads
+  is frozen at module load, so the record is a pure function of the path.
+
+Same target, same 1,131 dependents, same `dependentAttributionPartial`:
+**166,009 ms → 437 ms** (five runs: 481/451/441/443/437 ms). The re-profiled
+call is now dominated by nothing in particular — the C# type-reference tier
+(0.18 s) and this counter (0.16 s) are the same order.
+
+Equivalence is proven, not asserted. `hasTestImporterBruteForce` is exported as
+the never-pruned oracle (the role `computeDependentCountsBruteForce` plays for
+#1071) and the pruned predicate is checked against it for **every file** of the
+eleven real corpora the CLI E2E matrix names, plus serilog and OrchardCore, and
+the full `findDependents` result is diffed field-by-field against a pre-change
+build across those same corpora at depth 1 and depth 3. Zero mismatches
+throughout. #1044's order-independent `reported`/`queued` BFS is untouched.

--- a/packages/parser/src/dependency-analyzer.test.ts
+++ b/packages/parser/src/dependency-analyzer.test.ts
@@ -8,6 +8,8 @@ import {
   findDependents,
   findReExportedSymbolsForFile,
   chunkImportsFrom,
+  hasTestImporterFromChunks,
+  hasTestImporterBruteForce,
   COMPLEXITY_THRESHOLDS,
 } from './dependency-analyzer.js';
 import { chunkByAST } from './ast/chunker.js';
@@ -1497,5 +1499,198 @@ describe('bare crate-root `use` edges end-to-end (#1056 regression)', () => {
         d => d.filepath,
       ),
     ).toEqual(['lib_macro/src/lib.rs']);
+  });
+});
+
+/**
+ * #1075: `uncoveredProductionDependents` asks "does any test file import this?"
+ * once per production dependent. It used to answer by re-scanning the WHOLE
+ * import index each time -- O(dependents x every indexed import), measured at
+ * 95% of a 166-second `get_dependents` call on a 6,356-file C# corpus. It now
+ * resolves against a test-file-only projection of that index, built once.
+ *
+ * That makes the projection a pruning OPTIMIZATION, and this is the property
+ * that keeps it from quietly becoming a second import-matching dialect: for the
+ * same chunk set, the pruned predicate and the unpruned whole-index scan must
+ * agree for EVERY file. Without it, dropping a real test importer would just
+ * inflate `uncoveredProductionDependents` into a plausible-looking larger
+ * number -- an invented "untested dependents" signal, which is the exact
+ * failure direction #1014 warns about.
+ *
+ * Mirrors `dependent-count-index.test.ts`'s brute-force equivalence block, and
+ * verified out-of-band the same way: exhaustively over every file of the eleven
+ * real corpora the CLI E2E matrix names, plus serilog and OrchardCore.
+ */
+describe('test-importer index is exact (brute-force equivalence, #1075)', () => {
+  const ROOT = '/workspace';
+
+  function chunk(
+    file: string,
+    options: {
+      imports?: string[];
+      importedSymbols?: Record<string, string[]>;
+      language?: string;
+      startLine?: number;
+    } = {},
+  ): CodeChunk {
+    return {
+      content: '// body',
+      metadata: {
+        file,
+        startLine: options.startLine ?? 1,
+        endLine: (options.startLine ?? 1) + 9,
+        type: 'function',
+        language: options.language ?? 'typescript',
+        imports: options.imports ?? [],
+        importedSymbols: options.importedSymbols,
+      } as ChunkMetadata,
+    };
+  }
+
+  /**
+   * Test importers in each language's real specifier shape, as the index
+   * actually stores it after extraction-time resolution -- same sourcing
+   * discipline as `dependent-count-index.test.ts`'s fixture.
+   */
+  const corpora: Record<string, CodeChunk[]> = {
+    'multi-language test importers': [
+      // TypeScript: a relative spec from a co-located .test.ts.
+      chunk('src/utils/logger.ts'),
+      chunk('src/app.ts', { imports: ['./utils/logger'] }),
+      chunk('src/app.test.ts', { imports: ['./app'] }),
+      // ...and a production file with NO test importer at all.
+      chunk('src/orphan.ts'),
+      chunk('src/uses-orphan.ts', { imports: ['./orphan'] }),
+
+      // Python: dotted module from a tests/ directory.
+      chunk('src/flask/app.py', { language: 'python' }),
+      chunk('tests/test_app.py', { language: 'python', imports: ['src.flask.app'] }),
+
+      // Go: an external test file importing the package directory.
+      chunk('internal/bytesconv/bytesconv.go', { language: 'go' }),
+      chunk('router_test.go', { language: 'go', imports: ['internal/bytesconv'] }),
+
+      // PHP: PSR-4 namespace from a capitalized Tests/ directory (#925).
+      chunk('app/Models/Order.php', { language: 'php' }),
+      chunk('Tests/OrderTest.php', { language: 'php', imports: ['App\\Models\\Order'] }),
+
+      // Java: an already-source-root-resolved path from src/test (#1046).
+      chunk('src/main/java/com/example/Widget.java', { language: 'java' }),
+      chunk('src/test/java/com/example/WidgetTest.java', {
+        language: 'java',
+        imports: ['src/main/java/com/example/Widget.java'],
+      }),
+
+      // Ruby: a bare multi-segment require from spec/ (#887 -- names ONE file).
+      chunk('lib/rack/protection.rb', { language: 'ruby' }),
+      chunk('lib/rack/protection/base.rb', { language: 'ruby' }),
+      chunk('spec/protection_spec.rb', { language: 'ruby', imports: ['rack/protection'] }),
+
+      // Swift: a whole-module import from XCTest -- deliberately unresolvable
+      // per file (#884), so the .swift source must come back uncovered.
+      chunk('Sources/App/Feature.swift', { language: 'swift' }),
+      chunk('Tests/AppTests/FeatureTests.swift', { language: 'swift', imports: ['App'] }),
+
+      // C#: a dotted namespace from a *Tests.cs file. `matchesFile` genuinely
+      // can't resolve this shape (the #930 type-reference tier exists for it),
+      // so this is a negative the two implementations must agree on.
+      chunk('src/Serilog.Core/Enrichers.cs', { language: 'csharp' }),
+      chunk('test/Serilog.Tests/EnricherTests.cs', {
+        language: 'csharp',
+        imports: ['Serilog.Core.Enrichers'],
+      }),
+    ],
+
+    // Where the 15x dedup happens: one test file chunked many times, each chunk
+    // replicating the file's whole import list.
+    'a test file with many chunks sharing one import list': [
+      chunk('src/target.ts'),
+      chunk('src/other.ts'),
+      ...[1, 11, 21, 31, 41].map(startLine =>
+        chunk('src/target.test.ts', { imports: ['./target', './other'], startLine }),
+      ),
+    ],
+
+    // Only the direct-bucket branch fires: the stored specifier normalizes to
+    // exactly the target key, so neither implementation runs a fuzzy match.
+    'exact-key direct bucket only': [
+      chunk('src/deep/nested/thing.ts'),
+      chunk('src/deep/nested/thing.test.ts', { imports: ['src/deep/nested/thing.ts'] }),
+    ],
+
+    // importedSymbols-only importer (no `imports` entry) -- the second half of
+    // what `addChunkToImportIndex` feeds the index.
+    'test importer via importedSymbols only': [
+      chunk('src/service.ts'),
+      chunk('src/service.spec.ts', { importedSymbols: { './service': ['Service'] } }),
+    ],
+
+    // Near-miss names that must NOT resolve: a boundary bug in either
+    // implementation would light these up.
+    'boundary near-misses': [
+      chunk('src/logger.ts'),
+      chunk('src/logger-utils.ts'),
+      chunk('src/logger-utils.test.ts', { imports: ['./logger-utils'] }),
+      chunk('src/contest.ts', { imports: ['./logger'] }),
+    ],
+
+    // A test file that is itself imported by another test file.
+    'test importing test': [
+      chunk('test/helpers/factory.ts'),
+      chunk('test/user.test.ts', { imports: ['./helpers/factory'] }),
+    ],
+
+    // Degenerate metadata: empty file string, empty specifier.
+    'degenerate metadata': [
+      chunk('', { imports: [''] }),
+      chunk('src/real.ts'),
+      chunk('src/real.test.ts', { imports: ['./real'] }),
+    ],
+  };
+
+  for (const [name, chunks] of Object.entries(corpora)) {
+    it(`agrees with the unpruned whole-index scan for every file: ${name}`, () => {
+      const files = [...new Set(chunks.map(c => c.metadata.file))];
+      const verdicts = files.map(file => {
+        const pruned = hasTestImporterFromChunks(chunks, file, ROOT);
+        expect(pruned, `${name} -> ${file}`).toBe(hasTestImporterBruteForce(chunks, file, ROOT));
+        return pruned;
+      });
+      // A corpus where nothing has a test importer would make the equivalence
+      // above vacuously true, so require each fixture to exercise both answers.
+      expect(verdicts, `${name} produced no covered file`).toContain(true);
+      expect(verdicts, `${name} produced no uncovered file`).toContain(false);
+    });
+  }
+
+  it('counts uncovered production dependents from the projected index', () => {
+    const chunks = [
+      chunk('src/target.ts'),
+      // Covered: has a test importer of its own.
+      chunk('src/covered.ts', { imports: ['./target'] }),
+      chunk('src/covered.test.ts', { imports: ['./covered'] }),
+      // Uncovered: production dependent with no test importer.
+      chunk('src/uncovered.ts', { imports: ['./target'] }),
+      // A test file that depends on the target directly is not a *production*
+      // dependent at all, so it never enters the count.
+      chunk('src/target.test.ts', { imports: ['./target'] }),
+    ];
+
+    const result = findDependents(chunks, 'src/target.ts', () => {}, ROOT);
+
+    expect(result.dependents.map(d => d.filepath).sort()).toEqual([
+      'src/covered.ts',
+      'src/target.test.ts',
+      'src/uncovered.ts',
+    ]);
+    expect(result.productionDependentCount).toBe(2);
+    expect(result.uncoveredProductionDependents).toBe(1);
+  });
+
+  it('returns zero without building the projection when every dependent is a test file', () => {
+    const chunks = [chunk('src/target.ts'), chunk('src/target.test.ts', { imports: ['./target'] })];
+    const result = findDependents(chunks, 'src/target.ts', () => {}, ROOT);
+    expect(result.productionDependentCount).toBe(0);
+    expect(result.uncoveredProductionDependents).toBe(0);
   });
 });

--- a/packages/parser/src/dependency-analyzer.ts
+++ b/packages/parser/src/dependency-analyzer.ts
@@ -2136,31 +2136,218 @@ function mergeDiscovered<T extends CodeChunk>(args: {
 }
 
 /**
+ * One distinct (test file, raw import specifier) pair from the import index.
+ *
+ * Deliberately drops the chunk `ImportIndexEntry` carries: `hasTestImporter`
+ * asks a pure existence question, and the match decision
+ * (`importMatchesTarget`) reads nothing from a chunk beyond
+ * `metadata.file` -- which is `importerFile` here. So many chunks of the same
+ * test file that each replicate the file's import list collapse to a single
+ * entry, which is where most of the reduction comes from (measured 15x on
+ * OrchardCore: 15,339 test import entries -> 1,026 distinct pairs).
+ */
+interface TestImporterEntry {
+  /** Raw (pre-normalization) specifier, as `importMatchesTarget` wants it. */
+  rawSpecifier: string;
+  /** The importing test file's raw path (the language-detection input). */
+  importerFile: string;
+}
+
+/**
+ * The test-file-only slice of an import index: same keys (normalized import
+ * specifiers), entries restricted to test-file importers and deduplicated.
+ */
+type TestImporterIndex = Map<string, TestImporterEntry[]>;
+
+/**
+ * Project an import index down to its test-file importers, once per
+ * `findDependents` call (#1075).
+ *
+ * `countUncoveredProductionDependents` asks "does any test file import this?"
+ * once per production dependent. It used to answer that by running a full
+ * `findDependentChunks` scan of the WHOLE import index per dependent, which is
+ * O(dependents x every indexed import) -- and on a corpus with a high-fan-out
+ * target that product is what made a single `get_dependents` call take two
+ * minutes: 1,131 dependents x 119k+ entries = ~135M `importMatchesTarget`
+ * calls, 95% of a 166s profile. Nothing about the answer needed those 135M
+ * questions; the non-test importers were all discarded immediately after being
+ * matched.
+ *
+ * So this is the same build-once/resolve-many split #1073
+ * (`buildCSharpTypeReferenceIndex`) and #1071 (`computeDependentCountsFromChunks`)
+ * already use: pay one pass over the index, then answer each dependent against
+ * a set ~100x smaller. It is a projection, not a different matching dialect --
+ * the surviving entries go through the identical `importMatchesTarget`
+ * decision, in the identical two-branch (direct bucket, then fuzzy) order.
+ *
+ * Iterates the already-built `importIndex` rather than the raw chunks on
+ * purpose: its keys are the normalized specifiers this index needs anyway, and
+ * its entries have already had the build-time #884 whole-module drop applied,
+ * so re-deriving either from chunks would be a second implementation of a
+ * decision that is already made.
+ */
+function buildTestImporterIndex<T extends CodeChunk>(
+  importIndex: Map<string, ImportIndexEntry<T>[]>,
+): TestImporterIndex {
+  const testIndex: TestImporterIndex = new Map();
+  const isTest = createIsTestFileMemo();
+
+  for (const [normalizedImport, entries] of importIndex.entries()) {
+    const bucket = collectTestImporterBucket(entries, isTest);
+    if (bucket.length > 0) testIndex.set(normalizedImport, bucket);
+  }
+
+  return testIndex;
+}
+
+/**
+ * The test-file importers of one import-index bucket, deduplicated by
+ * (importer file, raw specifier) -- see `TestImporterEntry` for why the chunk
+ * itself is dropped. NUL joins the two halves of the dedup key because it is
+ * the one byte a file path cannot contain, so no (importer, specifier) pair can
+ * collide with a different one by straddling the separator.
+ */
+function collectTestImporterBucket<T extends CodeChunk>(
+  entries: ImportIndexEntry<T>[],
+  isTest: (filepath: string) => boolean,
+): TestImporterEntry[] {
+  const bucket: TestImporterEntry[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of entries) {
+    const importerFile = entry.chunk.metadata.file;
+    if (!isTest(importerFile)) continue;
+    const pairKey = `${importerFile}\u0000${entry.rawSpecifier}`;
+    if (seen.has(pairKey)) continue;
+    seen.add(pairKey);
+    bucket.push({ rawSpecifier: entry.rawSpecifier, importerFile });
+  }
+
+  return bucket;
+}
+
+/**
+ * Memoized `isTestFile`, for one index build. The import index holds an entry
+ * per (chunk, specifier), so the same file path is asked about many times over;
+ * `isTestFile` is a battery of regexes and its answer per path never changes.
+ */
+function createIsTestFileMemo(): (filepath: string) => boolean {
+  const cache = new Map<string, boolean>();
+  return (filepath: string): boolean => {
+    const cached = cache.get(filepath);
+    if (cached !== undefined) return cached;
+    const result = isTestFile(filepath);
+    cache.set(filepath, result);
+    return result;
+  };
+}
+
+/**
+ * Does any test file import `normalizedTarget`?
+ *
+ * Mirrors `findDependentChunks`'s two branches exactly, which is what makes
+ * this equivalent to the previous "scan every importer, then ask which ones
+ * were test files":
+ * - A bucket keyed exactly `normalizedTarget` counts unconditionally. Those
+ *   keys were built with the same normalizer and already passed the build-time
+ *   #884 prune, so `findDependentChunks` never re-guards them either.
+ * - Every other bucket's entries go through `importMatchesTarget`, once per
+ *   distinct (importer, specifier) pair.
+ *
+ * Returns on the first hit instead of materializing every importer, since the
+ * caller only ever needed the boolean.
+ */
+function hasTestImporter(
+  normalizedTarget: string,
+  testIndex: TestImporterIndex,
+  normalizePathCached: (path: string) => string,
+): boolean {
+  const direct = testIndex.get(normalizedTarget);
+  if (direct !== undefined && direct.length > 0) return true;
+
+  for (const [normalizedImport, entries] of testIndex.entries()) {
+    if (normalizedImport === normalizedTarget) continue;
+    // `.some` short-circuits, so this stops at the first matching importer
+    // exactly as an early-returning loop would.
+    const matched = entries.some(entry =>
+      importMatchesTarget(
+        entry.rawSpecifier,
+        entry.importerFile,
+        normalizedTarget,
+        normalizePathCached,
+      ),
+    );
+    if (matched) return true;
+  }
+  return false;
+}
+
+/**
  * For each production dependent, check whether any test file imports it.
- * Reuses the existing `importIndex` — no fresh scan.
+ * Builds the test-file-only projection of `ctx.importIndex` once (see
+ * `buildTestImporterIndex`) and resolves every dependent against that, rather
+ * than re-scanning the whole index per dependent.
  */
 function countUncoveredProductionDependents<T extends CodeChunk>(
   dependents: DependentInfo[],
   ctx: ScanContext<T>,
 ): number {
+  const productionDependents = dependents.filter(d => !d.isTestFile);
+  if (productionDependents.length === 0) return 0;
+
+  const testIndex = buildTestImporterIndex(ctx.importIndex);
   let uncovered = 0;
-  for (const d of dependents) {
-    if (d.isTestFile) continue;
-    if (!hasTestImporter(d.filepath, ctx)) uncovered += 1;
+  for (const d of productionDependents) {
+    if (!hasTestImporter(ctx.normalizePathCached(d.filepath), testIndex, ctx.normalizePathCached)) {
+      uncovered += 1;
+    }
   }
   return uncovered;
 }
 
-function hasTestImporter<T extends CodeChunk>(filepath: string, ctx: ScanContext<T>): boolean {
+/**
+ * Unpruned reference implementation of the `hasTestImporter` predicate: the
+ * whole-import-index scan `countUncoveredProductionDependents` did before
+ * #1075, expressed over a raw chunk set.
+ *
+ * Exists solely as the brute-force oracle the equivalence test checks the
+ * fast path against -- the same role `computeDependentCountsBruteForce` plays
+ * for `dependent-count-index.ts` (#1071). Production code must never call it:
+ * it rebuilds the scan index per query and is O(every indexed import) per
+ * question, which is precisely the cost #1075 removed.
+ */
+export function hasTestImporterBruteForce<T extends CodeChunk>(
+  chunks: Iterable<T>,
+  filepath: string,
+  workspaceRoot: string,
+): boolean {
+  const normalizePathCached = createPathNormalizer(workspaceRoot);
+  const { importIndex } = buildScanIndex(chunks, normalizePathCached);
   const importers = findDependentChunks(
-    ctx.normalizePathCached(filepath),
-    ctx.importIndex,
-    ctx.normalizePathCached,
+    normalizePathCached(filepath),
+    importIndex,
+    normalizePathCached,
   );
-  for (const chunk of importers) {
-    if (isTestFile(chunk.metadata.file)) return true;
-  }
-  return false;
+  return importers.some(chunk => isTestFile(chunk.metadata.file));
+}
+
+/**
+ * The fast path `hasTestImporterBruteForce` is checked against, over the same
+ * raw chunk-set input. Test-facing counterpart only -- `findDependents` builds
+ * its scan index once per call and goes straight to `buildTestImporterIndex`.
+ */
+export function hasTestImporterFromChunks<T extends CodeChunk>(
+  chunks: Iterable<T>,
+  filepath: string,
+  workspaceRoot: string,
+): boolean {
+  const normalizePathCached = createPathNormalizer(workspaceRoot);
+  const { importIndex } = buildScanIndex(chunks, normalizePathCached);
+  return hasTestImporter(
+    normalizePathCached(filepath),
+    buildTestImporterIndex(importIndex),
+    normalizePathCached,
+  );
 }
 
 /**

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -219,6 +219,12 @@ export type {
 // DEPENDENCY ANALYSIS
 // =============================================================================
 
+// `hasTestImporterFromChunks`/`hasTestImporterBruteForce` are #1075's fast path
+// and its never-pruned oracle for the "does any test file import this?"
+// predicate behind `uncoveredProductionDependents` -- exported (like
+// `computeDependentCountsBruteForce` above) purely so equivalence can be checked
+// from outside the module against real corpora; never call the brute-force one
+// in production.
 export {
   analyzeDependencies,
   findDependents,
@@ -229,6 +235,8 @@ export {
   chunkImportsFrom,
   fileIsReExporter,
   findReExportedSymbolsForFile,
+  hasTestImporterFromChunks,
+  hasTestImporterBruteForce,
   DEPENDENT_COUNT_THRESHOLDS,
   COMPLEXITY_THRESHOLDS,
 } from './dependency-analyzer.js';

--- a/packages/parser/src/utils/path-matching.test.ts
+++ b/packages/parser/src/utils/path-matching.test.ts
@@ -10,6 +10,7 @@ import {
   hasSingleFileImportSemantics,
   hasPythonModuleSemantics,
   hasNamespaceMatchingSemantics,
+  clearImporterSemanticsCache,
 } from './path-matching.js';
 import { markRustModSpecifier } from './rust-mod-marker.js';
 
@@ -1337,4 +1338,119 @@ describe('resolveWorkspaceImport', () => {
       'packages/parser/src/foo',
     );
   });
+});
+
+/**
+ * #1075 memoized the four per-importer-file language decisions
+ * (`importerLanguageSemantics`) because deriving them cost 42% of a large
+ * `findDependents` call. The registry those decisions read is frozen at module
+ * load, so a warm cache must be indistinguishable from a cold one -- these are
+ * the tests that hold that line, since a stale or cross-contaminated record
+ * would silently change which `matchesFile` strategies run for a whole
+ * language.
+ */
+describe('importer language semantics are memoized without changing any answer', () => {
+  const normalize = (p: string): string => normalizePath(p, '/fake/workspace');
+
+  /** One representative importer path per registered language, plus non-AST shapes. */
+  const importers = [
+    'src/app.ts',
+    'src/app.tsx',
+    'src/app.js',
+    'src/app.mjs',
+    'app/Models/User.php',
+    'src/flask/app.py',
+    'src/error.rs',
+    'internal/fs/fs.go',
+    'src/main/java/com/example/Widget.java',
+    'src/Serilog.Core/Enrichers.cs',
+    'lib/rack/protection.rb',
+    'src/main/kotlin/com/example/Json.kt',
+    'Source/Alamofire.swift',
+    // Non-AST / degenerate shapes: no extension, unknown extension, empty.
+    'Makefile',
+    'docs/readme.md',
+    'src/no-extension-here',
+    '',
+  ];
+
+  /** The four predicates, each asked directly. */
+  const answersFor = (importerFile: string) => ({
+    wholeModuleBare: isUnresolvableWholeModuleImport('Foundation', importerFile),
+    wholeModuleSlashed: isUnresolvableWholeModuleImport('a/b', importerFile),
+    singleFile: hasSingleFileImportSemantics(importerFile),
+    python: hasPythonModuleSemantics(importerFile),
+    namespace: hasNamespaceMatchingSemantics(importerFile),
+  });
+
+  it('answers identically cold, warm, and after a clear', () => {
+    clearImporterSemanticsCache();
+    const cold = importers.map(answersFor);
+    const warm = importers.map(answersFor);
+    clearImporterSemanticsCache();
+    const afterClear = importers.map(answersFor);
+
+    expect(warm).toEqual(cold);
+    expect(afterClear).toEqual(cold);
+  });
+
+  it('keeps each language distinct rather than serving a neighbour cache entry', () => {
+    clearImporterSemanticsCache();
+    // Interleave languages so a per-file cache miss/hit ordering bug would show.
+    for (const importerFile of [...importers, ...importers.slice().reverse()]) {
+      expect(answersFor(importerFile)).toEqual(expectedFor(importerFile));
+    }
+  });
+
+  it('gives importMatchesTarget the same verdict cold and warm, per language shape', () => {
+    const cases: Array<[string, string, string]> = [
+      // [specifier, importerFile, normalizedTarget]
+      ['./utils/logger', 'src/app.ts', 'src/utils/logger'],
+      ['src.flask.app', 'tests/test_app.py', 'src/flask/app'],
+      ['App\\Models\\Order', 'app/Services/OrderService.php', 'app/Models/Order'],
+      ['rack/protection', 'lib/sinatra/base.rb', 'rack/protection/base'],
+      ['internal/bytesconv', 'tree.go', 'internal/bytesconv/bytesconv'],
+      ['Alamofire', 'Source/Request.swift', 'Source/Alamofire'],
+      ['Serilog.Core.Enrichers', 'src/App.cs', 'src/Serilog.Core/Enrichers'],
+      ['crate::Error', 'src/context.rs', 'src/error'],
+    ];
+
+    clearImporterSemanticsCache();
+    const cold = cases.map(([s, f, t]) => importMatchesTarget(s, f, t, normalize));
+    const warm = cases.map(([s, f, t]) => importMatchesTarget(s, f, t, normalize));
+    expect(warm).toEqual(cold);
+    // Pin the actual verdicts too, so a cache that memoized the WRONG record
+    // consistently can't pass by being consistently wrong. Each value was read
+    // off the pre-#1075 build, not guessed: Ruby's `rack/protection` correctly
+    // refuses the "child file" (#887), Swift's bare `Alamofire` refuses the
+    // basename coincidence (#884), a C# dotted namespace is genuinely
+    // unresolvable by `matchesFile` (which is why the #930 type-reference tier
+    // exists), and a Rust bare `crate::Error` no longer self-matches
+    // `src/error.rs` (#1028).
+    expect(cold).toEqual([true, true, true, false, true, false, false, false]);
+  });
+
+  it('survives eviction at the cache bound', () => {
+    clearImporterSemanticsCache();
+    const before = answersFor('lib/rack/protection.rb');
+    // The cache clears wholesale at 20_000 entries; overflow it and re-ask.
+    for (let i = 0; i < 20_050; i++) hasSingleFileImportSemantics(`src/generated/f${i}.ts`);
+    expect(answersFor('lib/rack/protection.rb')).toEqual(before);
+    expect(answersFor('src/flask/app.py').python).toBe(true);
+  });
+
+  /** Independent expectations, derived from each language's documented flags. */
+  function expectedFor(importerFile: string) {
+    const ruby = importerFile.endsWith('.rb');
+    const php = importerFile.endsWith('.php');
+    const python = importerFile.endsWith('.py');
+    const swift = importerFile.endsWith('.swift');
+    return {
+      wholeModuleBare: swift,
+      wholeModuleSlashed: false,
+      singleFile: ruby,
+      python,
+      namespace: php,
+    };
+  }
 });

--- a/packages/parser/src/utils/path-matching.ts
+++ b/packages/parser/src/utils/path-matching.ts
@@ -230,6 +230,92 @@ function matchesSingleSegmentTail(
 }
 
 /**
+ * The four per-importer-file language decisions `importMatchesTarget` needs,
+ * resolved together. Each is a pure function of the importer's file extension
+ * and the static language registry, so the whole record can be memoized per
+ * file path (see `importerLanguageSemantics`).
+ */
+interface ImporterLanguageSemantics {
+  /** #884 — `LanguageDefinition.wholeModuleImports` (Swift). */
+  wholeModuleImports: boolean;
+  /** #887 — `LanguageDefinition.singleFileImports` (Ruby). */
+  singleFileImports: boolean;
+  /** #929 — Python's dotted-module semantics (`matchesFile` strategy 5). */
+  pythonModules: boolean;
+  /** #1028 — `LanguageDefinition.namespaceStyleImports` (PHP). */
+  namespaceStyleImports: boolean;
+}
+
+/** The answer for any path whose extension no registered language claims. */
+const NON_AST_SEMANTICS: ImporterLanguageSemantics = {
+  wholeModuleImports: false,
+  singleFileImports: false,
+  pythonModules: false,
+  namespaceStyleImports: false,
+};
+
+/**
+ * Memoized `importerFile` -> language semantics, and why this cache is
+ * load-bearing rather than a micro-optimization (#1075).
+ *
+ * `importMatchesTarget` needs four language decisions about the importing
+ * file, and every one of them starts with `detectLanguage(importerFile)` --
+ * i.e. `node:path`'s `extname` plus a `slice`/`toLowerCase`/`Map.get` -- for
+ * the SAME path string, four times per (import, target) pair. A single
+ * `findDependents` call on a large corpus asks that question millions of
+ * times over a set of paths bounded by the corpus size, so the derivation
+ * was measured (CPU profile, OrchardCore, 6,356 files) at 42% of the call's
+ * entire wall time: `detectLanguage` 32.5% self, `extname` alone 10.2%.
+ *
+ * Correctness is not at stake: `detectLanguage` and the three
+ * `LanguageDefinition` flag getters read a registry that is frozen at module
+ * load (`registry.ts` builds `extensionMap` once and throws on duplicates),
+ * so the record is a pure function of the path string. Memoizing it can only
+ * change how long the identical answer takes to produce.
+ *
+ * Bounded by an outright `clear()` at `MAX_IMPORTER_SEMANTICS_CACHE` rather
+ * than an LRU: `lien serve` is long-lived and the key space is "every path
+ * string ever passed in," so an unbounded map is a slow leak. A flat clear
+ * keeps the eviction O(1) with no per-hit bookkeeping, and the only cost of
+ * dropping the whole cache is re-deriving entries that are individually
+ * cheap -- there is no correctness cliff at the boundary, unlike an LRU whose
+ * value is in retaining the hot set.
+ */
+const MAX_IMPORTER_SEMANTICS_CACHE = 20_000;
+const importerSemanticsCache = new Map<string, ImporterLanguageSemantics>();
+
+function importerLanguageSemantics(importerFile: string): ImporterLanguageSemantics {
+  const cached = importerSemanticsCache.get(importerFile);
+  if (cached !== undefined) return cached;
+
+  const language = detectLanguage(importerFile);
+  const semantics: ImporterLanguageSemantics =
+    language === null
+      ? NON_AST_SEMANTICS
+      : {
+          wholeModuleImports: hasWholeModuleImports(language),
+          singleFileImports: hasSingleFileImports(language),
+          pythonModules: language === 'python',
+          namespaceStyleImports: hasNamespaceStyleImports(language),
+        };
+
+  if (importerSemanticsCache.size >= MAX_IMPORTER_SEMANTICS_CACHE) {
+    importerSemanticsCache.clear();
+  }
+  importerSemanticsCache.set(importerFile, semantics);
+  return semantics;
+}
+
+/**
+ * Drop the memoized importer-language records. Exported for tests that need
+ * to prove a cold cache and a warm cache give the same answer; production
+ * code never needs it (the registry the cache derives from is immutable).
+ */
+export function clearImporterSemanticsCache(): void {
+  importerSemanticsCache.clear();
+}
+
+/**
  * True when `importSpecifier` is a bare (slash-free) import from a file whose
  * language sets `LanguageDefinition.wholeModuleImports` (Swift today — see
  * `hasWholeModuleImports`'s doc comment for #869's structural background).
@@ -266,8 +352,7 @@ export function isUnresolvableWholeModuleImport(
   importerFile: string,
 ): boolean {
   if (importSpecifier.includes('/')) return false;
-  const language = detectLanguage(importerFile);
-  return language !== null && hasWholeModuleImports(language);
+  return importerLanguageSemantics(importerFile).wholeModuleImports;
 }
 
 /**
@@ -460,7 +545,15 @@ function matchesRustModSpecifier(normalizedImport: string, normalizedTarget: str
  * match-side call site again:
  * - The #884 whole-module guard (`isUnresolvableWholeModuleImport`) --
  *   `matchesFile` is language-agnostic and cannot know the importer's
- *   language, so this MUST run on the RAW specifier first.
+ *   language, so this MUST run on the RAW specifier first. Spelled inline
+ *   here as `semantics.wholeModuleImports && !importSpecifier.includes('/')`
+ *   rather than as a call to that predicate, purely so the shared
+ *   `importerLanguageSemantics` lookup is done once for all four guards
+ *   (#1075); the two conjuncts are both pure, so testing the language flag
+ *   before the slash is the same decision in the other order, and
+ *   `isUnresolvableWholeModuleImport` remains the single definition every
+ *   OTHER call site (`buildImportIndex`, `indexImportEntry`,
+ *   `test-associations.ts`, `get-files-context.ts`) uses.
  * - The #887 single-file-vs-package-directory distinction
  *   (`requireExactTailForMultiSegment`) -- derived from the importer's
  *   language via `hasSingleFileImports`, since that's the only information
@@ -538,7 +631,11 @@ export function importMatchesTarget(
   normalizedTarget: string,
   normalize: (p: string) => string,
 ): boolean {
-  if (isUnresolvableWholeModuleImport(importSpecifier, importerFile)) return false;
+  // One memoized lookup for all four language decisions, rather than the four
+  // separate `detectLanguage` derivations the individual predicates below each
+  // do -- see `importerLanguageSemantics` for why that mattered (#1075).
+  const semantics = importerLanguageSemantics(importerFile);
+  if (semantics.wholeModuleImports && !importSpecifier.includes('/')) return false;
   if (hasRustModMarker(importSpecifier)) {
     return matchesRustModSpecifier(
       normalize(stripRustModMarker(importSpecifier)),
@@ -548,9 +645,9 @@ export function importMatchesTarget(
   return matchesFile(
     normalize(importSpecifier),
     normalizedTarget,
-    hasSingleFileImportSemantics(importerFile),
-    hasPythonModuleSemantics(importerFile),
-    hasNamespaceMatchingSemantics(importerFile),
+    semantics.singleFileImports,
+    semantics.pythonModules,
+    semantics.namespaceStyleImports,
   );
 }
 
@@ -566,8 +663,7 @@ export function importMatchesTarget(
  * in sync with.
  */
 export function hasSingleFileImportSemantics(importerFile: string): boolean {
-  const language = detectLanguage(importerFile);
-  return language !== null && hasSingleFileImports(language);
+  return importerLanguageSemantics(importerFile).singleFileImports;
 }
 
 /**
@@ -583,7 +679,7 @@ export function hasSingleFileImportSemantics(importerFile: string): boolean {
  * against.
  */
 export function hasPythonModuleSemantics(importerFile: string): boolean {
-  return detectLanguage(importerFile) === 'python';
+  return importerLanguageSemantics(importerFile).pythonModules;
 }
 
 /**
@@ -600,8 +696,7 @@ export function hasPythonModuleSemantics(importerFile: string): boolean {
  * `src/error.rs`) this guards against.
  */
 export function hasNamespaceMatchingSemantics(importerFile: string): boolean {
-  const language = detectLanguage(importerFile);
-  return language !== null && hasNamespaceStyleImports(language);
+  return importerLanguageSemantics(importerFile).namespaceStyleImports;
 }
 
 /**


### PR DESCRIPTION
Fixes #1075.

## The lead was wrong — here is the profile

#1075 framed `buildReExportGraph` as a lead, not a root cause, and asked for a profile first. The profile refutes it. `buildReExportGraph`'s whole-corpus pass is real, and it really does run before the early exit, but it is **0.14% of the cost**, not 95%:

Reproduced first on `origin/main` (3ea2184e), OrchardCore, 6,356 files / 53,118 chunks, target `src/OrchardCore/OrchardCore.Abstractions/OrchardCoreConstants.cs`: **166,009 ms**, 1131 dependents, `dependentAttributionPartial: true` — the issue's cliff, slightly worse on this machine than the 126 s reported.

`node --cpu-prof` on that call, inclusive time:

```
=== INCLUSIVE TIME (top) ===
100.0%    165.86s  (root)
 95.8%    158.84s  findDependents            @ dependency-analyzer.js:978
 95.4%    158.28s  countUncoveredProductionDependents
 95.4%    158.26s  hasTestImporter
 95.3%    158.12s  findDependentChunks
 94.7%    157.04s  addFuzzyMatchChunks
 93.0%    154.22s  importMatchesTarget       @ utils/path-matching.js:488
 42.5%     70.55s  detectLanguage            @ languages/registry.js:92
 33.0%     54.80s  isUnresolvableWholeModuleImport
 15.2%     25.14s  hasSingleFileImportSemantics
 14.5%     24.13s  hasPythonModuleSemantics
 13.7%     22.66s  hasNamespaceMatchingSemantics
 10.2%     16.97s  extname                   @ node:path:1566
  0.1%      0.23s  seedDepth1Dependents      <- the ONLY path buildReExportGraph is on
```

```
=== SELF TIME (top) ===
 32.5%     53.83s  detectLanguage
 29.9%     49.54s  isUnresolvableWholeModuleImport
 10.2%     16.97s  extname
  6.1%     10.10s  importMatchesTarget
```

`seedDepth1Dependents` — which contains both `buildReExportGraph` call sites reachable from `findDependents` — is **0.23 s of 165.86 s**. The whole-corpus re-export scan is a real O(files) pass that is genuinely cheap: it touches each file's chunks once, whereas the actual culprit touches the entire import index once *per dependent*.

## Root cause: an O(dependents × corpus) loop, one level down

`countUncoveredProductionDependents` asks "does any test file import this?" once per production dependent. Its old doc comment claimed it "reuses the existing `importIndex` — no fresh scan," and it did reuse the index — by running a **full `findDependentChunks` fuzzy scan of every bucket in it**, per dependent:

```ts
function hasTestImporter(filepath, ctx) {
  const importers = findDependentChunks(ctx.normalizePathCached(filepath), ctx.importIndex, ...);
  for (const chunk of importers) if (isTestFile(chunk.metadata.file)) return true;
  return false;
}
```

1,131 dependents × 119,461 import entries ≈ **135M `importMatchesTarget` calls** — and the arithmetic checks out against the profile exactly (49.54 s of self time in a two-line `includes('/')` guard is ~0.37 µs × 135M). Every non-test importer was matched and then discarded on the very next line.

It only surfaces on a corpus with a high-fan-out target, which is why it survived: at 800 files with 20 dependents the same code is 16k comparisons.

## The fix: two build-once/resolve-many splits, no changed matching decision

**1. Project the import index down to its test-file importers, once per call.** `hasTestImporter` needs only "does *some* test-file importer match?", and `importMatchesTarget` reads nothing from a chunk beyond `metadata.file`. So the projection keeps one entry per distinct **(importer file, raw specifier)** pair whose importer is a test file — on OrchardCore, 15,339 test import entries collapse to **1,026** (15×), and the whole 119,461-entry index shrinks to those 1,026 (116×). Each dependent then resolves against that in the identical two-branch order (exact bucket counts unconditionally, then fuzzy `importMatchesTarget`), returning on the first hit.

**2. Memoize the per-importer-file language semantics.** `importMatchesTarget` derives four language decisions (#884 whole-module, #887 single-file, #929 Python bare-module, #1028 PHP namespace) and every one of them called `detectLanguage(importerFile)` — hence `node:path`'s `extname` — for the *same path string*, four times per comparison. That derivation was 42% of the profile on its own. The registry `detectLanguage` reads is frozen at module load, so the record is a pure function of the path; the cache is bounded by a flat `clear()` at 20,000 entries so long-lived `lien serve` cannot leak.

Both are pruning/memoization. The set of pairs the matching decision is *asked about* shrinks; the decision itself is untouched. `buildReExportGraph`, `findTransitiveDependents`, and #1044's order-independent `reported`/`queued` BFS are not modified — I read #1044 (`7160546e`) first, and nothing here goes near the traversal.

## Latency, before → after

Same corpus, same target, same process shape:

| | wall time | dependents | caveat |
|---|---|---|---|
| before (`origin/main`) | **166,009 ms** | 1131 | `dependentAttributionPartial: true` |
| after, run 1 | **537 ms** | 1131 | `dependentAttributionPartial: true` |
| after, run 2 | **476 ms** | 1131 | same |
| after, run 3 | **464 ms** | 1131 | same |
| after, run 4 | **479 ms** | 1131 | same |
| after, run 5 | **459 ms** | 1131 | same |

**~350×**, and back well under the documented ~1.5 s floor. Re-profiled after the fix, nothing dominates any more — `findDependents` is 0.45 s total, of which the C# type-reference tier is 0.18 s and this counter 0.16 s; the run's biggest single line item is now `scanAll` (0.58 s) reading the DB.

**Index-time cost added: none.** No precomputed table, no new `createVectorDB` call site, no schema change — so nothing to compose over base ∪ overlay, and no row to add to `index-state-matrix.test.ts` (its completeness guard is green: 46/46). The projection is built per call, lazily: `countUncoveredProductionDependents` returns 0 without building anything when every dependent is a test file.

## Equivalence evidence (oracle, not spot-check)

`hasTestImporterBruteForce` is exported as the never-pruned reference — literally the pre-#1075 whole-index scan — the same role `computeDependentCountsBruteForce` plays for #1071. Two independent oracles:

**Oracle A — the predicate, for every file.** Pruned vs unpruned, per file:

| corpus | files checked | files with a test importer | mismatches |
|---|---|---|---|
| requests (py) | 51 / 51 | 36 | **0** |
| zod (ts) | 454 / 454 | 20 | **0** |
| express (js) | 150 / 150 | 33 | **0** |
| monolog (php) | 232 / 232 | 24 | **0** |
| anyhow (rs) | 40 / 40 | 3 | **0** |
| chi (go) | 86 / 86 | 0 | **0** |
| javapoet (java) | 43 / 43 | 2 | **0** |
| MediatR (cs) | 160 / 160 | 0 | **0** |
| sinatra (rb) | 170 / 170 | 12 | **0** |
| klaxon (kt) | 103 / 103 | 0 | **0** |
| SwiftyJSON (swift) | 27 / 27 | 0 | **0** |
| serilog (cs) | 254 / 254 | 0 | **0** |
| OrchardCore (cs) | see below | | |

Reported honestly: chi, MediatR, klaxon, SwiftyJSON and serilog return `false` for every file, so on those five the predicate-level agreement is vacuous — Go same-package tests don't import their subject, and a C# `using` of a dotted namespace is not resolvable by `matchesFile` (which is why the #930 type-reference tier exists). Those corpora are covered non-vacuously by Oracle B, which compares the full result including `dependents`.

**Oracle B — the whole `findDependents` result, before vs after.** A snapshot of `origin/main`'s parser `dist` and the working-tree build are imported into one process and run against the identical chunk set; every observable field is diffed (`dependents` with all per-entry fields, `productionDependentCount`, `testDependentCount`, `fileComplexities`, `complexityMetrics`, `uncoveredProductionDependents`, `truncated`, all five honesty flags, `targetIndexed`, and the `chunksByFile` key set). Exhaustive over every file, at depth 1 **and** depth 3 (so the BFS path is exercised too):

```
{"corpus":"requests","depth":1,"filesChecked":51,"mismatches":0,"msBefore":5374,"msAfter":1497,"speedup":3.59}
{"corpus":"requests","depth":3,"filesChecked":51,"mismatches":0,"msBefore":31021,"msAfter":13375,"speedup":2.32}
{"corpus":"zod","depth":1,"filesChecked":454,"mismatches":0,"msBefore":37611,"msAfter":8824,"speedup":4.26}
{"corpus":"zod","depth":3,"filesChecked":152,"mismatches":0,"msBefore":92931,"msAfter":21784,"speedup":4.27}
{"corpus":"express","depth":1,"filesChecked":150,"mismatches":0,"msBefore":2434,"msAfter":365,"speedup":6.67}
{"corpus":"express","depth":3,"filesChecked":150,"mismatches":0,"msBefore":9221,"msAfter":2167,"speedup":4.26}
{"corpus":"monolog","depth":1,"filesChecked":232,"mismatches":0,"msBefore":7206,"msAfter":2501,"speedup":2.88}
{"corpus":"monolog","depth":3,"filesChecked":116,"mismatches":0,"msBefore":6853,"msAfter":3026,"speedup":2.26}
{"corpus":"anyhow","depth":1,"filesChecked":40,"mismatches":0,"msBefore":105,"msAfter":43,"speedup":2.44}
{"corpus":"anyhow","depth":3,"filesChecked":40,"mismatches":0,"msBefore":251,"msAfter":84,"speedup":2.99}
{"corpus":"chi","depth":1,"filesChecked":86,"mismatches":0,"msBefore":80,"msAfter":41,"speedup":1.95}
{"corpus":"chi","depth":3,"filesChecked":86,"mismatches":0,"msBefore":76,"msAfter":57,"speedup":1.33}
{"corpus":"javapoet","depth":1,"filesChecked":43,"mismatches":0,"msBefore":473,"msAfter":114,"speedup":4.15}
{"corpus":"javapoet","depth":3,"filesChecked":43,"mismatches":0,"msBefore":553,"msAfter":135,"speedup":4.1}
{"corpus":"MediatR","depth":1,"filesChecked":160,"mismatches":0,"msBefore":2123,"msAfter":1117,"speedup":1.9}
{"corpus":"MediatR","depth":3,"filesChecked":160,"mismatches":0,"msBefore":2124,"msAfter":1072,"speedup":1.98}
{"corpus":"sinatra","depth":1,"filesChecked":170,"mismatches":0,"msBefore":1198,"msAfter":414,"speedup":2.89}
{"corpus":"sinatra","depth":3,"filesChecked":170,"mismatches":0,"msBefore":2379,"msAfter":632,"speedup":3.76}
{"corpus":"klaxon","depth":1,"filesChecked":103,"mismatches":0,"msBefore":256,"msAfter":91,"speedup":2.81}
{"corpus":"klaxon","depth":3,"filesChecked":103,"mismatches":0,"msBefore":272,"msAfter":81,"speedup":3.36}
{"corpus":"SwiftyJSON","depth":1,"filesChecked":27,"mismatches":0,"msBefore":11,"msAfter":10,"speedup":1.1}
{"corpus":"SwiftyJSON","depth":3,"filesChecked":27,"mismatches":0,"msBefore":12,"msAfter":10,"speedup":1.2}
{"corpus":"serilog","depth":1,"filesChecked":254,"mismatches":0,"msBefore":2648,"msAfter":2495,"speedup":1.06}
{"corpus":"serilog","depth":3,"filesChecked":127,"mismatches":0,"msBefore":1405,"msAfter":1315,"speedup":1.07}
{"corpus":"OrchardCore","depth":1,"filesChecked":80,"filesInCorpus":6356,"mismatches":0,"msBefore":86330,"msAfter":27990,"speedup":3.08}
```

On OrchardCore, Oracle B is an 80-file deterministic stride sample rather than exhaustive, and that is a deliberate honest limit: the *before* build costs up to 166 s on a single hub file, so all 6,356 would be days. Oracle A **did** run exhaustively there — all 6,356 files, 0 mismatches, 16 minutes:

```
{"corpus":"OrchardCore","chunks":53118,"filesInCorpus":6356,"filesChecked":6356,"hasTestImporterTrue":0,"mismatches":0,"ms":955840}
```

— but with the same vacuity caveat as the other C# corpora: the answer is `false` for all 6,356, so that run proves the pruned path never *invents* a covered file on the corpus this defect was found on, and cannot confirm the positive direction there. The positive direction is confirmed on requests (36 covered files), express (33), monolog (24), zod (20), sinatra (12), anyhow (3), javapoet (2) — and on this repo itself, 761 files through Oracle B with real test-importer coverage throughout.

**Zero mismatches everywhere.** The oracle scripts and both raw logs are attached as a comment below.

Both oracles also bite: mutating the fast path (dropping the fuzzy branch; dropping the direct-bucket branch) fails 7 and 2 of the new unit tests respectively, and each fixture asserts it produced both a covered and an uncovered file so no equivalence check is vacuously true.

## Dogfood

The real `lien serve` MCP server, in this linked worktree (so through `OverlayBackend`, base ∪ overlay composed — 10,404 chunks), driven over stdio exactly as Claude Code drives it:

```
[Lien MCP] [info] 📦 Linked worktree - refreshing the overlay against the shared base index...
[Lien MCP] [info] ✓ Index is up to date with git state
packages/parser/src/dependency-analyzer.ts  502 ms  dependentCount=25 risk=medium riskReasoning="17 production callers,2 untested,max complexity 11"
packages/parser/src/utils/path-matching.ts   82 ms  dependentCount=31 risk=high   riskReasoning="24 production callers,2 untested,max complexity 11"
packages/parser/src/types.ts                 71 ms  dependentCount=47 risk=high   riskReasoning="33 production callers,4 untested,max complexity 12"
```

(`N untested` is `uncoveredProductionDependents` — the value this PR changes how we compute — surfacing correctly through `riskReasoning`.)

And before/after over the same overlay-composed corpus, on this repo's own hub files plus every file in it:

```
packages/parser/src/dependency-analyzer.ts  dependents=25 prod=17 test=8  uncoveredProd=2  before=767 ms  after=109 ms  identical=true
packages/parser/src/utils/path-matching.ts  dependents=31 prod=24 test=7  uncoveredProd=2  before=930 ms  after= 98 ms  identical=true
packages/parser/src/types.ts                dependents=47 prod=33 test=14 uncoveredProd=4  before=1197 ms after= 70 ms  identical=true
checked 761 files, mismatches=0
```

## Gates

| gate | result |
|---|---|
| `npm run format:check` | pass |
| `npm run lint` | 0 errors (41 pre-existing warnings) |
| `npm run typecheck` | pass |
| `npm run build` | pass |
| `npm test` | 1681 + 60 + 40 + 59 + 5 + 1 files, all pass |
| `lien delta` | **exit 0** — no crossings |

`lien delta` detail, since the `review` gate is delta-aware and this touches a hot function: 4 worsened, 3 improved, no new-over-threshold. The largest is `hasTestImporter` cognitive 3 → 8 against a threshold of 15 (it went from a one-liner to a two-branch scan; I extracted the inner loop to `.some` to bring it down from 10). `countUncoveredProductionDependents` moves on Halstead *time* only (5m → 12m). Nothing crosses a warning threshold, so no complexity violation exists to be reported at any severity.

Changeset included (`@liendev/parser` + `@liendev/lien` patch), which also triggers the 11-corpus E2E matrix (#1066).

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR is a performance fix for `get_dependents` that replaces a per-dependent full import-index scan with a once-built test-importer projection and adds a bounded memoization cache for per-importer language semantics. The matching logic is intentionally unchanged; the new code is equivalent to the old brute-force path and is validated by exported oracle functions and extensive equivalence tests across real corpora. No correctness-affecting bugs were found.
>
> - Replaced O(dependents × corpus) test-importer scan with a single projection of the import index down to test-file importers, deduplicated by (importer file, raw specifier).
> - Added a bounded per-path cache for the four language-semantics decisions used by `importMatchesTarget`, with a flat clear at 20,000 entries to prevent long-lived `lien serve` leakage.
> - Exported `hasTestImporterBruteForce` and `hasTestImporterFromChunks` as test-facing oracle functions to prove equivalence against the old whole-index scan.

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 27788d4. Updates automatically on new commits.</sup>
<!-- /lien-stats -->
