### PR TITLE
fix(parser,cli,review): name the fallback behind an inferred dependent (#1018)

### DIFF
--- a/.changeset/brave-pandas-consolidate.md
+++ b/.changeset/brave-pandas-consolidate.md
@@ -1,0 +1,40 @@
+---
+'@liendev/parser': patch
+'@liendev/lien': patch
+'@liendev/review': patch
+---
+
+fix(parser,cli,review): name the fallback behind an inferred dependent (#1018)
+
+`get_dependents`' `dependent-attribution-partial` caveat described C#'s
+type-reference fallback in every case, because `confidence: 'inferred'` was
+single-valued and the mechanism identity was discarded at the parser boundary.
+When #1039 added Go's root-package export lookup — same marker, same caveat
+reason — every recovered Go file was told *"its language, C#, lets real callers
+use its exports with no per-file import naming it at all"* and that its
+dependents came from *"matching a uniquely-declared type name against other
+files' source text"*. Both false; measured on a real `go-chi/chi` clone, 24 of
+24 recovered edges across `context.go`/`mux.go`/`chain.go`.
+
+`@liendev/parser` now owns `INFERRED_DEPENDENT_MECHANISMS`, a `Record`-guarded
+table of the non-import recovery fallbacks and their canonical prose, and
+`DependentInfo.inferredVia` names the mechanism per dependent. Every
+consumer-facing surface — the caveat note, the caveat-reason text, the server
+instructions, the tool description and the docs page — derives from the table
+instead of restating it, so a third fallback is a compile error until its prose
+exists and then correct everywhere at once.
+
+`DependentInfo.confidence` is unchanged and still marks exactly what it did;
+`inferredVia` is additive. `review`'s `isPreciseProvenance` returns exactly what
+it returned for all seven tiers, now via a `Record<EdgeProvenance, boolean>` so
+an eighth tier can't default silently.
+
+Also fixes two doc-truth defects on the MCP tools page found while mapping the
+surfaces: `dependent-attribution-partial` was documented as C#-only, and
+`testAssociations[]` was documented as `{ testFile, confidence, method }` with a
+"Confidence Levels" section — a shape and vocabulary that exist nowhere in the
+code (the real field is `string[]`), attributed to a tool that never emitted the
+field.
+
+ADR-016 records why the three vocabularies #1018 named were not merged into one,
+and the routing rule for where a new honesty signal belongs.

--- a/docs/architecture/decisions/0016-dependency-attribution-honesty-axes.md
+++ b/docs/architecture/decisions/0016-dependency-attribution-honesty-axes.md
@@ -104,12 +104,16 @@ natural home.
 
 `confidence: 'inferred'` was single-valued, so the mechanism identity was
 discarded at `parser`'s boundary and every prose surface had to name a
-mechanism from memory. When #930 shipped there was one (C#), so six surfaces
-hard-coded C#. #1039/#1064 then added Go's root-package export lookup —
-same marker, same caveat reason — and updated none of them, because nothing
-forced it: `Record<AttributionCaveatReason, string>` guards the set of
-*reasons*, and no reason was added. Only an existing reason's mechanism
-coverage widened.
+mechanism from memory. When #930 shipped there was one (C#), so all six
+surfaces described C#'s mechanism specifically — four of them naming C# by
+name (the runtime caveat note, the `AttributionCaveatReason` doc comment, the
+tool description, the docs page), the other two saying "text-matching
+fallback" (`ATTRIBUTION_CAVEAT_REASON_TEXT` and, by interpolation, the server
+instructions), which is equally wrong for Go. #1039/#1064 then added Go's
+root-package export lookup — same marker, same caveat reason — and updated
+none of them, because nothing forced it:
+`Record<AttributionCaveatReason, string>` guards the set of *reasons*, and no
+reason was added. Only an existing reason's mechanism coverage widened.
 
 Measured on a real `go-chi/chi` clone against `origin/main`, every recovered
 Go root file was told *"its language, C#, lets real callers use its exports

--- a/docs/architecture/decisions/0016-dependency-attribution-honesty-axes.md
+++ b/docs/architecture/decisions/0016-dependency-attribution-honesty-axes.md
@@ -82,11 +82,18 @@ shared bucketing predicate would have to make one of those two answers
 wrong.
 
 Independently: four of `EdgeProvenance`'s seven tiers (`import-only`,
-`require-only`, `symbol-name-match`, `oop-method-import`) are symbol-level
-distinctions `parser`'s file-level `findDependents` cannot produce. Hoisting
-the enum into `parser` would publish tiers nothing in `parser` emits — a
-vocabulary with dead members, which is worse than two honest ones. So
-`EdgeProvenance` stays `review`'s internal ranking detail.
+`require-only`, `symbol-name-match`, `oop-method-import`) are distinctions
+that only arise *in* a symbol-level analysis — each records something
+different about what could be established for the specific symbol, which is a
+question `parser`'s file-level `findDependents` never asks. Note this is not a
+claim that those four tiers all verify a symbol: `require-only` and
+`symbol-name-match` explicitly do not, which is why
+`SYMBOL_VERIFIED_BY_PROVENANCE` marks them `false`. The point is that a
+file-level pipeline has no way to *draw* the distinction at all, in either
+direction. Hoisting the enum into `parser` would therefore publish tiers
+nothing in `parser` emits — a vocabulary with dead members, which is worse
+than two honest ones. So `EdgeProvenance` stays `review`'s internal ranking
+detail.
 
 ### Why Axis B was already consolidated
 

--- a/docs/architecture/decisions/0016-dependency-attribution-honesty-axes.md
+++ b/docs/architecture/decisions/0016-dependency-attribution-honesty-axes.md
@@ -1,0 +1,255 @@
+# ADR-016: Dependency-Attribution Honesty Has Two Axes and Three Scopes — Route, Don't Merge
+
+**Status**: Accepted
+**Date**: 2026-08-05
+**Deciders**: Core Team
+**Related**: #1018 (proposal and the refusal recorded here), PR for #1018
+(implementation) · #930, #940, #951, #980, #984, #994, #1005, #1011, #1013,
+#1014, #1015, #1026, #1030, #1039, #1064, #1067, #1072, #1078
+
+## Context and Problem Statement
+
+#1018 observed that three vocabularies answer what looks like one question —
+*how much should a consumer trust this dependency answer?* — and proposed
+consolidating them into a single canonical type owned by `parser`, which
+`core`, `cli` and `review` would consume instead of maintaining parallel
+dialects:
+
+| vocabulary | home | shape |
+|---|---|---|
+| `confidence?: 'inferred'` | `packages/parser/src/dependency-analyzer.ts` | single-valued, per dependent |
+| `EdgeProvenance` | `packages/review/src/dependency-graph.ts` | 7 ranked tiers, per caller edge |
+| `AttributionCaveatReason` | `packages/cli/src/mcp/attribution-caveat-reasons.ts` | 5 reasons, per response |
+
+The pressure was real. Four consumers had been blocked or had bent around
+the gap: #1072 needed to express whole-store and whole-language properties
+and fell back to the `note` channel plus omission; #1067's declaration-index
+tier named a missing caveat reason as an explicit prerequisite, its concept
+currently living as prose in four separate signal-module doc comments; #1015
+wants to say a count is a floor distinctly from the existing caveat; and an
+evaluation of coverage-derived test associations found `testAssociations:
+string[]` carries no provenance at all.
+
+The decision needed was not "merge or don't" but *what is actually one
+decision here, and what is several*.
+
+## Decision Drivers
+
+- A consumer-facing honesty signal must get **more** specific under
+  consolidation, never vaguer. #1014 is the cost of a signal that fires
+  wrongly; a signal that fires vaguely is the same failure with extra steps.
+- Whatever replaces or extends an existing vocabulary must keep its
+  build-breaking forcing function (#984's `Record<>` pattern). Prose that can
+  drift silently is the defect class this repo bleeds.
+- `review` depends on `parser` only, never `core` (ADR-012). `parser` is the
+  one package all three consumers already import.
+- Preserve shipped behaviour: #1026's caveat reasons, #1030's
+  verified/inferred bucketing, #1072's note-and-omission.
+
+## Decision Outcome
+
+**The three vocabularies were NOT merged.** They sit on two different axes,
+and one of the three is already downstream of the other's canonical facts.
+What *was* consolidated is the one thing genuinely decided in more than one
+place and demonstrably wrong in production: **the identity of the recovery
+mechanism behind an inferred dependent.**
+
+### The model: two axes, three scopes
+
+**Axis A — how was this edge resolved?** A property of an individual edge
+that is present. `parser`'s `confidence` and `review`'s `EdgeProvenance` both
+live here.
+
+**Axis B — why can't this answer be trusted as a verified clear?** A property
+of an answer, usually about what is *absent*. `cli`'s
+`AttributionCaveatReason` lives here, and nothing else does.
+
+Orthogonal to both, a signal has one of three **scopes**: per-edge,
+per-answer (about a caller-supplied `filepath`), or per-store/per-language
+(a capability of the index or the language, independent of any query).
+
+### Why Axis A's two members must stay separate
+
+They are the same axis at **different granularities**, and each is correct
+for its own.
+
+`require-only` is the proof. A Ruby `require_relative` verifiably resolves
+the target *file*, so `parser`'s file-level `findDependents` correctly treats
+that dependent as import-verified and attaches no `confidence` marker. The
+same statement names no *symbol* at all, so `review`'s symbol-level graph
+correctly ranks it imprecise — the boundary #1030 argued from evidence. One
+shared bucketing predicate would have to make one of those two answers
+wrong.
+
+Independently: four of `EdgeProvenance`'s seven tiers (`import-only`,
+`require-only`, `symbol-name-match`, `oop-method-import`) are symbol-level
+distinctions `parser`'s file-level `findDependents` cannot produce. Hoisting
+the enum into `parser` would publish tiers nothing in `parser` emits — a
+vocabulary with dead members, which is worse than two honest ones. So
+`EdgeProvenance` stays `review`'s internal ranking detail.
+
+### Why Axis B was already consolidated
+
+`AttributionCaveatReason` is not an independent taxonomy. `buildAttributionCaveat`
+derives all five reasons from fields `parser` already owns on
+`FindDependentsResult`: `targetIndexed`, `symbolAttributionDegraded`,
+`symbolFoundInFile`, `typeSymbolAttributionIncomplete`,
+`dependentAttributionPartial`, `dependentAttributionIncomplete`. The
+structural facts are in `parser`; `attribution-caveat-reasons.ts` is the
+prose and mutual-exclusion layer over them. Moving model-facing prose into
+the AST package would gain nothing and cost the #984 forcing function its
+natural home.
+
+### What was actually broken, and fixed
+
+`confidence: 'inferred'` was single-valued, so the mechanism identity was
+discarded at `parser`'s boundary and every prose surface had to name a
+mechanism from memory. When #930 shipped there was one (C#), so six surfaces
+hard-coded C#. #1039/#1064 then added Go's root-package export lookup —
+same marker, same caveat reason — and updated none of them, because nothing
+forced it: `Record<AttributionCaveatReason, string>` guards the set of
+*reasons*, and no reason was added. Only an existing reason's mechanism
+coverage widened.
+
+Measured on a real `go-chi/chi` clone against `origin/main`, every recovered
+Go root file was told *"its language, C#, lets real callers use its exports
+with no per-file import naming it at all"* and that its dependents were
+*"recovered by matching a uniquely-declared type name against other files'
+source text"* — both false, on 24 of 24 recovered edges across
+`context.go`/`mux.go`/`chain.go`.
+
+So `parser` now owns `INFERRED_DEPENDENT_MECHANISMS`
+(`inferred-dependent-mechanisms.ts`): a `Record`-guarded table of the
+non-import fallbacks and their canonical prose, with `DependentInfo.inferredVia`
+naming the mechanism per dependent. Every consumer-facing surface derives
+from the table instead of restating it. The two forcing functions compose —
+one guards the set of reasons, the other the set of mechanisms.
+
+### The routing rule for a new honesty signal
+
+1. Is it about **an edge that is present**? Axis A. A new non-import recovery
+   mechanism is a new entry in `INFERRED_DEPENDENT_MECHANISMS`; a new
+   symbol-level resolution tier is a new `EdgeProvenance` member (and a new
+   row in `SYMBOL_VERIFIED_BY_PROVENANCE`).
+2. Is it about **why an answer about a caller-supplied `filepath`** isn't a
+   verified clear? Axis B — a new `AttributionCaveatReason`.
+3. Is it a property of **the store or the language**, true independently of
+   any query? Neither axis. Use the response-level `note` channel and the
+   existing predicates (`hasDependentAttributionBlindSpot`,
+   `hasDependentCounts`, `classifyIndexState`). #1078 got this right and its
+   reasoning holds.
+
+Under this rule #1067's prerequisite — a first-class home for *"unique among
+indexed declarations in this scope; a reference may still resolve to an
+unindexed stdlib/third-party declaration of the same name"* — is a new entry
+in `INFERRED_DEPENDENT_MECHANISMS`, not a fifth doc comment and not a sixth
+caveat reason. Adding it makes all six prose surfaces correct with no
+further edits.
+
+## Considered Options
+
+1. **One canonical enum in `parser`, consumed by all three** (#1018's
+   proposal). Rejected: forces one of Axis A's two granularities to be
+   wrong, publishes dead tiers from `parser`, and would widen
+   `AttributionCaveatReason`'s documented meaning across the five prose
+   surfaces #980 had to reconcile — for a category it isn't about.
+2. **Close #1018 as won't-fix**, with each blocked consumer getting a
+   narrow targeted fix. Rejected: the axis model would stay undocumented and
+   get relitigated a fifth time, and the shipped Go/C# prose defect would
+   stay shipped.
+3. **Record the axis model; consolidate only the recovery-mechanism
+   identity; keep the per-axis forcing functions.** Selected.
+
+## Consequences
+
+### Positive
+
+- The Go prose defect is fixed, and its recurrence is a compile error.
+- #1067 is unblocked without a new vocabulary: one table entry, six surfaces
+  correct.
+- `isPreciseProvenance` no longer defaults a new tier silently to "not
+  precise" — `Record<EdgeProvenance, boolean>` forces the decision, the same
+  move ADR-015 made for `LanguageDefinition`'s matcher-path fields.
+- Two live doc-truth defects in the public docs page were found and fixed
+  while mapping the surfaces: `dependent-attribution-partial` was documented
+  as C#-only, and `testAssociations[]` was documented as
+  `{ testFile, confidence, method }` with a "Confidence Levels" section —
+  a shape and vocabulary that exist nowhere in the code (the real field is
+  `string[]`), on a tool (`search_code`) that never emitted the field at all.
+
+### Negative / Risks
+
+- Three vocabularies still exist. This ADR argues they should, but a reader
+  who only counts them will read that as the problem unfixed. The routing
+  rule is the mitigation; the ADR is the answer to the fifth relitigation.
+- `INFERRED_DEPENDENT_MECHANISMS`' prose is asserted correct per mechanism by
+  a test that checks distinctness and a few anchor phrases, not by anything
+  that can verify a sentence actually describes the code. A wrong-but-distinct
+  description would pass.
+- The word "confidence" remains overloaded across unrelated concepts —
+  `DependentInfo.confidence`, `review`'s Confidence column, and
+  `StaleLiteralCandidate.confidence: 'low'|'medium'|'high'` (an unrelated
+  stale-literal score). Not renamed here; noted so the next reader doesn't
+  mistake the collision for duplication.
+
+### Neutral
+
+- No semantics change. No caveat starts or stops firing, no dependent's
+  `confidence` value changes, `isPreciseProvenance` returns exactly what it
+  returned for all seven tiers, and #1072's note-and-omission is untouched.
+  `DependentInfo.inferredVia` is additive; a consumer filtering
+  `confidence === 'inferred'` is unaffected.
+
+## Deliberately Out of Scope
+
+- **`lien annotate`'s test-coverage tiers.** `formatTests` distinguishes
+  four mechanisms in hand-written prose over four parallel arrays
+  (`tests`, `packageLevelTests`, `symbolUsageTests`,
+  `csharpTypeReferenceTests`) — the same decision as Axis A, at another
+  surface, and the next site to consolidate. Left alone because it needs a
+  data-shape change to `testAssociations`, not a prose fix, and nothing is
+  blocked on it today.
+- **Per-association provenance on `testAssociations`.** The consumer that
+  motivated it — coverage-derived associations — was evaluated and rejected
+  (no coverage artifact in 40 of 40 real checkouts). Building the vocabulary
+  for a feature that will not be built is the wrong order.
+- **A "stronger than import-verified" direction.** `confidence` can only mark
+  something weaker, which was raised as a limitation. No live consumer needs
+  "stronger"; the one candidate was coverage-derived associations, above.
+- **#1015's "this count is a floor" for real type-reference counting.** When
+  that lands, `type-symbol-attribution-incomplete`'s prose needs updating (it
+  currently says usages are "often 0"). A prose update at that time, not a
+  vocabulary gap now.
+- **Renaming the overloaded `confidence`.** A wide mechanical rename with no
+  behavioural benefit.
+
+## Validation
+
+1. **Behaviour-preserving on Axis A's bucketing**: `isPreciseProvenance`'s
+   existing table-driven test covers all seven tiers and passes unchanged.
+2. **The defect is pinned in both directions**: a Go-mechanism response must
+   not contain `C#`, `global using` or `source text`, and must contain Go's
+   real mechanism; the C# case must still contain C#'s.
+3. **The pairing invariant is asserted in both directions**: `confidence ===
+   'inferred'` iff `inferredVia !== undefined`, and an import-verified
+   dependent carries neither.
+4. **Dogfooded through a real `lien serve` over stdio** against a real
+   `go-chi/chi` clone, before and after — see the PR body.
+
+## References
+
+- `packages/parser/src/inferred-dependent-mechanisms.ts`: the table, its
+  forcing function, and the measured defect it exists to prevent
+- `packages/parser/src/dependency-analyzer.ts`: `DependentInfo.confidence` /
+  `inferredVia` and `inferredDependent()`, the single constructor for the pair
+- `packages/cli/src/mcp/attribution-caveat-reasons.ts`: Axis B's reasons and
+  the #984 `Record<>` forcing function, plus why the two guards compose
+- `packages/review/src/dependency-graph.ts`:
+  `SYMBOL_VERIFIED_BY_PROVENANCE` and `isPreciseProvenance`
+- `docs/architecture/index-state-honesty.md`: the scope-3 policy this ADR
+  routes to rather than duplicates
+- ADR-012: why `review` cannot depend on `core`, which makes `parser` the
+  only shared home
+- ADR-015: the precedent for turning a repeatedly-relitigated cross-cutting
+  decision into a compiler-forced contract, and for recording a rejected
+  proposal alongside the accepted one

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -21,6 +21,7 @@ This directory contains Architectural Decision Records (ADRs) documenting signif
 | [ADR-013](0013-prebuilt-native-parser-napi-rs.md) | Prebuilt Native Parser via napi-rs (`@liendev/parser-native`) | 2026-07-08 | Accepted |
 | [ADR-014](0014-per-rule-candidate-loop-passes.md) | Per-Rule Candidate-Loop Passes for Agent Review | 2026-07-16 | Accepted |
 | [ADR-015](0015-required-matcher-path-language-fields.md) | Make Per-Language Matching Policy Mandatory and Declarative | 2026-08-01 | Accepted |
+| [ADR-016](0016-dependency-attribution-honesty-axes.md) | Dependency-Attribution Honesty Has Two Axes and Three Scopes — Route, Don't Merge | 2026-08-05 | Accepted |
 
 ## Conventions
 

--- a/packages/cli/src/mcp/attribution-caveat-reasons.ts
+++ b/packages/cli/src/mcp/attribution-caveat-reasons.ts
@@ -1,3 +1,5 @@
+import { summarizeInferredDependentMechanisms } from '@liendev/parser';
+
 /**
  * Why a `get_dependents` answer's counts can't be trusted as a verified
  * clear (#940). Exactly one reason can ever apply to a given response --
@@ -26,16 +28,21 @@
  *   top-level export at all; this one fires when it very much IS one, just
  *   not the kind of export call-site tracking can see through.
  * - `dependent-attribution-partial`: a file-level query (no `symbol`) found
- *   zero import-based dependents, but the C# type-reference-matching
- *   fallback recovered one or more (#930 part 2) -- those entries are
- *   tagged `confidence: 'inferred'` in `dependents`, and the counts are a
- *   recovered lower bound, not a verified/complete answer.
+ *   zero import-based dependents, but ONE OF PARSER'S NON-IMPORT FALLBACKS
+ *   recovered one or more -- those entries are tagged `confidence: 'inferred'`
+ *   in `dependents` and name the mechanism that recovered them in
+ *   `inferredVia`, and the counts are a recovered lower bound, not a
+ *   verified/complete answer. Which fallbacks exist is deliberately NOT listed
+ *   here: `@liendev/parser`'s `INFERRED_DEPENDENT_MECHANISMS` is the single
+ *   source, and this reason's text below derives from it. Listing them here is
+ *   exactly what went stale when #1039 added Go's alongside #930's C# one
+ *   (#1018).
  * - `dependent-attribution-incomplete`: a file-level query (no `symbol`)
  *   came back with zero dependents in a language where the import graph
  *   structurally can't see every real usage, e.g. C#'s `global using` /
  *   implicit enclosing-namespace access (#930, #936), or Java/Kotlin's
  *   same-package visibility and Swift's whole-module access (#1005), EVEN
- *   AFTER the type-reference-matching fallback also found nothing.
+ *   AFTER any applicable fallback above also found nothing.
  *
  * This is the SINGLE SOURCE for the model/user-facing explanation of each
  * reason (`ATTRIBUTION_CAVEAT_REASON_TEXT` below). #941 hand-wrote this
@@ -68,6 +75,13 @@ export type AttributionCaveatReason =
  * object literal unless it has EXACTLY the union's members as keys -- add a
  * fifth reason to the union and this line fails to compile until its text
  * is added here too.
+ *
+ * That guard covers the set of REASONS, and only that. It cannot see a change
+ * in what an existing reason COVERS, which is how #1039's second recovery
+ * mechanism reached production with five surfaces still saying "C#" (#1018).
+ * `dependent-attribution-partial` below therefore derives its mechanism list
+ * from `@liendev/parser`'s own `Record`-guarded table instead of naming any
+ * mechanism itself -- the two forcing functions compose, one per axis.
  */
 export const ATTRIBUTION_CAVEAT_REASON_TEXT: Record<AttributionCaveatReason, string> = {
   'unresolved-target':
@@ -94,18 +108,19 @@ export const ATTRIBUTION_CAVEAT_REASON_TEXT: Record<AttributionCaveatReason, str
 
   'dependent-attribution-partial':
     'a file-level query (no symbol) found zero import-based dependents, but a lower-confidence ' +
-    'text-matching fallback recovered some dependents anyway (those entries carry ' +
-    'confidence: "inferred"). Treat the counts as a recovered floor, not a complete answer — ' +
-    'the fallback can still miss a real dependent reached via an alias, a generic type ' +
-    'argument, or reflection.',
+    'non-import fallback recovered some dependents anyway (those entries carry ' +
+    'confidence: "inferred", and inferredVia names which fallback found them; today ' +
+    `${summarizeInferredDependentMechanisms()} have one). Treat the counts as a recovered ` +
+    'floor, not a complete answer — the note explains what that specific fallback can still ' +
+    'miss.',
 
   'dependent-attribution-incomplete':
     'a file-level query (no symbol) came back with zero dependents in a language where the ' +
     "import graph structurally can't see every real usage (e.g. C#'s global using / implicit " +
     "enclosing-namespace access, Java/Kotlin's same-package visibility, or Swift's " +
-    'whole-module access), even after the text-matching fallback above also found nothing. ' +
-    'Treat dependentCount: 0 and riskLevel: "low" as a floor, not a finding — verify with ' +
-    'grep before concluding the file is unused.',
+    'whole-module access), even after any applicable non-import fallback above also found ' +
+    'nothing. Treat dependentCount: 0 and riskLevel: "low" as a floor, not a finding — verify ' +
+    'with grep before concluding the file is unused.',
 };
 
 /**

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
@@ -799,6 +799,8 @@ describe('findDependents', () => {
       expect(result.dependents[0]).toMatchObject({
         filepath: 'Padding.cs',
         confidence: 'inferred',
+        // #1018: names the mechanism so the caveat note need not assume it.
+        inferredVia: 'csharp-type-reference',
       });
       expect(result.productionDependentCount).toBe(1);
       expect(result.dependentAttributionPartial).toBe(true);

--- a/packages/cli/src/mcp/handlers/get-dependents.test.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleGetDependents } from './get-dependents.js';
 import type { ToolContext } from '../types.js';
 import type { SearchResult } from '@liendev/core';
+import type { InferredDependentMechanism } from '@liendev/parser';
 
 // Mock the dependency-analyzer module
 vi.mock('./dependency-analyzer.js', async importOriginal => {
@@ -47,6 +48,7 @@ describe('handleGetDependents', () => {
         usages?: Array<{ callerSymbol: string; line: number; snippet: string }>;
         hops?: number;
         confidence?: 'inferred';
+        inferredVia?: InferredDependentMechanism;
       }>;
       hitLimit?: boolean;
       complexityMetrics?: {
@@ -793,6 +795,7 @@ describe('handleGetDependents', () => {
               filepath: 'src/Serilog/Rendering/Padding.cs',
               isTestFile: false,
               confidence: 'inferred',
+              inferredVia: 'csharp-type-reference',
             },
           ],
           dependentAttributionPartial: true,
@@ -813,6 +816,70 @@ describe('handleGetDependents', () => {
       expect(parsed.attributionCaveat.reason).toBe('dependent-attribution-partial');
       expect(parsed.attributionCaveat.note).toContain('Alignment.cs');
       expect(parsed.attributionCaveat.note).toContain('lower bound'.toUpperCase());
+      expect(parsed.attributionCaveat.note).toContain('C#');
+      expect(parsed.attributionCaveat.note).toContain('global using');
+    });
+
+    // #1018: this fallback is no longer C#-only. Before this fix the note below
+    // told every recovered Go file "its language, C#" and described a
+    // source-text type-name scan — measured on a real go-chi/chi clone, 24 of
+    // 24 recovered edges across context.go/mux.go/chain.go.
+    it("describes GO's fallback, not C#'s, when Go's root-package lookup recovered the dependents", async () => {
+      vi.mocked(findDependents).mockResolvedValue(
+        createMockAnalysis({
+          dependents: [
+            {
+              filepath: 'middleware/clean_path.go',
+              isTestFile: false,
+              confidence: 'inferred',
+              inferredVia: 'go-root-package-export',
+            },
+          ],
+          dependentAttributionPartial: true,
+        }),
+      );
+
+      const result = await handleGetDependents({ filepath: 'context.go' }, mockCtx);
+
+      const parsed = JSON.parse(result.content![0].text);
+      const note = parsed.attributionCaveat.note as string;
+      expect(parsed.attributionCaveat.reason).toBe('dependent-attribution-partial');
+      expect(note).toContain('its language, Go');
+      // The regression this test exists for, asserted directly.
+      expect(note).not.toContain('C#');
+      expect(note).not.toContain('global using');
+      expect(note).not.toContain('source text');
+      // And it must actually describe Go's real mechanism.
+      expect(note).toContain('import path');
+      expect(note).toContain('exports');
+    });
+
+    it('describes both fallbacks when a response somehow carries both', async () => {
+      vi.mocked(findDependents).mockResolvedValue(
+        createMockAnalysis({
+          dependents: [
+            {
+              filepath: 'a.cs',
+              isTestFile: false,
+              confidence: 'inferred',
+              inferredVia: 'csharp-type-reference',
+            },
+            {
+              filepath: 'b.go',
+              isTestFile: false,
+              confidence: 'inferred',
+              inferredVia: 'go-root-package-export',
+            },
+          ],
+          dependentAttributionPartial: true,
+        }),
+      );
+
+      const result = await handleGetDependents({ filepath: 'target.cs' }, mockCtx);
+
+      const note = JSON.parse(result.content![0].text).attributionCaveat.note as string;
+      expect(note).toContain('its language, C# and Go');
+      expect(note).toContain('2 of the 2 dependent(s)');
     });
 
     it('does not fire alongside dependent-attribution-incomplete', async () => {

--- a/packages/cli/src/mcp/handlers/get-dependents.ts
+++ b/packages/cli/src/mcp/handlers/get-dependents.ts
@@ -4,7 +4,11 @@ import { GetDependentsSchema } from '../schemas/index.js';
 import { findUnindexedPaths, formatUnindexedPathsNote } from '../utils/unindexed-paths.js';
 import { relabelCallerReasoning } from '../../utils/blast-radius-reasoning.js';
 import type { ToolContext, MCPToolResult } from '../types.js';
-import { computeBlastRadiusRisk, type BlastRadiusRisk } from '@liendev/parser';
+import {
+  computeBlastRadiusRisk,
+  describeInferredDependentRecovery,
+  type BlastRadiusRisk,
+} from '@liendev/parser';
 import type { AttributionCaveatReason } from '../attribution-caveat-reasons.js';
 import {
   findDependents,
@@ -160,6 +164,38 @@ function computeRisk(analysis: DependencyAnalysisResult): BlastRadiusRisk {
 }
 
 /**
+ * The `dependent-attribution-partial` note, describing the fallback(s) that
+ * ACTUALLY recovered these dependents rather than assuming which one ran.
+ *
+ * Every mechanism-specific clause comes from `@liendev/parser`'s
+ * `INFERRED_DEPENDENT_MECHANISMS`, keyed by each dependent's own `inferredVia`.
+ * This sentence previously hard-coded C#'s language and mechanism, so when
+ * #1039 added Go's root-package fallback — same `confidence: 'inferred'` tag,
+ * same caveat reason — every recovered Go file was told "its language, C#" and
+ * that its dependents came from matching a type name against source text.
+ * Measured on a real `go-chi/chi` clone: 24 of 24 recovered edges across
+ * `context.go`/`mux.go`/`chain.go`. See #1018.
+ */
+function buildPartialRecoveryNote(analysis: DependencyAnalysisResult, filepath: string): string {
+  const inferred = analysis.dependents.filter(d => d.confidence === 'inferred');
+  const mechanisms = [
+    ...new Set(
+      inferred.map(d => d.inferredVia).filter((m): m is NonNullable<typeof m> => m !== undefined),
+    ),
+  ];
+  const { languageLabel, importGraphBlindSpot, recovery, residualRisk } =
+    describeInferredDependentRecovery(mechanisms);
+  return (
+    `The import graph found zero import-based dependents for ${filepath} (its language, ` +
+    `${languageLabel}, ${importGraphBlindSpot}), but ${inferred.length} of the ` +
+    `${analysis.dependents.length} dependent(s) below were recovered by ${recovery} ` +
+    `(marked "confidence": "inferred" in \`dependents\`, with \`inferredVia\` naming the ` +
+    `fallback). Treat dependentCount/riskLevel as a recovered LOWER BOUND, not a ` +
+    `verified/complete answer — this heuristic ${residualRisk}.`
+  );
+}
+
+/**
  * Decide which (if any) attribution caveat applies, and build its note.
  *
  * The five reasons are mutually exclusive by construction, so at most one
@@ -252,19 +288,9 @@ function buildAttributionCaveat(
     return { reason: 'type-symbol-attribution-incomplete', note };
   }
   if (analysis.dependentAttributionPartial) {
-    const inferredCount = analysis.dependents.filter(d => d.confidence === 'inferred').length;
     return {
       reason: 'dependent-attribution-partial',
-      note:
-        `The import graph found zero import-based dependents for ${filepath} (its language, C#, ` +
-        `lets real callers use its exports with no per-file import naming it at all — "global ` +
-        `using" / implicit enclosing-namespace member access), but ${inferredCount} of the ` +
-        `${analysis.dependents.length} dependent(s) below were recovered by matching a ` +
-        `uniquely-declared type name against other files' source text (marked ` +
-        `"confidence": "inferred" in \`dependents\`). Treat dependentCount/riskLevel as a ` +
-        `recovered LOWER BOUND, not a verified/complete answer — this heuristic can still miss a ` +
-        `real dependent that references the type via an alias, a generic type argument, or ` +
-        `reflection.`,
+      note: buildPartialRecoveryNote(analysis, filepath),
     };
   }
   if (analysis.dependentAttributionIncomplete) {

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -1,3 +1,5 @@
+import { summarizeInferredDependentMechanisms } from '@liendev/parser';
+
 import { toMCPToolSchema } from './utils/zod-to-json-schema.js';
 import {
   SearchCodeSchema,
@@ -8,7 +10,6 @@ import {
   GetComplexitySchema,
 } from './schemas/index.js';
 import { ATTRIBUTION_CAVEAT_REASON_TEXT } from './attribution-caveat-reasons.js';
-import { summarizeInferredDependentMechanisms } from '@liendev/parser';
 
 /**
  * MCP tool definitions with Zod-generated schemas.

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -8,6 +8,7 @@ import {
   GetComplexitySchema,
 } from './schemas/index.js';
 import { ATTRIBUTION_CAVEAT_REASON_TEXT } from './attribution-caveat-reasons.js';
+import { summarizeInferredDependentMechanisms } from '@liendev/parser';
 
 /**
  * MCP tool definitions with Zod-generated schemas.
@@ -149,11 +150,13 @@ Returns:
   signal among dependents always lifts this above "low", even when every dependent
   is fully tested (testedness lowers the chance of a *silent* break, it does not
   shrink the blast radius). Check riskReasoning for which signal(s) drove it.
-- dependents[]: { filepath, isTestFile, usages[]?, confidence?: "inferred" }
-  \`confidence: "inferred"\` marks a dependent recovered by text-matching a
-  uniquely-declared type name (C#'s global-using gap, see
-  dependent-attribution-partial below) rather than a real import edge — absent
-  entirely on every ordinary, import-verified dependent.
+- dependents[]: { filepath, isTestFile, usages[]?, confidence?: "inferred", inferredVia? }
+  \`confidence: "inferred"\` marks a dependent recovered by a non-import fallback
+  rather than a real import edge — absent entirely on every ordinary,
+  import-verified dependent. \`inferredVia\` names which fallback found it (today
+  ${summarizeInferredDependentMechanisms()} have one); the attributionCaveat note
+  spells out what that specific fallback can miss. See
+  dependent-attribution-partial below.
 - complexityMetrics: { averageComplexity, maxComplexity, highComplexityDependents[] }
 - totalUsageCount?: number (when symbol parameter provided)
 - attributionCaveat?: { reason, note } — present whenever dependentCount/riskLevel

--- a/packages/parser/src/dependency-analyzer.test.ts
+++ b/packages/parser/src/dependency-analyzer.test.ts
@@ -1228,6 +1228,45 @@ describe('findDependents (Go root-package export-lookup recovery, #1039)', () =>
     ]);
     expect(result.dependents.every(d => d.confidence === 'inferred')).toBe(true);
     expect(result.dependentAttributionPartial).toBe(true);
+    // #1018: every recovered dependent names the mechanism that found it, so a
+    // consumer's prose can describe Go's fallback instead of assuming C#'s.
+    expect(result.dependents.every(d => d.inferredVia === 'go-root-package-export')).toBe(true);
+  });
+
+  it('pairs confidence and inferredVia on every dependent, in both directions (#1018)', () => {
+    // The pair is written by `inferredDependent()` and nowhere else, so neither
+    // half can appear without the other. Asserting BOTH directions is the
+    // point: a `confidence: 'inferred'` with no mechanism sends a consumer back
+    // to guessing (the #1039 defect), and an `inferredVia` on an
+    // import-verified dependent would mark a real import edge as recovered.
+    const chunks: CodeChunk[] = [
+      createGoChunk('context.go', { exports: ['RouteContext'] }),
+      createGoChunk('middleware/clean_path.go', {
+        imports: [MODULE_PREFIX],
+        callSites: ['RouteContext'],
+      }),
+    ];
+
+    const recovered = findDependents(chunks, 'context.go', noopLog, workspaceRoot);
+    expect(recovered.dependents.length).toBeGreaterThan(0);
+    for (const d of recovered.dependents) {
+      expect(d.confidence === 'inferred').toBe(d.inferredVia !== undefined);
+    }
+
+    // An ordinary import-verified dependent carries neither field.
+    const verified = findDependents(
+      [
+        createGoChunk('sub/helper.go', { exports: ['Helper'] }),
+        createGoChunk('sub/caller.go', { imports: [`${MODULE_PREFIX}/sub`] }),
+      ],
+      'sub/helper.go',
+      noopLog,
+      workspaceRoot,
+    );
+    for (const d of verified.dependents) {
+      expect(d.confidence).toBeUndefined();
+      expect(d.inferredVia).toBeUndefined();
+    }
   });
 
   it('does NOT fabricate a false hub: two unrelated root files get disjoint dependents (the #1056 failure shape, checked explicitly)', () => {

--- a/packages/parser/src/dependency-analyzer.ts
+++ b/packages/parser/src/dependency-analyzer.ts
@@ -16,6 +16,7 @@ import {
 } from './ast/languages/registry.js';
 import { findCSharpTypeReferenceDependents } from './csharp-type-reference-signals.js';
 import { findGoRootPackageDependents } from './go-root-package-signals.js';
+import type { InferredDependentMechanism } from './inferred-dependent-mechanisms.js';
 
 /**
  * Risk level thresholds for dependent count.
@@ -850,16 +851,47 @@ export interface DependentInfo {
    * import-verified dependent (the default, confident tier). A caller that
    * needs to distinguish "verified" from "recovered, lower confidence"
    * should filter on this field rather than assuming every entry in
-   * `dependents` came from the import graph. Two such fallbacks exist today:
-   * - C#'s type-reference-matching fallback (#930's remaining half -- see
-   *   `findCSharpTypeReferenceDependents`'s module doc): a word-boundary text
-   *   match against a uniquely-declared type name.
-   * - Go's root-package export-lookup fallback (#1039 -- see
-   *   `findGoRootPackageDependents`'s module doc): a bare module-root
-   *   self-import plus a matching call-site symbol, resolved to the specific
-   *   root file that exports it.
+   * `dependents` came from the import graph.
+   *
+   * Which fallbacks exist is NOT restated here: they are enumerated once, with
+   * their canonical prose, in `./inferred-dependent-mechanisms.ts`, and named
+   * per dependent by `inferredVia` below. This comment used to hand-list them
+   * and was one of six surfaces that still said "C# only" after #1039 added a
+   * second (see that module's doc for the measured consequence).
    */
   confidence?: 'inferred';
+  /**
+   * Which fallback recovered this dependent. Set if and only if `confidence`
+   * is `'inferred'` -- both are written together by `inferredDependent()`
+   * below, which is the only way either is produced.
+   *
+   * Exists so a consumer describing a recovered dependent can say which
+   * mechanism ran instead of assuming one (#1018). Downstream prose must read
+   * `INFERRED_DEPENDENT_MECHANISMS[inferredVia]` rather than restating it.
+   */
+  inferredVia?: InferredDependentMechanism;
+}
+
+/**
+ * The one constructor for a fallback-recovered dependent.
+ *
+ * Writing `confidence` and `inferredVia` together, in one place, is what keeps
+ * the pair from drifting: there is no code path that can produce a
+ * `confidence: 'inferred'` dependent whose mechanism is unknown, so a consumer
+ * may rely on `inferredVia` being present whenever `confidence` is. A third
+ * fallback (#1067) calls this with its own mechanism id and inherits every
+ * prose surface for free.
+ */
+export function inferredDependent(
+  filepath: string,
+  mechanism: InferredDependentMechanism,
+): DependentInfo {
+  return {
+    filepath,
+    isTestFile: isTestFile(filepath),
+    confidence: 'inferred',
+    inferredVia: mechanism,
+  };
 }
 
 /**
@@ -1779,12 +1811,9 @@ function enrichWithCSharpTypeReferenceDependents<T extends CodeChunk>(
   if (inferredFiles.length === 0) return undefined;
 
   for (const rawFile of inferredFiles) {
-    const canonicalFile = getCanonicalPath(rawFile, ctx.workspaceRoot);
-    dependents.push({
-      filepath: canonicalFile,
-      isTestFile: isTestFile(canonicalFile),
-      confidence: 'inferred',
-    });
+    dependents.push(
+      inferredDependent(getCanonicalPath(rawFile, ctx.workspaceRoot), 'csharp-type-reference'),
+    );
   }
 
   ctx.log(
@@ -1835,12 +1864,9 @@ function enrichWithGoRootPackageDependents<T extends CodeChunk>(
   if (inferredFiles.length === 0) return undefined;
 
   for (const rawFile of inferredFiles) {
-    const canonicalFile = getCanonicalPath(rawFile, ctx.workspaceRoot);
-    dependents.push({
-      filepath: canonicalFile,
-      isTestFile: isTestFile(canonicalFile),
-      confidence: 'inferred',
-    });
+    dependents.push(
+      inferredDependent(getCanonicalPath(rawFile, ctx.workspaceRoot), 'go-root-package-export'),
+    );
   }
 
   ctx.log(

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -253,7 +253,7 @@ export type {
 // Which non-import fallback recovered a `confidence: 'inferred'` dependent,
 // plus the canonical prose every consumer-facing surface must derive from
 // rather than restate (#1018) -- see inferred-dependent-mechanisms.ts's module
-// doc, and ADR-0016 for the axis model it belongs to.
+// doc, and ADR-016 for the axis model it belongs to.
 export {
   INFERRED_DEPENDENT_MECHANISMS,
   INFERRED_DEPENDENT_MECHANISM_IDS,

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -250,6 +250,21 @@ export type {
   ImportIndexEntry,
 } from './dependency-analyzer.js';
 
+// Which non-import fallback recovered a `confidence: 'inferred'` dependent,
+// plus the canonical prose every consumer-facing surface must derive from
+// rather than restate (#1018) -- see inferred-dependent-mechanisms.ts's module
+// doc, and ADR-0016 for the axis model it belongs to.
+export {
+  INFERRED_DEPENDENT_MECHANISMS,
+  INFERRED_DEPENDENT_MECHANISM_IDS,
+  summarizeInferredDependentMechanisms,
+  describeInferredDependentRecovery,
+} from './inferred-dependent-mechanisms.js';
+export type {
+  InferredDependentMechanism,
+  InferredDependentMechanismDescriptor,
+} from './inferred-dependent-mechanisms.js';
+
 // =============================================================================
 // COMPLEXITY ANALYSIS (chunk-based, no VectorDB)
 // =============================================================================

--- a/packages/parser/src/inferred-dependent-mechanisms.test.ts
+++ b/packages/parser/src/inferred-dependent-mechanisms.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  INFERRED_DEPENDENT_MECHANISMS,
+  INFERRED_DEPENDENT_MECHANISM_IDS,
+  summarizeInferredDependentMechanisms,
+  describeInferredDependentRecovery,
+  type InferredDependentMechanism,
+} from './inferred-dependent-mechanisms.js';
+
+describe('INFERRED_DEPENDENT_MECHANISMS (#1018)', () => {
+  it('describes every mechanism id with non-empty prose', () => {
+    // The `Record<InferredDependentMechanism, ...>` type already makes a
+    // MISSING key a compile error. This catches the other failure mode a type
+    // can't see: a key present but its prose left blank or a placeholder.
+    for (const id of INFERRED_DEPENDENT_MECHANISM_IDS) {
+      const d = INFERRED_DEPENDENT_MECHANISMS[id];
+      expect(d.languageLabel.length, `${id} languageLabel`).toBeGreaterThan(0);
+      expect(d.importGraphBlindSpot.length, `${id} importGraphBlindSpot`).toBeGreaterThan(20);
+      expect(d.recovery.length, `${id} recovery`).toBeGreaterThan(20);
+      expect(d.residualRisk.length, `${id} residualRisk`).toBeGreaterThan(20);
+    }
+  });
+
+  it('derives its id list from the table rather than a hand-written copy', () => {
+    expect(INFERRED_DEPENDENT_MECHANISM_IDS.sort()).toEqual(
+      Object.keys(INFERRED_DEPENDENT_MECHANISMS).sort(),
+    );
+  });
+
+  it('gives each mechanism a distinct language label and a distinct mechanism sentence', () => {
+    // Two mechanisms describing themselves identically would defeat the whole
+    // point — a consumer could not tell from the note which one ran.
+    const labels = INFERRED_DEPENDENT_MECHANISM_IDS.map(
+      id => INFERRED_DEPENDENT_MECHANISMS[id].languageLabel,
+    );
+    const recoveries = INFERRED_DEPENDENT_MECHANISM_IDS.map(
+      id => INFERRED_DEPENDENT_MECHANISMS[id].recovery,
+    );
+    expect(new Set(labels).size).toBe(labels.length);
+    expect(new Set(recoveries).size).toBe(recoveries.length);
+  });
+
+  it("never describes Go's mechanism in C#'s terms, or vice versa", () => {
+    // The exact defect this module exists to prevent: #1039's Go fallback
+    // inherited #930's C#-specific prose at five surfaces at once.
+    const csharp = INFERRED_DEPENDENT_MECHANISMS['csharp-type-reference'];
+    const go = INFERRED_DEPENDENT_MECHANISMS['go-root-package-export'];
+
+    expect(csharp.languageLabel).toBe('C#');
+    expect(csharp.importGraphBlindSpot).toContain('global using');
+    expect(csharp.recovery).toContain('type name');
+
+    expect(go.languageLabel).toBe('Go');
+    expect(go.importGraphBlindSpot).not.toContain('global using');
+    expect(go.importGraphBlindSpot).toContain('import path');
+    expect(go.recovery).toContain('exports');
+    // Go's recovery is an import-anchored export lookup, NOT a source-text scan.
+    expect(go.recovery).not.toContain('source text');
+  });
+});
+
+describe('summarizeInferredDependentMechanisms', () => {
+  it('enumerates the languages that have a fallback, joined for prose', () => {
+    // Interpolated into the tool description, the server instructions, the
+    // caveat-reason text and the docs page — so this is what an agent reads.
+    expect(summarizeInferredDependentMechanisms()).toBe('C# and Go');
+  });
+
+  it('stays in sync with the table by construction', () => {
+    for (const id of INFERRED_DEPENDENT_MECHANISM_IDS) {
+      expect(summarizeInferredDependentMechanisms()).toContain(
+        INFERRED_DEPENDENT_MECHANISMS[id].languageLabel,
+      );
+    }
+  });
+});
+
+describe('describeInferredDependentRecovery', () => {
+  it('describes a single mechanism verbatim from the table', () => {
+    const out = describeInferredDependentRecovery(['go-root-package-export']);
+    const expected = INFERRED_DEPENDENT_MECHANISMS['go-root-package-export'];
+    expect(out.languageLabel).toBe('Go');
+    expect(out.importGraphBlindSpot).toBe(expected.importGraphBlindSpot);
+    expect(out.recovery).toBe(expected.recovery);
+    expect(out.residualRisk).toBe(expected.residualRisk);
+  });
+
+  it('never leaks the other mechanism into a single-mechanism description', () => {
+    const go = describeInferredDependentRecovery(['go-root-package-export']);
+    expect(go.languageLabel).not.toContain('C#');
+    expect(go.recovery).not.toContain('source text');
+
+    const csharp = describeInferredDependentRecovery(['csharp-type-reference']);
+    expect(csharp.languageLabel).not.toContain('Go');
+  });
+
+  it('joins multiple mechanisms without duplicating a shared clause', () => {
+    const out = describeInferredDependentRecovery([
+      'csharp-type-reference',
+      'go-root-package-export',
+    ]);
+    expect(out.languageLabel).toBe('C# and Go');
+    expect(out.recovery).toContain('type name');
+    expect(out.recovery).toContain('exports');
+  });
+
+  it('deduplicates a repeated mechanism (one clause per distinct mechanism)', () => {
+    // Callers pass one entry per recovered dependent, so the same mechanism
+    // arrives many times over — the prose must not repeat once per edge.
+    const repeated: InferredDependentMechanism[] = Array.from(
+      { length: 11 },
+      () => 'go-root-package-export',
+    );
+    expect(describeInferredDependentRecovery(repeated)).toEqual(
+      describeInferredDependentRecovery(['go-root-package-export']),
+    );
+  });
+
+  it('returns empty clauses rather than throwing on an empty list', () => {
+    // Defensive: a caller that finds no `inferredVia` should degrade to a
+    // vaguer sentence, never crash the whole `get_dependents` response.
+    expect(describeInferredDependentRecovery([])).toEqual({
+      languageLabel: '',
+      importGraphBlindSpot: '',
+      recovery: '',
+      residualRisk: '',
+    });
+  });
+});

--- a/packages/parser/src/inferred-dependent-mechanisms.ts
+++ b/packages/parser/src/inferred-dependent-mechanisms.ts
@@ -19,10 +19,14 @@
  *
  * `confidence: 'inferred'` was single-valued, so every prose surface
  * describing it had to name a mechanism from memory. When #930 shipped there
- * was exactly one (C#'s type-reference matching), so five surfaces hard-coded
- * C#: `get_dependents`' runtime caveat note, `ATTRIBUTION_CAVEAT_REASON_TEXT`,
- * the `AttributionCaveatReason` doc comment, `tools.ts`' tool description, and
- * the public docs page.
+ * was exactly one (C#'s type-reference matching), so all six surfaces described
+ * that mechanism specifically -- and four of the six named C# by name:
+ * `get_dependents`' runtime caveat note ("its language, C#"), the
+ * `AttributionCaveatReason` doc comment, `tools.ts`' tool description ("C#'s
+ * global-using gap"), and the public docs page ("today only for C#"). The
+ * remaining two -- `ATTRIBUTION_CAVEAT_REASON_TEXT` and, by interpolating it,
+ * the server instructions -- didn't say "C#" but did say "text-matching
+ * fallback", which is equally wrong for Go.
  *
  * #1039/#1064 then added a SECOND mechanism -- Go's root-package export lookup
  * -- which reuses the same `confidence: 'inferred'` marking and the same

--- a/packages/parser/src/inferred-dependent-mechanisms.ts
+++ b/packages/parser/src/inferred-dependent-mechanisms.ts
@@ -1,0 +1,164 @@
+/**
+ * Which non-import recovery mechanism produced a `confidence: 'inferred'`
+ * dependent, and the canonical prose describing it (#1018).
+ *
+ * ## What this is, and what it deliberately is NOT
+ *
+ * This is a **refinement of one existing value**, not a new confidence
+ * vocabulary. `DependentInfo.confidence` stays exactly as it was -- absent for
+ * an ordinary import-verified dependent, `'inferred'` for one a fallback
+ * recovered. All this module adds is the *identity* of the fallback that did
+ * the recovering, which the parser has always known and used to throw away at
+ * its own boundary.
+ *
+ * See `docs/architecture/decisions/0016-dependency-attribution-honesty-axes.md`
+ * for why the three vocabularies #1018 named were NOT merged, and for the
+ * routing rule that decides where a new honesty signal belongs.
+ *
+ * ## The defect this exists to make impossible
+ *
+ * `confidence: 'inferred'` was single-valued, so every prose surface
+ * describing it had to name a mechanism from memory. When #930 shipped there
+ * was exactly one (C#'s type-reference matching), so five surfaces hard-coded
+ * C#: `get_dependents`' runtime caveat note, `ATTRIBUTION_CAVEAT_REASON_TEXT`,
+ * the `AttributionCaveatReason` doc comment, `tools.ts`' tool description, and
+ * the public docs page.
+ *
+ * #1039/#1064 then added a SECOND mechanism -- Go's root-package export lookup
+ * -- which reuses the same `confidence: 'inferred'` marking and the same
+ * `dependent-attribution-partial` caveat reason. None of the five surfaces was
+ * updated, because nothing forced it: `attribution-caveat-reasons.ts`'
+ * `Record<AttributionCaveatReason, string>` guards the *set of reasons*, and no
+ * reason was added -- only an existing reason's mechanism coverage widened.
+ * Measured on a real `go-chi/chi` clone against `origin/main`, every recovered
+ * Go root file was told, verbatim: *"its language, C#, lets real callers use
+ * its exports with no per-file import naming it at all"*, and that its
+ * dependents were *"recovered by matching a uniquely-declared type name against
+ * other files' source text"*. Both halves false for Go, on 24 of 24 recovered
+ * edges across `context.go`/`mux.go`/`chain.go`.
+ *
+ * So the forcing function here is the point, not a side benefit: the prose is
+ * a `Record` keyed by the mechanism union, and every surface *derives* from it
+ * rather than restating it. Adding a third mechanism is a compile error until
+ * its prose exists, and once it exists all five surfaces are correct with no
+ * further edits. #1067's declaration-index tier is the third mechanism, and its
+ * stated prerequisite -- a first-class home for *"unique among indexed
+ * declarations in this scope; a reference may still resolve to an unindexed
+ * stdlib/third-party declaration of the same name"*, currently prose in four
+ * separate signal-module doc comments -- is a new entry in this table.
+ */
+
+/**
+ * The non-import fallbacks that can produce a `confidence: 'inferred'`
+ * dependent. Add a member here and `INFERRED_DEPENDENT_MECHANISMS` below fails
+ * to compile until its prose is written.
+ */
+export type InferredDependentMechanism = 'csharp-type-reference' | 'go-root-package-export';
+
+/** The canonical prose for one mechanism. Every prose surface reads these. */
+export interface InferredDependentMechanismDescriptor {
+  /**
+   * How to name the language in prose -- the value that used to be hard-coded
+   * as `'C#'` in `get_dependents`' caveat note regardless of the real language.
+   */
+  readonly languageLabel: string;
+  /**
+   * Why the import graph structurally finds nothing for this file, phrased to
+   * follow "its language, <languageLabel>, ".
+   */
+  readonly importGraphBlindSpot: string;
+  /** How the fallback actually resolved the dependents it recovered. */
+  readonly recovery: string;
+  /** What the fallback can still miss or misattribute. */
+  readonly residualRisk: string;
+}
+
+/**
+ * `Record<InferredDependentMechanism, ...>` makes the compiler reject this
+ * object literal unless it has EXACTLY the union's members as keys -- the same
+ * deliberate forcing function `ATTRIBUTION_CAVEAT_REASON_TEXT` uses for caveat
+ * reasons (#984), applied to the axis that one could not see.
+ */
+export const INFERRED_DEPENDENT_MECHANISMS: Record<
+  InferredDependentMechanism,
+  InferredDependentMechanismDescriptor
+> = {
+  'csharp-type-reference': {
+    languageLabel: 'C#',
+    importGraphBlindSpot:
+      'lets real callers use its exports with no per-file import naming it at all — "global ' +
+      'using" / implicit enclosing-namespace member access',
+    recovery:
+      "matching a uniquely-declared type name against other files' source text (#930) — the " +
+      'name is only trusted when exactly one C# file project-wide declares it',
+    residualRisk:
+      'can still miss a real dependent that references the type via an alias, a generic type ' +
+      'argument, or reflection',
+  },
+  'go-root-package-export': {
+    languageLabel: 'Go',
+    importGraphBlindSpot:
+      'gives a file outside the root package no way to spell a reference to it except the ' +
+      'module\'s own bare import path ("github.com/org/mod"), which names no specific file',
+    recovery:
+      'looking up which single root-level file actually exports a distinctive symbol the ' +
+      "importing file's own call sites name (#1039) — only files that already import the " +
+      'root package are considered, and an export declared by two root files is never guessed at',
+    residualRisk:
+      'cannot distinguish a genuine root-package reference from an unrelated call that merely ' +
+      'shares the same distinctive name, and recovers nothing for a root file whose entire ' +
+      'exported surface is single-segment',
+  },
+};
+
+/**
+ * Every mechanism id, derived from the table's keys rather than hand-listed
+ * again -- so this array can never fall out of sync with the union the way the
+ * docs page did in #980.
+ */
+export const INFERRED_DEPENDENT_MECHANISM_IDS = Object.keys(
+  INFERRED_DEPENDENT_MECHANISMS,
+) as InferredDependentMechanism[];
+
+/** Join a list of clauses as "a", "a and b", "a, b and c". */
+function joinClauses(clauses: string[]): string {
+  if (clauses.length <= 1) return clauses[0] ?? '';
+  return `${clauses.slice(0, -1).join(', ')} and ${clauses[clauses.length - 1]}`;
+}
+
+/**
+ * The static, query-independent sentence naming which languages have a
+ * recovery fallback at all, for prose surfaces that describe the field in the
+ * abstract (the tool description, the server instructions, the caveat-reason
+ * text, the docs page). Derived from the table, so a new mechanism updates
+ * every one of them with no further edits -- exactly the update that #1039
+ * silently skipped.
+ */
+export function summarizeInferredDependentMechanisms(): string {
+  return joinClauses(
+    INFERRED_DEPENDENT_MECHANISM_IDS.map(id => INFERRED_DEPENDENT_MECHANISMS[id].languageLabel),
+  );
+}
+
+/**
+ * The mechanism-specific half of `get_dependents`' `dependent-attribution-partial`
+ * caveat note, for the mechanism(s) that actually ran on THIS query.
+ *
+ * Takes a list because nothing structurally forbids two mechanisms
+ * contributing to one answer, even though today's two are mutually exclusive by
+ * language (`enrichWithCSharpTypeReferenceDependents` only fires for C#,
+ * `enrichWithGoRootPackageDependents` only for Go). Describing whatever is
+ * actually present costs one `map` and removes the assumption that broke when
+ * the second mechanism landed.
+ */
+export function describeInferredDependentRecovery(
+  mechanisms: readonly InferredDependentMechanism[],
+): { languageLabel: string; importGraphBlindSpot: string; recovery: string; residualRisk: string } {
+  const descriptors = mechanisms.map(id => INFERRED_DEPENDENT_MECHANISMS[id]);
+  return {
+    languageLabel: joinClauses([...new Set(descriptors.map(d => d.languageLabel))]),
+    importGraphBlindSpot: joinClauses([...new Set(descriptors.map(d => d.importGraphBlindSpot))]),
+    recovery: joinClauses([...new Set(descriptors.map(d => d.recovery))]),
+    residualRisk: joinClauses([...new Set(descriptors.map(d => d.residualRisk))]),
+  };
+}

--- a/packages/review/src/dependency-graph.ts
+++ b/packages/review/src/dependency-graph.ts
@@ -112,7 +112,7 @@ export type EdgeProvenance =
  * treats that dependent as import-verified, no `confidence` marker), while
  * naming no symbol at all (so this table correctly calls it imprecise). One
  * shared bucketing would have to make one of the two wrong. See
- * ADR-0016 for the full argument and for why the two vocabularies were not
+ * ADR-016 for the full argument and for why the two vocabularies were not
  * merged.
  */
 const SYMBOL_VERIFIED_BY_PROVENANCE: Record<EdgeProvenance, boolean> = {

--- a/packages/review/src/dependency-graph.ts
+++ b/packages/review/src/dependency-graph.ts
@@ -94,24 +94,54 @@ export type EdgeProvenance =
   | 'namespace-inferred';
 
 /**
- * True for the three tiers where the SPECIFIC seed symbol is verifiably
- * imported/declared in the dependent — same-file trivially, import-verified
- * via a named call site, import-only via the import alone (no call site
- * names it, but `resolveOneChunkImports` still confirmed this exact symbol
- * resolves to this exact file through `importMatchesTarget`'s guards — see
- * `EdgeProvenance`'s doc comment). Deliberately excludes `require-only`
- * despite it also being a guarded, resolved import: that tier only verifies
- * a FILE-level relationship (Ruby's `require`/`load` names no symbol at
- * all), never that THIS symbol is the one depended on — see `require-only`'s
- * own doc for why it ranks below `import-only`. The remaining tiers
- * (`symbol-name-match`, `oop-method-import`, `namespace-inferred`) resolve
- * the specific file via a name/namespace convention rather than a verified
- * import, so they stay imprecise regardless of language.
+ * Whether each tier verifies the SPECIFIC seed symbol, as opposed to only the
+ * file — the boundary `isPreciseProvenance` reads, and the one #1030 argued
+ * from evidence.
+ *
+ * `Record<EdgeProvenance, boolean>` is the forcing function: an eighth tier is
+ * a compile error until someone states which side of this line it falls on.
+ * The predicate used to be a hand-written three-way `||`, so a new tier
+ * defaulted silently to "not precise" — the same shape of silent default that
+ * ADR-015 removed from `LanguageDefinition`'s matcher-path fields, and the
+ * same class of drift #1018 found on the parser/CLI side of this axis.
+ *
+ * Note this is the SYMBOL-level reading, and it is deliberately NOT the same
+ * boundary as `@liendev/parser`'s `DependentInfo.confidence`, which answers the
+ * FILE-level question. `require-only` is the proof the two must stay separate:
+ * a Ruby `require_relative` verifiably resolves the file (so parser correctly
+ * treats that dependent as import-verified, no `confidence` marker), while
+ * naming no symbol at all (so this table correctly calls it imprecise). One
+ * shared bucketing would have to make one of the two wrong. See
+ * ADR-0016 for the full argument and for why the two vocabularies were not
+ * merged.
+ */
+const SYMBOL_VERIFIED_BY_PROVENANCE: Record<EdgeProvenance, boolean> = {
+  // Same file — no import needed for the symbol to be in scope.
+  'same-file': true,
+  // A guarded import resolves to this file AND a call site names the symbol.
+  'import-verified': true,
+  // The same guarded import resolved this exact symbol to this exact file;
+  // only the call site is missing (PHP `new Order()`, a type hint).
+  'import-only': true,
+  // A guarded, resolved import of the FILE that names no symbol whatsoever
+  // (Ruby `require`/`load`, #1013) — file-level proof only.
+  'require-only': false,
+  // Same-named symbol imported from a package path; source file never confirmed.
+  'symbol-name-match': false,
+  // Class import is verified; the method-level attribution is inferred.
+  'oop-method-import': false,
+  // No import at all — a name/namespace/directory convention, or C#'s
+  // type-reference fallback.
+  'namespace-inferred': false,
+};
+
+/**
+ * True for the tiers where the SPECIFIC seed symbol is verifiably
+ * imported/declared in the dependent, per `SYMBOL_VERIFIED_BY_PROVENANCE`
+ * above (which carries the per-tier rationale).
  */
 export function isPreciseProvenance(provenance: EdgeProvenance): boolean {
-  return (
-    provenance === 'same-file' || provenance === 'import-verified' || provenance === 'import-only'
-  );
+  return SYMBOL_VERIFIED_BY_PROVENANCE[provenance];
 }
 
 export interface SymbolNode {

--- a/packages/site/docs/guide/mcp-tools.md
+++ b/packages/site/docs/guide/mcp-tools.md
@@ -215,12 +215,7 @@ Get file context for app/Models/User.php without related files
       "score": 0.0
     }
   ],
-  "testAssociations": [
-    {
-      "testFile": "src/utils/auth.test.ts",
-      "confidence": "high"
-    }
-  ],
+  "testAssociations": ["src/utils/auth.test.ts"],
   "relatedChunks": [
     {
       "content": "import { validateToken } from './auth';",
@@ -397,7 +392,7 @@ Five unrelated situations can each make `dependentCount`/`riskLevel` untrustwort
 - **`unresolved-target`** — `filepath` isn't resolvable in the index at all: never indexed, misspelled, or a typo'd directory prefix. `dependentCount: 0` / `riskLevel: "low"` then means "the path is unresolved," not "confirmed zero dependents." (Two independent checks can produce this — the index manifest has no entry for the path at all, or the path resolves in the manifest but has zero chunks in the current scan — but only one `attributionCaveat` is ever returned, never two competing explanations of the same zero.)
 - **`symbol-attribution-degraded`** — `symbol` also accepts a method or constructor name (e.g. `__construct`, `moveUp`); those aren't top-level exports, so when call sites for one can't be confirmed, the response widens `dependentCount`/`riskLevel` to the file-level answer (every file that imports `filepath`) rather than asserting an unverifiable symbol-scoped count. The unconfirmed symbol may genuinely be a method/constructor, or it may be a typo'd/hallucinated/removed name — the `note` field says which.
 - **`type-symbol-attribution-incomplete`** — `symbol` IS a top-level export of `filepath`, but it names a class/struct/interface/enum declaration rather than a function or method (#1015). Usage attribution is call-site-driven, and nothing "calls" a type by its own name the way a function call does — constructor calls, type hints, `extends`/`implements` clauses, generic type arguments, and dependency-injected property access don't reliably surface as a tracked call site. `totalUsageCount`/`usages` are a partial, best-effort floor — often `0` even when real usages exist — never a verified total; `dependentCount`/`dependents` (which files import the symbol) remain reliable.
-- **`dependent-attribution-partial`** — a file-level query (no `symbol`) found zero import-based dependents, but a lower-confidence text-matching fallback (matching a uniquely-declared type name against other files' source text — today only for C#) recovered one or more dependents anyway. Those entries carry `confidence: "inferred"` in `dependents[]`. Treat `dependentCount`/`riskLevel` as a recovered floor, not a verified/complete answer — the fallback can still miss a real dependent reached via an alias, a generic type argument, or reflection.
+- **`dependent-attribution-partial`** — a file-level query (no `symbol`) found zero import-based dependents, but a lower-confidence non-import fallback recovered one or more anyway. Those entries carry `confidence: "inferred"` in `dependents[]`, plus `inferredVia` naming which fallback found them (C# has one, for the `global using` gap; Go has one, for a bare module-root self-import). Treat `dependentCount`/`riskLevel` as a recovered floor, not a verified/complete answer — the `note` spells out what that specific fallback can still miss, and the two miss different things.
 - **`dependent-attribution-incomplete`** — a file-level query (no `symbol`) found zero dependents in a language where the import graph structurally can't see every real usage — C#'s enclosing-namespace access, where a `global using` lets a real caller reach `filepath`'s exports with no per-file import at all (#930); or Java/Kotlin's same-package visibility and Swift's whole-module access (#1005) — even after the `dependent-attribution-partial` fallback above also found nothing. `dependentCount: 0` / `riskLevel: "low"` here means "the import graph found nothing," not "nothing depends on this file."
 
 At most one reason ever applies to a given response. Always check for `attributionCaveat` before treating a low (especially zero) `dependentCount` as a verified all-clear.
@@ -563,32 +558,44 @@ similarity: a match means your query terms appear in the code or its comments.
 
 ## Test Associations
 
-All search results include test association metadata:
+`get_files_context` and `get_complexity` return test associations as a flat
+array of test-file paths:
 
 ```json
 {
   "file": "src/auth/login.ts",
-  "testAssociations": [
-    {
-      "testFile": "src/auth/login.test.ts",
-      "confidence": "high",
-      "method": "convention"
-    }
-  ]
+  "testAssociations": ["src/auth/login.test.ts"]
 }
 ```
 
-### Confidence Levels
+`search_code` does not return this field.
 
-- **high**: Import-based detection or strong naming convention
-- **medium**: Naming convention match
-- **low**: Weak pattern match
+### How associations are found
 
-### Detection Methods
+Every entry is derived statically — nothing here comes from executing tests or
+reading a coverage report:
 
-- **import**: Test imports the source file (most reliable)
-- **convention**: File naming patterns (e.g., `file.test.ts` for `file.ts`)
-- **pattern**: Weak heuristic match
+- **Import-based matching** (all languages): the test file's own import
+  statements resolve to the source file. This is the primary mechanism.
+- **Same-directory basename** (Go): `foo.go` ↔ `foo_test.go`, no import needed.
+- **Same-package basename** (Java): the same pairing across a package's test
+  source set.
+- **Enclosing-namespace type references** (C#): a test referencing a type that
+  exactly one project file declares, for the `global using` case where no import
+  statement names the file.
+
+### There are no per-association confidence levels
+
+Each entry is a path, and every entry in this field is one the mechanisms above
+established. There is no `confidence` or `method` field on an association, so
+don't branch on one.
+
+Some lower-confidence mechanisms deliberately stay out of this field rather than
+being folded in unlabelled — Go package-level fallbacks and Swift symbol-usage
+matching among them. Those surface only in `lien annotate`'s output, which labels
+each tier in prose (for example *"Test coverage inferred from symbol usage (not
+import-verified)"*). A language whose imports structurally cannot answer the
+question says so there too, rather than reporting a bare empty list.
 
 ## Tool Selection Guide
 


### PR DESCRIPTION
Closes #1018.

## Verdict first: the three vocabularies were not merged, and the reason is a shipped bug they were hiding

#1018 asked for one canonical provenance/confidence vocabulary in `parser` that `cli` and `review` consume instead of parallel dialects. **I'm declining that**, with reasons below — and the investigation turned up a live, agent-facing falsehood that the merge framing had obscured. That defect is what this PR fixes.

## The canonical type

```ts
// packages/parser/src/inferred-dependent-mechanisms.ts
export type InferredDependentMechanism = 'csharp-type-reference' | 'go-root-package-export';

export const INFERRED_DEPENDENT_MECHANISMS: Record<
  InferredDependentMechanism,
  { languageLabel; importGraphBlindSpot; recovery; residualRisk }
> = { ... };
```

plus `DependentInfo.inferredVia?: InferredDependentMechanism`, written only by `inferredDependent()` — the single constructor for the `confidence`/`inferredVia` pair.

This is a **refinement inside one existing value**, not a fourth dialect. `confidence?: 'inferred'` is byte-identical in meaning and value space; all that's added is *which* fallback produced it, a fact `parser` always knew and threw away at its own boundary.

## The bug, reproduced on `origin/main`

`confidence: 'inferred'` was single-valued, so every prose surface had to name a mechanism from memory. #930 shipped one (C#), so six surfaces hard-coded C#. #1039/#1064 added Go's root-package export lookup — same marker, same `dependent-attribution-partial` reason — and updated none of them, because **nothing forced it**: `Record<AttributionCaveatReason, string>` guards the set of *reasons*, and no reason was added. Only an existing reason's mechanism coverage widened.

Real `go-chi/chi` clone, real `lien serve` over stdio, `origin/main` (`3d78d6b0`):

```
===== context.go =====
dependentCount: 11
attributionCaveat.reason: dependent-attribution-partial
attributionCaveat.note: The import graph found zero import-based dependents for context.go
  (its language, C#, lets real callers use its exports with no per-file import naming it at
  all — "global using" / implicit enclosing-namespace member access), but 11 of the 11
  dependent(s) below were recovered by matching a uniquely-declared type name against other
  files' source text ...
```

Both halves false for Go. 24 of 24 recovered edges across `context.go`/`mux.go`/`chain.go`. The tool description carried the same claim (`C#'s global-using gap`), as did the docs page (`today only for C#`), the `AttributionCaveatReason` doc comment, and — via interpolation — the server instructions every MCP client reads on connect.

### After

```
===== context.go =====
dependentCount: 11
attributionCaveat.note: ... for context.go (its language, Go, gives a file outside the root
  package no way to spell a reference to it except the module's own bare import path
  ("github.com/org/mod"), which names no specific file), but 11 of the 11 dependent(s) below
  were recovered by looking up which single root-level file actually exports a distinctive
  symbol the importing file's own call sites name (#1039) — only files that already import
  the root package are considered, and an export declared by two root files is never guessed
  at ... this heuristic cannot distinguish a genuine root-package reference from an unrelated
  call that merely shares the same distinctive name ...
inferred dependents: [ 'middleware/clean_path.go [inferredVia=go-root-package-export]', ... ]
```

**Dependent lists are byte-identical before and after** (11 / 5 / 8 across the three files, same paths) — the change is prose accuracy plus one additive field, not semantics.

C# preserved exactly, real serilog clone, 254 files:

```
===== src/Serilog/Parsing/Alignment.cs =====
dependentCount: 6
note: ... (its language, C#, lets real callers use its exports with no per-file import naming
  it at all — "global using" / implicit enclosing-namespace member access), but 6 of the 6
  ... recovered by matching a uniquely-declared type name against other files' source text
  (#930) — the name is only trusted when exactly one C# file project-wide declares it ...
inferred: [ '.../MessageTemplateTextFormatter.cs [inferredVia=csharp-type-reference]', ... ]
```

Negative control (Go subpackage files, genuine resolved zero) — gains nothing:

```
===== middleware/middleware.go =====   dependentCount: 0   reason: undefined   inferred: []
===== middleware/logger.go =====       dependentCount: 0   reason: undefined   inferred: []
```

## The mapping, and why the merge was refused

There are **two axes and three scopes**, not one question asked three times. ADR-016 has the full argument.

| # | vocabulary | axis | scope | disposition |
|---|---|---|---|---|
| 1 | `confidence?: 'inferred'` (parser) | A: how was this edge resolved | per-edge, **file-level** | kept; refined by `inferredVia` |
| 2 | `EdgeProvenance` (review, 7 tiers) | A: how was this edge resolved | per-edge, **symbol-level** | kept as review's internal ranking detail |
| 3 | `AttributionCaveatReason` (cli, 5) | B: why can't this *answer* be trusted | per-answer | kept; already parser-derived |

**Axis A's two members must stay separate — merging makes one wrong.** `require-only` is the proof: a Ruby `require_relative` verifiably resolves the target *file*, so parser's file-level `findDependents` correctly treats that dependent as import-verified (no `confidence` marker), while naming no *symbol* at all, so review's symbol-level graph correctly ranks it imprecise (#1030's argued boundary). One shared bucketing predicate has to contradict one of them.

Separately, 4 of `EdgeProvenance`'s 7 tiers (`import-only`, `require-only`, `symbol-name-match`, `oop-method-import`) are distinctions that only arise *in* a symbol-level analysis — each records something different about what could be established for the specific symbol, a question parser's file-level pipeline never asks. (Not a claim that all four *verify* a symbol: `require-only` and `symbol-name-match` explicitly don't, which is why `SYMBOL_VERIFIED_BY_PROVENANCE` marks them `false`. The point is a file-level pipeline can't draw the distinction in either direction.) Hoisting the enum into `parser` publishes tiers nothing in `parser` emits — dead members, worse than two honest vocabularies.

**Axis B is already consolidated where it matters.** `AttributionCaveatReason` is not an independent taxonomy: `buildAttributionCaveat` derives all five reasons from fields `parser` already owns on `FindDependentsResult` (`targetIndexed`, `symbolAttributionDegraded`, `symbolFoundInFile`, `typeSymbolAttributionIncomplete`, `dependentAttributionPartial`, `dependentAttributionIncomplete`). The structural facts are in `parser`; `attribution-caveat-reasons.ts` is the prose + mutual-exclusion layer. Moving model-facing prose into the AST package gains nothing.

### The four blocked consumers, re-checked

- **#1072** — needed whole-store and whole-language scope. That's **scope 3**, neither axis; `note` + omission was the right call and #1078's reasoning holds. Its one genuinely shared piece (`hasDependentAttributionBlindSpot`) was already in `parser`. Nothing to do.
- **#1067** — **the real one, and now unblocked.** Its stated prerequisite (a first-class home for *"unique among indexed declarations in this scope; a reference may still resolve to an unindexed stdlib/third-party declaration of the same name"*, currently prose in four signal-module doc comments) is one new entry in `INFERRED_DEPENDENT_MECHANISMS`. Adding it makes all six surfaces correct with no further edits, and the compiler refuses the tier until its prose exists.
- **#1015** — needs `type-symbol-attribution-incomplete`'s prose updated when real type-reference counting lands (it currently says usages are "often 0"). A prose update then, not a vocabulary gap now.
- **Coverage-derived test associations** — the consumer motivating a "stronger than import-verified" direction. **That feature was evaluated and rejected** (no coverage artifact in 40 of 40 real checkouts). Building vocabulary for it would be YAGNI, so the "stronger" direction is deliberately not built.

## Forcing functions — both kept, and they now compose

- `Record<AttributionCaveatReason, string>` (#984) unchanged.
- `Record<InferredDependentMechanism, Descriptor>` is new and guards the axis the first one structurally cannot see. That composition is the fix: one guards the set of reasons, the other the set of mechanisms each reason covers.
- `isPreciseProvenance` was a hand-written three-way `||`, so an eighth `EdgeProvenance` tier would default silently to "not precise". Now `Record<EdgeProvenance, boolean>` with a per-tier rationale — ADR-015's move applied here. **Returns exactly what it returned for all seven tiers**; the existing table-driven test covers all seven and passes unchanged.

## Two doc-truth defects found while mapping the surfaces

Both on `packages/site/docs/guide/mcp-tools.md`:

1. `dependent-attribution-partial` documented as `today only for C#`.
2. **A whole fictional vocabulary.** The page documented `testAssociations[]` as `{ testFile, confidence: "high"|"medium"|"low", method }` with a *"Confidence Levels"* section (`high`/`medium`/`low`) and a *"Detection Methods"* section — none of which exists in code. The real field is `string[]`. It was also attributed to `search_code`, which never emitted the field at all (`grep testAssociations` over `search-code.ts` and `metadata-shaper.ts`: no hits). Replaced with the four real static mechanisms and an explicit "there are no per-association confidence levels".

Worth noting because that phantom shape is exactly the "stronger/weaker than import-verified" vocabulary #1018 assumed didn't exist — it existed only in docs, describing something never built.

## Tests

- `inferred-dependent-mechanisms.test.ts` (11 new): prose non-empty/distinct per mechanism; ids derived from the table; **`not.toContain('global using')` / `not.toContain('source text')` on Go's descriptor** — the regression pinned at the source; dedup of a repeated mechanism; empty-list degradation.
- `get-dependents.test.ts` (3 new): the Go note must contain `its language, Go` and its real mechanism, and must **not** contain `C#`, `global using` or `source text`; the C# note must still contain C#'s; both mechanisms together render `C# and Go`.
- `dependency-analyzer.test.ts` (parser): the pairing invariant **in both directions** — `confidence === 'inferred'` iff `inferredVia !== undefined`, and an import-verified dependent carries neither; the #1039 chi repro now also asserts `inferredVia`.

## Gates

`format:check` ✅ · `lint` **0 errors** (41 pre-existing warnings) ✅ · `typecheck` ✅ · `build` ✅ · `npm test` **5,790 tests / 240 files, all green** ✅ · `docs:build` ✅ (rendered page read) · `lien delta` **exit 0** ✅

`lien delta` reports **4 improved, 0 worsened, 0 new violations**:

```
packages/cli/src/mcp/handlers/get-dependents.ts
  · new       buildPartialRecoveryNote cyclomatic – → 1
  ✓ improved  buildAttributionCaveat   cognitive 8 → 7
packages/parser/src/dependency-analyzer.ts
  ✓ improved  enrichWithCSharpTypeReferenceDependents time 40m → 35m
  ✓ improved  enrichWithGoRootPackageDependents       time 39m → 35m
packages/review/src/dependency-graph.ts
  ✓ improved  isPreciseProvenance      cognitive 1 → 0
✓ 4 improved · 11 files · 236 ms
```

Relevant to the `review` gate (#1070), which is delta-aware and blocks on a *worsened* pre-existing violation even without a threshold crossing: nothing here worsens. The one crossing this PR did produce mid-development (`buildAttributionCaveat` halstead 38→65, threshold 60) was caught by the hook and fixed by extracting `buildPartialRecoveryNote`, not silenced with `--soft`.

## Harness evidence

No prompt, rule, or fixture files touched — nothing under `packages/review/src/plugins/agent/` or `packages/review/test/harness/` appears in the diff. The only `review` change is `dependency-graph.ts`'s `isPreciseProvenance` table.

```
 .changeset/brave-pandas-consolidate.md             |  40 ++++
 .../0016-dependency-attribution-honesty-axes.md    | 255 +++++++++++++++++++++
 docs/architecture/decisions/README.md              |   1 +
 packages/cli/src/mcp/attribution-caveat-reasons.ts |  39 +++-
 .../src/mcp/handlers/dependency-analyzer.test.ts   |   2 +
 .../cli/src/mcp/handlers/get-dependents.test.ts    |  67 ++++++
 packages/cli/src/mcp/handlers/get-dependents.ts    |  50 +++-
 packages/cli/src/mcp/tools.ts                      |  13 +-
 packages/parser/src/dependency-analyzer.test.ts    |  39 ++++
 packages/parser/src/dependency-analyzer.ts         |  66 ++++--
 packages/parser/src/index.ts                       |  15 ++
 .../src/inferred-dependent-mechanisms.test.ts      | 130 +++++++++++
 .../parser/src/inferred-dependent-mechanisms.ts    | 164 +++++++++++++
 packages/review/src/dependency-graph.ts            |  62 +++--
 packages/site/docs/guide/mcp-tools.md              |  53 +++--
 15 files changed, 908 insertions(+), 88 deletions(-)
```

## ADR

Yes — **ADR-016**, following ADR-015's precedent (a repeatedly-relitigated cross-cutting decision turned into a documented contract with a compiler-forced field, recording the rejected proposal alongside the accepted one). It documents the two-axis/three-scope model, the `require-only` proof, the routing rule for a new honesty signal, #1067's landing spot, and an explicit out-of-scope list: `lien annotate`'s four-tier test-coverage prose (the next site, needs a data-shape change), per-association test provenance (rejected consumer), the "stronger" direction (no consumer), #1015's floor prose (later), and renaming the overloaded `confidence` (no benefit).

## What I deliberately left out

- **Merging the three vocabularies** — argued above and in ADR-016.
- **Surfacing a 7-tier provenance in `get_dependents`' JSON** (#1018's part 2 as literally drafted). The tiers are review's symbol-level pipeline; exporting them to MCP would publish distinctions parser can't produce and make the consumer-facing field vaguer, which is the opposite of the goal.
- **`lien annotate`'s test-coverage tiers** — the same Axis-A decision at another surface, over four parallel arrays. Needs a `testAssociations` shape change; nothing is blocked on it. Named in the ADR as the next site.
- **A sixth `AttributionCaveatReason` for #1067** — it would be dead vocabulary until the tier producing it ships. #1067 adds its table entry together with its producer.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes a real shipped bug where Go files recovered by the root-package export fallback were described with C#-specific prose. It introduces `DependentInfo.inferredVia` and a parser-owned `INFERRED_DEPENDENT_MECHANISMS` table, then drives all consumer-facing prose (caveat note, tool description, server instructions, docs) from that single source. The change is additive (`confidence` is untouched), the pairing invariant is enforced by a single constructor, and the new code is well-covered by tests. No breaking changes or silent failure modes were found.
>
> - Added `InferredDependentMechanism` vocabulary and `INFERRED_DEPENDENT_MECHANISMS` table in `@liendev/parser`
> - Added `DependentInfo.inferredVia`, always paired with `confidence: 'inferred'` via `inferredDependent()`
> - Updated `get_dependents` caveat note, tool description, and server instructions to derive mechanism prose from the table
> - Converted `isPreciseProvenance` to a `Record<EdgeProvenance, boolean>` to prevent silent defaults for new tiers

> [!WARNING]
> 🟡 **Trust: Degraded — budget-starved**
>
> The review stopped after exhausting its token budget before finishing. Treat the findings above as partial.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 980c9db. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 702K/820K tokens
<!-- /lien:attestation -->