### PR TITLE
fix(parser): extract call sites from module-level code, not just function bodies (#1087)

### DIFF
--- a/.changeset/lucky-pandas-listen.md
+++ b/.changeset/lucky-pandas-listen.md
@@ -1,0 +1,24 @@
+---
+'@liendev/parser': patch
+---
+
+Extract call sites from module-level code, not just function and method bodies (#1087)
+
+`ast/chunker.ts` gated call-site extraction behind `shouldCalcComplexity` — the
+same flag as cognitive/Halstead metrics — so anything that wasn't a function or
+method body contributed no call-site evidence at all: `export const client =
+createClient(loadConfig())`, route/DI registration, config objects built from
+factory calls, and (because a test file is almost entirely bare top-level
+statements) every test that calls the function it tests.
+
+Call sites are now extracted for every chunk whose line range no other chunk
+overlaps, plus the module-level "uncovered" chunks that previously had no AST
+node to extract from. Containers stay excluded, because a class chunk's range
+contains its methods' and nothing downstream dedupes across a file's chunks.
+
+Measured across 12 real corpora, the share of files referencing an identifier
+declared in the same corpus: this repo 53.6% → 87.5%, zod 26.9% → 85.4%,
+express 12.1% → 84.4%, sinatra 42.9% → 82.3%, requests 62.2% → 70.3%. Zero
+duplicate attributions anywhere. Complexity metrics, chunk boundaries and
+precomputed `dependentCount` are byte-identical before and after; index size
+grows ~11% and index time is unchanged.

--- a/.changeset/lucky-pandas-listen.md
+++ b/.changeset/lucky-pandas-listen.md
@@ -22,3 +22,10 @@ express 12.1% → 84.4%, sinatra 42.9% → 82.3%, requests 62.2% → 70.3%. Zero
 duplicate attributions anywhere. Complexity metrics, chunk boundaries and
 precomputed `dependentCount` are byte-identical before and after; index size
 grows ~11% and index time is unchanged.
+
+Two knock-on fixes for output that only becomes common once module-level code
+carries call sites: `get_dependents` usages from module-level code now report
+`callerSymbol: "(module-level)"` rather than `"unknown"` (matching the wording
+`review` already uses), and their `snippet` is located by finding the line that
+mentions the symbol instead of computing it, which was landing a line late for
+any chunk whose leading blank lines were trimmed out of its content.

--- a/.changeset/wild-otters-agree.md
+++ b/.changeset/wild-otters-agree.md
@@ -1,0 +1,22 @@
+---
+'@liendev/parser': patch
+'@liendev/review': patch
+---
+
+Share one chunk-line lookup between `get_dependents` usage snippets and review's dependent context (#1087)
+
+Both computed a snippet's position as `callSiteLine - chunk.metadata.startLine`,
+which is only exact when a chunk's content starts on the line `startLine` names.
+A module-level chunk's does not — `createChunkFromRange` trims its range's
+leading blank lines out of the content while `startLine` keeps naming the
+untrimmed start — so the subtraction overshoots: `get_dependents` returned a
+neighbouring statement as the snippet, and review's `extractSnippetWindow`
+either centred its window a line late or, once the overshoot exceeded the
+content, returned `null` and dropped the snippet from the review prompt
+entirely.
+
+Both now go through `findChunkLineIndex`, which locates the line by finding the
+nearby one that mentions the symbol. `review`'s module-level callers are also
+labelled `(module-level)` rather than `unknown`, matching what parser already
+reports, and the `()` suffix is dropped for them since module-level code is not
+a function.

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.test.ts
@@ -15,6 +15,7 @@ function createChunk(
     callSites: Array<{ symbol: string; line: number }>;
     symbolName: string;
     symbolType: 'function' | 'method' | 'class' | 'interface';
+    type: 'function' | 'class' | 'block';
     content: string;
     startLine: number;
     endLine: number;
@@ -359,6 +360,39 @@ describe('findDependents', () => {
         callerSymbol: 'handleRequest',
         line: 3,
         snippet: 'doWork(data);',
+      });
+    });
+
+    it('finds the right snippet line for a module-level chunk whose content was trimmed (#1087)', async () => {
+      // A module-level chunk's range starts on the blank line after the
+      // preceding chunk, and `createChunkFromRange` trims that line out of
+      // `content` while `startLine` keeps naming it -- so `line - startLine`
+      // lands one line late. The reported `line` is the true file line either
+      // way; the snippet has to be found, not computed.
+      const chunk = createChunk('src/wiring.ts', {
+        imports: ['src/target.ts'],
+        importedSymbols: { 'src/target': ['doWork'] },
+        callSites: [{ symbol: 'doWork', line: 11 }],
+        symbolName: undefined,
+        type: 'block',
+        startLine: 10,
+        endLine: 13,
+      });
+      // Range was lines 10-13, but line 10 was blank and got trimmed away, so
+      // content[0] is really file line 11.
+      chunk.content = 'export const wired = doWork(config);\n\nexport const other = 1;';
+
+      mockDB.scanAll.mockResolvedValue([
+        createChunk('src/target.ts', { exports: ['doWork'] }),
+        chunk,
+      ]);
+
+      const result = await findDependents(mockDB as any, 'src/target.ts', mockLog, 'doWork');
+
+      expect(result.dependents[0].usages![0]).toEqual({
+        callerSymbol: '(module-level)',
+        line: 11,
+        snippet: 'export const wired = doWork(config);',
       });
     });
   });

--- a/packages/parser/src/ast/chunker.test.ts
+++ b/packages/parser/src/ast/chunker.test.ts
@@ -1411,6 +1411,34 @@ class Service:
       expect(entries).toHaveLength(new Set(entries).size);
       expect(symbolsOf(chunks).has('helper')).toBe(true);
     });
+
+    it('records a bare call directly inside a transparent container (Ruby module)', () => {
+      // Review finding on #1087/#1088: `emitsChildChunks` deliberately voids a
+      // transparent container's OWN call sites (extractCallSites recurses
+      // unscoped, so extracting on the module node would double-count its real
+      // children), but that container's full range used to sit in
+      // `coveredRanges` too -- so a bare statement directly inside the module,
+      // wrapped in no further declaration of its own, was silently dropped:
+      // neither the module's chunk nor any child chunk claimed it.
+      const content = `module Foo
+  configure()
+
+  class Bar
+    def method1
+      helper_call()
+    end
+  end
+end
+`;
+      const chunks = chunkByAST('foo.rb', content);
+      const symbols = symbolsOf(chunks);
+
+      expect(symbols.has('configure')).toBe(true);
+      expect(symbols.has('helper_call')).toBe(true);
+
+      const entries = allCallSites(chunks);
+      expect(entries).toHaveLength(new Set(entries).size);
+    });
   });
 
   describe('error handling', () => {

--- a/packages/parser/src/ast/chunker.test.ts
+++ b/packages/parser/src/ast/chunker.test.ts
@@ -1267,6 +1267,152 @@ test('does something', () => {
     });
   });
 
+  describe('module-level call sites (#1087)', () => {
+    /** Every (symbol, line) pair the whole file's chunks report. */
+    const allCallSites = (chunks: ReturnType<typeof chunkByAST>) =>
+      chunks.flatMap(c => (c.metadata.callSites ?? []).map(cs => `${cs.symbol}:${cs.line}`));
+
+    const symbolsOf = (chunks: ReturnType<typeof chunkByAST>) =>
+      new Set(chunks.flatMap(c => (c.metadata.callSites ?? []).map(cs => cs.symbol)));
+
+    it('records call sites in a top-level declaration that contains no function', () => {
+      // The shape this fix exists for: `export const x = createThing(...)` is
+      // not a 'function'/'method' symbol, so sharing the complexity gate meant
+      // it contributed no call-site evidence at all.
+      const content = `import { createClient } from './client.js';
+import { loadConfig } from './config.js';
+
+export const client = createClient(loadConfig());
+`;
+      const chunks = chunkByAST('wiring.ts', content);
+
+      expect(symbolsOf(chunks)).toEqual(new Set(['createClient', 'loadConfig']));
+    });
+
+    it('records call sites in bare top-level statements', () => {
+      const content = `import { app } from './app.js';
+import { authRoutes, userRoutes } from './routes.js';
+
+app.use(authRoutes());
+app.use(userRoutes());
+`;
+      const chunks = chunkByAST('server.ts', content);
+      const symbols = symbolsOf(chunks);
+
+      expect(symbols.has('use')).toBe(true);
+      expect(symbols.has('authRoutes')).toBe(true);
+      expect(symbols.has('userRoutes')).toBe(true);
+    });
+
+    it('records call sites in a test file with no top-level declaration at all', () => {
+      const content = `import { describe, it, expect } from 'vitest';
+import { chunkByAST } from './chunker.js';
+
+describe('chunker', () => {
+  it('chunks', () => {
+    expect(chunkByAST('a.ts', 'x')).toHaveLength(1);
+  });
+});
+`;
+      const chunks = chunkByAST('chunker.test.ts', content);
+
+      expect(symbolsOf(chunks).has('chunkByAST')).toBe(true);
+    });
+
+    it('never attributes the same call site to two chunks of one file', () => {
+      // Nothing downstream dedupes call sites across a file's chunks, so an
+      // overlapping attribution would inflate get_dependents' totalUsageCount
+      // and review's caller-edge counts.
+      const content = `import { helper, decorate } from './util.js';
+
+export const table = { a: helper(1), b: helper(2) };
+
+export class Service {
+  private dep = helper(3);
+
+  run() {
+    return helper(4);
+  }
+
+  also() {
+    return decorate(helper(5));
+  }
+}
+
+register(table);
+`;
+      const chunks = chunkByAST('service.ts', content);
+      const entries = allCallSites(chunks);
+
+      expect(entries).toHaveLength(new Set(entries).size);
+    });
+
+    it('leaves complexity metrics untouched', () => {
+      const content = `import { helper } from './util.js';
+
+export const wired = helper(configure());
+
+export function branchy(n: number): number {
+  if (n > 1) {
+    for (let i = 0; i < n; i++) {
+      if (i % 2 === 0) return i;
+    }
+  }
+  return n;
+}
+`;
+      const chunks = chunkByAST('metrics.ts', content);
+      const wired = chunks.find(c => c.content.includes('export const wired'))!;
+      const branchy = chunks.find(c => c.metadata.symbolName === 'branchy')!;
+
+      // The module-level chunk gains call sites but stays metric-free: only
+      // functions and methods get cognitive/Halstead numbers.
+      expect(wired.metadata.callSites?.map(cs => cs.symbol)).toEqual(['helper', 'configure']);
+      expect(wired.metadata.cognitiveComplexity).toBeUndefined();
+      expect(wired.metadata.halsteadVolume).toBeUndefined();
+
+      expect(branchy.metadata.cognitiveComplexity).toBeGreaterThan(0);
+      expect(branchy.metadata.halsteadVolume).toBeGreaterThan(0);
+    });
+
+    it('keeps a decorated Python function as a leaf, not a container', () => {
+      // `decorated_definition` is in Python's containerTypes, but
+      // getContainerBody() returns null for a decorated FUNCTION. Treating it
+      // as a container dropped its whole body's call sites -- measured at 384
+      // of 2580 references on psf/requests.
+      const content = `from .util import helper, cache
+
+
+@cache
+def run(n):
+    return helper(n)
+`;
+      const chunks = chunkByAST('run.py', content);
+      const symbols = symbolsOf(chunks);
+
+      expect(symbols.has('helper')).toBe(true);
+      expect(symbols.has('cache')).toBe(false); // a bare decorator is not a call
+    });
+
+    it('does not double-count a decorated Python class', () => {
+      const content = `from .util import helper
+
+
+@register
+class Service:
+    dep = helper(1)
+
+    def run(self):
+        return helper(2)
+`;
+      const chunks = chunkByAST('service.py', content);
+      const entries = allCallSites(chunks);
+
+      expect(entries).toHaveLength(new Set(entries).size);
+      expect(symbolsOf(chunks).has('helper')).toBe(true);
+    });
+  });
+
   describe('error handling', () => {
     it('should throw error for unsupported language', () => {
       const content = 'print("Hello")';

--- a/packages/parser/src/ast/chunker.ts
+++ b/packages/parser/src/ast/chunker.ts
@@ -574,8 +574,9 @@ function createChunk(
   // `shouldCalcComplexity` used to make a top-level `const schema =
   // z.object({...})` or `export const client = createClient(...)` contribute
   // no call-site evidence at all, since neither is a 'function'/'method'
-  // symbol; measured on this repo, that silence covered 94% of the call
-  // expressions in the tree.
+  // symbol. Between this gate and the module-level statements handled by
+  // `withModuleLevelCallSites` below, 81% of the call expressions in this
+  // repo's own tree went unextracted (12,118 of 63,847 emitted).
   //
   // The one exclusion is a container (`nodeEmitsChildChunks`): its range
   // *contains* its members' chunks, and nothing downstream dedupes call sites

--- a/packages/parser/src/ast/chunker.ts
+++ b/packages/parser/src/ast/chunker.ts
@@ -387,11 +387,30 @@ export function chunkByAST(
   const topLevelNodes = findTopLevelNodes(rootNode, context.traverser);
   const topLevelChunks = processTopLevelNodes(topLevelNodes, filepath, content, context, language);
 
-  // Extract uncovered code (imports, exports, top-level statements)
-  const coveredRanges = topLevelNodes.map(n => ({
-    start: n.startPosition.row,
-    end: n.endPosition.row,
-  }));
+  // Extract uncovered code (imports, exports, top-level statements).
+  //
+  // Transparent containers (e.g. Ruby's `module`) are excluded here even
+  // though `findTopLevelNodes` pushes them: `emitsChildChunks` voids their
+  // OWN chunk's call sites specifically because `extractCallSites` recurses
+  // unscoped, so keeping the module's own [start,end] "covered" would only
+  // have suppressed double-counting for it, not for anything genuinely
+  // extracted here. But a bare statement directly inside the module — not
+  // wrapped in any further declaration, so it gets no chunk of its own
+  // either — has no extractor claiming it at all, and covering the module's
+  // full range (which is only ever right for a REAL container, whose own
+  // chunk deliberately claims nothing precisely because its children do)
+  // silently marked that statement's line "already handled". Dropping
+  // transparent containers from this list lets `withModuleLevelCallSites`
+  // reach those lines the same way it reaches any other module-level code;
+  // real children nested inside (a class, its methods) still cover their
+  // own ranges via their own entries in `topLevelNodes`, so nothing here
+  // gets double-counted.
+  const coveredRanges = topLevelNodes
+    .filter(n => !context.traverser.transparentContainerTypes?.includes(n.type))
+    .map(n => ({
+      start: n.startPosition.row,
+      end: n.endPosition.row,
+    }));
   const uncoveredChunks = withModuleLevelCallSites(
     extractUncoveredCode(
       context.lines,

--- a/packages/parser/src/ast/chunker.ts
+++ b/packages/parser/src/ast/chunker.ts
@@ -304,9 +304,40 @@ function processTopLevelNode(
     symbolInfo,
     fileImports,
     language,
+    emitsChildChunks(node, traverser),
     fileExports,
     importedSymbols,
   );
+}
+
+/**
+ * Does `findTopLevelNodes` emit chunks for this node's members as well as for
+ * the node itself?
+ *
+ * Mirrors exactly the two branches there that push a node and keep descending:
+ * a container it can actually descend INTO (`shouldExtractChildren` *and* a
+ * non-null `getContainerBody` — e.g. a class, whose methods each become their
+ * own chunk), and a transparent container (`transparentContainerTypes`, e.g.
+ * Ruby's `module`). Every other top-level node is a leaf of the chunk tree —
+ * `findTopLevelNodes` returns on match without descending — so its line range
+ * overlaps no other chunk's.
+ *
+ * The `getContainerBody` half is load-bearing, not belt-and-braces:
+ * `shouldExtractChildren` states an *intent* to descend that a language may
+ * then decline per node. Python's `decorated_definition` is in
+ * `containerTypes`, but `getContainerBody` returns null for a decorated
+ * FUNCTION (only a decorated class has a body worth recursing into) — so a
+ * `@decorator`-ed top-level function is a leaf, and treating it as a container
+ * silently dropped its call sites. Measured on psf/requests: 384 of 2580
+ * references, i.e. this predicate getting it wrong looks like a 15%
+ * *regression*, not a missing improvement.
+ *
+ * Only used to decide call-site extraction (see `createChunk`), where the
+ * overlap would mean double-counting.
+ */
+function emitsChildChunks(node: SyntaxNode, traverser: ReturnType<typeof getTraverser>): boolean {
+  if (traverser.transparentContainerTypes?.includes(node.type)) return true;
+  return traverser.shouldExtractChildren(node) && traverser.getContainerBody(node) !== null;
 }
 
 /**
@@ -361,21 +392,26 @@ export function chunkByAST(
     start: n.startPosition.row,
     end: n.endPosition.row,
   }));
-  const uncoveredChunks = extractUncoveredCode(
-    context.lines,
-    coveredRanges,
-    filepath,
-    minChunkSize,
-    context.fileImports,
+  const uncoveredChunks = withModuleLevelCallSites(
+    extractUncoveredCode(
+      context.lines,
+      coveredRanges,
+      filepath,
+      minChunkSize,
+      context.fileImports,
+      language,
+      context.fileExports,
+      context.importedSymbols,
+      // When no top-level node was recognized (e.g. a file containing only bare
+      // statements/calls, like a single `test(...)` block with no exported
+      // declaration), coveredRanges is empty and the single "uncovered" range
+      // below is the entire file — the file's only chance at a chunk. See
+      // extractUncoveredCode for why minChunkSize must not apply there.
+      topLevelNodes.length === 0,
+    ),
+    rootNode,
     language,
-    context.fileExports,
-    context.importedSymbols,
-    // When no top-level node was recognized (e.g. a file containing only bare
-    // statements/calls, like a single `test(...)` block with no exported
-    // declaration), coveredRanges is empty and the single "uncovered" range
-    // below is the entire file — the file's only chance at a chunk. See
-    // extractUncoveredCode for why minChunkSize must not apply there.
-    topLevelNodes.length === 0,
+    coveredRanges,
   );
 
   // Combine and sort by line number
@@ -520,6 +556,7 @@ function createChunk(
   symbolInfo: ReturnType<typeof extractSymbolInfo>,
   imports: string[],
   language: SupportedLanguage,
+  nodeEmitsChildChunks: boolean,
   fileExports?: string[],
   importedSymbols?: Record<string, string[]>,
 ): ASTChunk {
@@ -532,8 +569,20 @@ function createChunk(
   // Calculate Halstead metrics only for functions and methods
   const halstead = shouldCalcComplexity ? calculateHalstead(node, language) : undefined;
 
-  // Extract call sites for functions and methods
-  const callSites = shouldCalcComplexity ? extractCallSites(node, language) : undefined;
+  // Call sites, on the other hand, are extracted for EVERY chunk whose range
+  // no other chunk overlaps — not just functions and methods (#1087). Sharing
+  // `shouldCalcComplexity` used to make a top-level `const schema =
+  // z.object({...})` or `export const client = createClient(...)` contribute
+  // no call-site evidence at all, since neither is a 'function'/'method'
+  // symbol; measured on this repo, that silence covered 94% of the call
+  // expressions in the tree.
+  //
+  // The one exclusion is a container (`nodeEmitsChildChunks`): its range
+  // *contains* its members' chunks, and nothing downstream dedupes call sites
+  // across a file's chunks, so extracting here would report every method's
+  // calls a second time under the class. Module-level code no chunk covers is
+  // handled by `withModuleLevelCallSites` below.
+  const callSites = nodeEmitsChildChunks ? undefined : extractCallSites(node, language);
 
   return {
     content,
@@ -642,6 +691,59 @@ function createChunkFromRange(
       ...(importedSymbols && Object.keys(importedSymbols).length > 0 && { importedSymbols }),
     },
   };
+}
+
+/** Is this 1-based line inside any of these 0-based-row ranges? */
+function lineIsCovered(line: number, coveredRanges: LineRange[]): boolean {
+  const row = line - 1;
+  return coveredRanges.some(r => row >= r.start && row <= r.end);
+}
+
+/**
+ * Attach call sites to the module-level ("uncovered") chunks — the top-level
+ * statements no function/class chunk covers (#1087).
+ *
+ * `createChunk` needs a `SyntaxNode` and only ever sees the top-level nodes
+ * `findTopLevelNodes` recognized, so bare top-level statements — the ones that
+ * reach `createChunkFromRange` from a raw line range instead — had no path to
+ * call-site extraction at all: route/DI registration, `app.use(...)`, and
+ * (because a Vitest/Jest file is almost entirely bare top-level statements)
+ * every `expect(chunkByAST(...))` in the test suite. Together with the widened
+ * gate in `createChunk`, this took the share of TypeScript files in this repo
+ * that reference a locally-declared identifier from 52.0% to 88.5%.
+ *
+ * Works from the whole-file `rootNode` — there is no node to hand a line
+ * range — and drops anything `coveredRanges` already claims, so a call site is
+ * attributed exactly once even though `findUncoveredRanges` can return a range
+ * that overlaps a container's (it rewinds past nested covered ranges, e.g. a
+ * class plus its own methods). That single-attribution property is the
+ * constraint, not a nicety: neither `dependency-analyzer.ts`'s
+ * `extractSymbolUsagesFromChunks` nor `review`'s `buildCallerEdges` dedupes
+ * across a file's chunks, so a doubled attribution would inflate
+ * `totalUsageCount` and caller-edge counts.
+ *
+ * Complexity metrics are untouched — `shouldCalcComplexity` still gates
+ * cognitive/Halstead exactly as before; only call sites widen.
+ */
+function withModuleLevelCallSites(
+  chunks: ASTChunk[],
+  rootNode: SyntaxNode,
+  language: SupportedLanguage,
+  coveredRanges: LineRange[],
+): ASTChunk[] {
+  if (chunks.length === 0) return chunks;
+
+  const all = extractCallSites(rootNode, language);
+  const moduleLevel =
+    coveredRanges.length === 0 ? all : all.filter(cs => !lineIsCovered(cs.line, coveredRanges));
+  if (moduleLevel.length === 0) return chunks;
+
+  return chunks.map(chunk => {
+    const { startLine, endLine } = chunk.metadata;
+    const callSites = moduleLevel.filter(cs => cs.line >= startLine && cs.line <= endLine);
+    if (callSites.length === 0) return chunk;
+    return { ...chunk, metadata: { ...chunk.metadata, callSites } };
+  });
 }
 
 /**

--- a/packages/parser/src/chunk-line-lookup.test.ts
+++ b/packages/parser/src/chunk-line-lookup.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { findChunkLineIndex } from './chunk-line-lookup.js';
+
+describe('findChunkLineIndex', () => {
+  it('returns the arithmetic index when the chunk content starts where it claims', () => {
+    const lines = ['function a() {', '  helper();', '}'];
+
+    // Chunk starts at file line 10, so file line 11 is index 1.
+    expect(findChunkLineIndex(lines, 11, 10, 'helper')).toBe(1);
+  });
+
+  it('corrects for leading lines trimmed out of the content', () => {
+    // Range began at file line 10, but that line was blank and got trimmed, so
+    // content[0] is really file line 11. Bare arithmetic would say index 2.
+    const lines = ['import x', 'register(handler);', 'const y = 1;'];
+
+    expect(findChunkLineIndex(lines, 12, 10, 'register')).toBe(1);
+  });
+
+  it('corrects an offset that would otherwise run past the end of the content', () => {
+    const lines = ['a', 'b', 'register(handler);'];
+
+    // Arithmetic gives 5, out of bounds for a 3-line content.
+    expect(findChunkLineIndex(lines, 15, 10, 'register')).toBe(2);
+  });
+
+  it('prefers the nearest mention, and the earlier line on a tie', () => {
+    const lines = ['register(a);', 'filler', 'register(b);'];
+
+    // Guess is index 1 (no mention); index 0 and 2 are equidistant.
+    expect(findChunkLineIndex(lines, 11, 10, 'register')).toBe(0);
+  });
+
+  it('falls back to the arithmetic guess when nothing nearby mentions the symbol', () => {
+    const lines = ['a', 'b', 'c'];
+
+    expect(findChunkLineIndex(lines, 11, 10, 'register')).toBe(1);
+  });
+
+  it('returns null when the guess is out of bounds and the symbol is nowhere near', () => {
+    const lines = ['a', 'b', 'c'];
+
+    expect(findChunkLineIndex(lines, 40, 10, 'register')).toBeNull();
+    expect(findChunkLineIndex(lines, 1, 10, 'register')).toBeNull();
+  });
+
+  it('does not look further than five lines either side', () => {
+    const lines = ['register(a);', 'x', 'x', 'x', 'x', 'x', 'x', 'x'];
+
+    // Guess is index 7; the mention at index 0 is seven lines away.
+    expect(findChunkLineIndex(lines, 17, 10, 'register')).toBe(7);
+  });
+});

--- a/packages/parser/src/chunk-line-lookup.ts
+++ b/packages/parser/src/chunk-line-lookup.ts
@@ -1,0 +1,63 @@
+/**
+ * Locating a file line inside a chunk's own `content`.
+ *
+ * `absoluteLine - chunk.metadata.startLine` is the obvious arithmetic and it is
+ * only exact when the chunk's content starts on exactly the line `startLine`
+ * names. A module-level chunk's does not: `ast/chunker.ts`'s
+ * `createChunkFromRange` trims its range's leading blank lines out of the
+ * content — a gap between two functions starts on the blank line right after
+ * the first one — while `startLine` keeps naming the untrimmed start. The
+ * arithmetic then OVERSHOOTS by however many lines were trimmed, landing on a
+ * later statement or past the end of the content entirely.
+ *
+ * That was unreachable before #1087, because module-level chunks carried no
+ * call sites to build a snippet for. It is now the common case, and it had two
+ * independent implementations of the same arithmetic to go wrong in
+ * (`dependency-analyzer.ts`'s `extractSnippet` for `get_dependents` usages,
+ * `review`'s `extractSnippetWindow` for PR-review context) — the shape that
+ * keeps producing "one decision implemented at N sites, fixed at fewer than N"
+ * bugs here. Hence one shared lookup rather than two parallel fixes.
+ *
+ * Deliberately corrects the LOOKUP rather than narrowing a chunk's own
+ * `startLine`/`endLine` to match its content: `isValidChunk` measures
+ * `minChunkSize` from exactly those two fields, so shrinking them would
+ * silently drop small module-level chunks from the index — the #772 failure
+ * mode. The `line` reported alongside a snippet is the call site's own,
+ * which is the true file line and was never affected.
+ */
+
+/** How far either side of the arithmetic guess to look for the symbol. */
+const SEARCH_RADIUS = 5;
+
+/**
+ * 0-based index into `lines` of the line that corresponds to file line
+ * `absoluteLine`, for a chunk whose metadata claims to start at
+ * `chunkStartLine`.
+ *
+ * Prefers the nearest line that actually mentions `symbolName` — the only
+ * evidence available that survives a trimmed offset — searching outward from
+ * the arithmetic guess, with the earlier line winning a tie. Falls back to the
+ * guess itself when it is in range and nothing nearby mentions the symbol, and
+ * returns `null` when even that is out of bounds.
+ */
+export function findChunkLineIndex(
+  lines: string[],
+  absoluteLine: number,
+  chunkStartLine: number,
+  symbolName: string,
+): number | null {
+  const guess = absoluteLine - chunkStartLine;
+  const mentionsSymbol = (i: number) => i >= 0 && i < lines.length && lines[i].includes(symbolName);
+
+  if (mentionsSymbol(guess)) return guess;
+
+  // Nearest offset first, and within an offset the earlier line first.
+  const nearby = Array.from({ length: SEARCH_RADIUS }, (_, k) => k + 1).flatMap(offset => [
+    guess - offset,
+    guess + offset,
+  ]);
+  const found = nearby.find(mentionsSymbol);
+  if (found !== undefined) return found;
+
+  return guess >= 0 && guess < lines.length ? guess : null;
+}

--- a/packages/parser/src/dependency-analyzer.ts
+++ b/packages/parser/src/dependency-analyzer.ts
@@ -2415,6 +2415,21 @@ function findSymbolUsages<T extends CodeChunk>(
 }
 
 /**
+ * What to call the caller when the calling chunk has no symbol name of its own.
+ *
+ * A `'block'` chunk is module-level code — top-level statements, a declaration
+ * holding no function — so there is no enclosing function to name, and saying
+ * so beats `'unknown'`, which reads as "we failed to work it out". Matches the
+ * `(module-level)` wording `review`'s `dependency-graph.ts` already uses for
+ * the same situation. Since #1087 widened call-site extraction to module-level
+ * code this is a common case, not a rare fallback.
+ */
+function callerSymbolFor(chunk: CodeChunk): string {
+  if (chunk.metadata.symbolName) return chunk.metadata.symbolName;
+  return chunk.metadata.type === 'block' ? '(module-level)' : 'unknown';
+}
+
+/**
  * Extract all usages of a symbol from a file's chunks.
  */
 function extractSymbolUsagesFromChunks<T extends CodeChunk>(
@@ -2433,7 +2448,7 @@ function extractSymbolUsagesFromChunks<T extends CodeChunk>(
     for (const call of callSites) {
       if (call.symbol === targetSymbol) {
         usages.push({
-          callerSymbol: chunk.metadata.symbolName || 'unknown',
+          callerSymbol: callerSymbolFor(chunk),
           line: call.line,
           snippet: extractSnippet(lines, call.line, chunk.metadata.startLine, targetSymbol),
         });
@@ -2444,9 +2459,45 @@ function extractSymbolUsagesFromChunks<T extends CodeChunk>(
   return usages;
 }
 
+/** Lines either side of the arithmetic guess that `extractSnippet` will consider. */
+const SNIPPET_SEARCH_RADIUS = 5;
+
+/**
+ * Index of the line that actually mentions `symbolName`, searching outward from
+ * `lineIndex` (nearest first, earlier line winning a tie). `null` if none does.
+ *
+ * `callLine - startLine` is only exact when a chunk's `content` starts on
+ * exactly the line its `startLine` names, and for a module-level chunk it does
+ * not: `createChunkFromRange` trims its range's leading blank lines out of the
+ * content while `startLine` still names the untrimmed start, so the arithmetic
+ * lands N lines late — where N is however many blank lines the gap opened
+ * with. That was unreachable before #1087 (module-level chunks carried no call
+ * sites to build a snippet for) and is now the common case, so the snippet has
+ * to be found rather than computed.
+ *
+ * Deliberately corrects the lookup instead of narrowing the chunk's own
+ * `startLine`/`endLine` to match its content: `isValidChunk` measures
+ * `minChunkSize` from exactly those two fields, so shrinking them would
+ * silently drop small module-level chunks from the index — the #772 failure
+ * mode. The `line` a usage reports is `callSite.line` throughout, which is the
+ * true file line and was never affected.
+ */
+function findSymbolLine(lines: string[], lineIndex: number, symbolName: string): number | null {
+  const mentionsSymbol = (i: number) => i >= 0 && i < lines.length && lines[i].includes(symbolName);
+  if (mentionsSymbol(lineIndex)) return lineIndex;
+
+  // Nearest offset first, and within an offset the earlier line first.
+  const nearbyLines = Array.from({ length: SNIPPET_SEARCH_RADIUS }, (_, k) => k + 1).flatMap(
+    offset => [lineIndex - offset, lineIndex + offset],
+  );
+  return nearbyLines.find(mentionsSymbol) ?? null;
+}
+
 /**
  * Extract a code snippet for a call site with bounds checking.
- * If the target line is blank, searches nearby lines for context.
+ * Prefers the nearby line that actually mentions the symbol (see
+ * `findSymbolLine`); if the target line is blank, searches nearby lines for
+ * context.
  */
 function extractSnippet(
   lines: string[],
@@ -2463,6 +2514,11 @@ function extractSnippet(
     return placeholder;
   }
 
+  const symbolLine = findSymbolLine(lines, lineIndex, symbolName);
+  if (symbolLine !== null) {
+    return lines[symbolLine].trim();
+  }
+
   // Try the direct line first
   const directLine = lines[lineIndex].trim();
   if (directLine) {
@@ -2471,7 +2527,7 @@ function extractSnippet(
 
   // If direct line is blank, search for nearby non-blank context
   // Limit search radius to 5 lines to ensure contextual relevance
-  const searchRadius = 5;
+  const searchRadius = SNIPPET_SEARCH_RADIUS;
 
   // Search backwards first (prefer earlier lines)
   for (let i = lineIndex - 1; i >= Math.max(0, lineIndex - searchRadius); i--) {

--- a/packages/parser/src/dependency-analyzer.ts
+++ b/packages/parser/src/dependency-analyzer.ts
@@ -2447,11 +2447,16 @@ function findSymbolUsages<T extends CodeChunk>(
  * A `'block'` chunk is module-level code — top-level statements, a declaration
  * holding no function — so there is no enclosing function to name, and saying
  * so beats `'unknown'`, which reads as "we failed to work it out". Matches the
- * `(module-level)` wording `review`'s `dependency-graph.ts` already uses for
- * the same situation. Since #1087 widened call-site extraction to module-level
- * code this is a common case, not a rare fallback.
+ * `(module-level)` wording `review`'s `dependency-graph.ts` and
+ * `dependent-context.ts` also use for the same situation — exported so those
+ * two sites (and this one) share one implementation instead of three
+ * independently-maintained copies of the same ternary (review finding on
+ * #1087: the `dependency-graph.ts` copy had fallen out of sync with the other
+ * two, still returning `'unknown'` for a module-level caller). Since #1087
+ * widened call-site extraction to module-level code this is a common case,
+ * not a rare fallback.
  */
-function callerSymbolFor(chunk: CodeChunk): string {
+export function callerSymbolFor(chunk: CodeChunk): string {
   if (chunk.metadata.symbolName) return chunk.metadata.symbolName;
   return chunk.metadata.type === 'block' ? '(module-level)' : 'unknown';
 }

--- a/packages/parser/src/dependency-analyzer.ts
+++ b/packages/parser/src/dependency-analyzer.ts
@@ -14,6 +14,7 @@ import {
   hasEnclosingNamespaceAccess,
   hasDependentAttributionBlindSpot,
 } from './ast/languages/registry.js';
+import { findChunkLineIndex } from './chunk-line-lookup.js';
 import { findCSharpTypeReferenceDependents } from './csharp-type-reference-signals.js';
 import { findGoRootPackageDependents } from './go-root-package-signals.js';
 
@@ -2459,45 +2460,12 @@ function extractSymbolUsagesFromChunks<T extends CodeChunk>(
   return usages;
 }
 
-/** Lines either side of the arithmetic guess that `extractSnippet` will consider. */
-const SNIPPET_SEARCH_RADIUS = 5;
-
-/**
- * Index of the line that actually mentions `symbolName`, searching outward from
- * `lineIndex` (nearest first, earlier line winning a tie). `null` if none does.
- *
- * `callLine - startLine` is only exact when a chunk's `content` starts on
- * exactly the line its `startLine` names, and for a module-level chunk it does
- * not: `createChunkFromRange` trims its range's leading blank lines out of the
- * content while `startLine` still names the untrimmed start, so the arithmetic
- * lands N lines late — where N is however many blank lines the gap opened
- * with. That was unreachable before #1087 (module-level chunks carried no call
- * sites to build a snippet for) and is now the common case, so the snippet has
- * to be found rather than computed.
- *
- * Deliberately corrects the lookup instead of narrowing the chunk's own
- * `startLine`/`endLine` to match its content: `isValidChunk` measures
- * `minChunkSize` from exactly those two fields, so shrinking them would
- * silently drop small module-level chunks from the index — the #772 failure
- * mode. The `line` a usage reports is `callSite.line` throughout, which is the
- * true file line and was never affected.
- */
-function findSymbolLine(lines: string[], lineIndex: number, symbolName: string): number | null {
-  const mentionsSymbol = (i: number) => i >= 0 && i < lines.length && lines[i].includes(symbolName);
-  if (mentionsSymbol(lineIndex)) return lineIndex;
-
-  // Nearest offset first, and within an offset the earlier line first.
-  const nearbyLines = Array.from({ length: SNIPPET_SEARCH_RADIUS }, (_, k) => k + 1).flatMap(
-    offset => [lineIndex - offset, lineIndex + offset],
-  );
-  return nearbyLines.find(mentionsSymbol) ?? null;
-}
-
 /**
  * Extract a code snippet for a call site with bounds checking.
- * Prefers the nearby line that actually mentions the symbol (see
- * `findSymbolLine`); if the target line is blank, searches nearby lines for
- * context.
+ * Locates the line via `findChunkLineIndex` (which corrects for a module-level
+ * chunk's trimmed content — see its module doc) rather than trusting
+ * `callLine - startLine`; if the resulting line is blank, searches nearby lines
+ * for context.
  */
 function extractSnippet(
   lines: string[],
@@ -2505,18 +2473,13 @@ function extractSnippet(
   startLine: number,
   symbolName: string,
 ): string {
-  const lineIndex = callLine - startLine;
   const placeholder = `${symbolName}(...)`;
+  const lineIndex = findChunkLineIndex(lines, callLine, startLine, symbolName);
 
-  if (lineIndex < 0 || lineIndex >= lines.length) {
+  if (lineIndex === null) {
     // This can happen when call site line is outside chunk boundaries (edge case)
     // Not necessarily an error - could be chunk boundary misalignment
     return placeholder;
-  }
-
-  const symbolLine = findSymbolLine(lines, lineIndex, symbolName);
-  if (symbolLine !== null) {
-    return lines[symbolLine].trim();
   }
 
   // Try the direct line first
@@ -2527,7 +2490,7 @@ function extractSnippet(
 
   // If direct line is blank, search for nearby non-blank context
   // Limit search radius to 5 lines to ensure contextual relevance
-  const searchRadius = SNIPPET_SEARCH_RADIUS;
+  const searchRadius = 5;
 
   // Search backwards first (prefer earlier lines)
   for (let i = lineIndex - 1; i >= Math.max(0, lineIndex - searchRadius); i--) {

--- a/packages/parser/src/go-root-package-signals.ts
+++ b/packages/parser/src/go-root-package-signals.ts
@@ -165,7 +165,7 @@ function fileImportsBareModuleRoot(fileChunks: CodeChunk[], modulePrefix: string
   return fileChunks.some(c => (c.metadata.imports ?? []).includes(modulePrefix));
 }
 
-/** Every distinctive symbol referenced anywhere in `fileChunks`' own `callSites` (aggregated across all of that file's chunks -- each chunk only carries the call sites made within its own function/method body). */
+/** Every distinctive symbol referenced anywhere in `fileChunks`' own `callSites` (aggregated across all of that file's chunks -- a function/method chunk carries the calls made in its own body, and a module-level chunk the ones made in the top-level statements it spans; the two never overlap, see `ast/chunker.ts`'s `withModuleLevelCallSites`). */
 function collectCallSiteSymbols(fileChunks: CodeChunk[]): Set<string> {
   const symbols = new Set<string>();
   for (const chunk of fileChunks) {

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -237,6 +237,7 @@ export {
   findReExportedSymbolsForFile,
   hasTestImporterFromChunks,
   hasTestImporterBruteForce,
+  callerSymbolFor,
   DEPENDENT_COUNT_THRESHOLDS,
   COMPLEXITY_THRESHOLDS,
 } from './dependency-analyzer.js';

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -302,3 +302,11 @@ export type { BlastRadiusRiskInput, BlastRadiusRisk } from './risk/blast-radius-
 // =============================================================================
 
 export { wordBoundaryRe, isDistinctiveToken } from './doc-reference-matching.js';
+
+// =============================================================================
+// CHUNK LINE LOOKUP (shared by `get_dependents`' usage snippets and review's
+// dependent-context snippets — see chunk-line-lookup.ts's own docstring for
+// why the obvious arithmetic is wrong for a module-level chunk)
+// =============================================================================
+
+export { findChunkLineIndex } from './chunk-line-lookup.js';

--- a/packages/review/src/dependency-graph.ts
+++ b/packages/review/src/dependency-graph.ts
@@ -41,6 +41,7 @@ import {
   normalizePath,
   detectLanguage,
   findCSharpTypeReferenceDependents,
+  callerSymbolFor,
 } from '@liendev/parser';
 
 // ---------------------------------------------------------------------------
@@ -779,7 +780,12 @@ function addEdge(
   existing.push({
     caller: {
       filepath: callerChunk.metadata.file,
-      symbolName: callerChunk.metadata.symbolName ?? 'unknown',
+      // #1087 widened call-site extraction to module-level code, so a caller
+      // with no symbolName is now common, not rare -- `callerSymbolFor` reports
+      // `(module-level)` for it rather than `'unknown'`, matching the wording
+      // `dependent-context.ts` and `dependency-analyzer.ts` already use (review
+      // finding on #1087: this site had fallen out of sync with those two).
+      symbolName: callerSymbolFor(callerChunk),
       chunk: callerChunk,
     },
     callSiteLine,

--- a/packages/review/src/dependent-context.ts
+++ b/packages/review/src/dependent-context.ts
@@ -6,7 +6,7 @@
  * are used in dependent files within the same PR.
  */
 
-import { findChunkLineIndex } from '@liendev/parser';
+import { callerSymbolFor, findChunkLineIndex } from '@liendev/parser';
 import type { CodeChunk } from '@liendev/parser';
 import type { ComplexityReport } from './types.js';
 
@@ -56,9 +56,9 @@ const MAX_LINE_LENGTH = 120;
 
 /**
  * Stands in for the caller's name when the calling chunk is module-level code
- * and so has no enclosing function to name. Same wording `dependency-graph.ts`
- * uses for its own version of this (`NO_REPRESENTATIVE_SYMBOL`) and that
- * `@liendev/parser` reports for `get_dependents` usages.
+ * and so has no enclosing function to name. Produced by `callerSymbolFor`
+ * (`@liendev/parser`) below; kept as its own constant only for the equality
+ * check further down, so this file doesn't hardcode the string a second time.
  */
 const MODULE_LEVEL_CALLER = '(module-level)';
 
@@ -137,15 +137,7 @@ export function findCallSitesForSymbol(
     seenFiles.add(file);
     results.push({
       filepath: file,
-      // A 'block' chunk is module-level code — top-level statements, or a
-      // declaration holding no function — so there is no enclosing function to
-      // name. Same wording `dependency-graph.ts` uses (NO_REPRESENTATIVE_SYMBOL)
-      // and `dependency-analyzer.ts` reports for `get_dependents` usages. Since
-      // #1087 widened call-site extraction to module-level code, this is a
-      // common case rather than a rare fallback.
-      callerSymbol:
-        chunk.metadata.symbolName ??
-        (chunk.metadata.type === 'block' ? MODULE_LEVEL_CALLER : 'unknown'),
+      callerSymbol: callerSymbolFor(chunk),
       line: callSite.line,
       snippet,
       callerComplexity: chunk.metadata.complexity,

--- a/packages/review/src/dependent-context.ts
+++ b/packages/review/src/dependent-context.ts
@@ -6,6 +6,7 @@
  * are used in dependent files within the same PR.
  */
 
+import { findChunkLineIndex } from '@liendev/parser';
 import type { CodeChunk } from '@liendev/parser';
 import type { ComplexityReport } from './types.js';
 
@@ -52,6 +53,14 @@ const MAX_SNIPPETS_PER_FUNCTION = 3;
 const CONTEXT_LINES_BEFORE = 2;
 const CONTEXT_LINES_AFTER = 2;
 const MAX_LINE_LENGTH = 120;
+
+/**
+ * Stands in for the caller's name when the calling chunk is module-level code
+ * and so has no enclosing function to name. Same wording `dependency-graph.ts`
+ * uses for its own version of this (`NO_REPRESENTATIVE_SYMBOL`) and that
+ * `@liendev/parser` reports for `get_dependents` usages.
+ */
+const MODULE_LEVEL_CALLER = '(module-level)';
 
 const RISK_WEIGHTS: Record<string, number> = {
   critical: 4,
@@ -122,13 +131,21 @@ export function findCallSitesForSymbol(
     const callSite = findMatchingCallSite(chunk, symbolName);
     if (!callSite) continue;
 
-    const snippet = extractSnippetWindow(chunk, callSite.line);
+    const snippet = extractSnippetWindow(chunk, callSite.line, symbolName);
     if (!snippet) continue;
 
     seenFiles.add(file);
     results.push({
       filepath: file,
-      callerSymbol: chunk.metadata.symbolName ?? 'unknown',
+      // A 'block' chunk is module-level code — top-level statements, or a
+      // declaration holding no function — so there is no enclosing function to
+      // name. Same wording `dependency-graph.ts` uses (NO_REPRESENTATIVE_SYMBOL)
+      // and `dependency-analyzer.ts` reports for `get_dependents` usages. Since
+      // #1087 widened call-site extraction to module-level code, this is a
+      // common case rather than a rare fallback.
+      callerSymbol:
+        chunk.metadata.symbolName ??
+        (chunk.metadata.type === 'block' ? MODULE_LEVEL_CALLER : 'unknown'),
       line: callSite.line,
       snippet,
       callerComplexity: chunk.metadata.complexity,
@@ -156,14 +173,27 @@ function findMatchingCallSite(chunk: CodeChunk, symbolName: string): { line: num
 
 /**
  * Extract a ~5-line window around a call site line from a chunk's content.
- * Converts the absolute line number to chunk-relative and clamps to bounds.
  * Truncates lines longer than MAX_LINE_LENGTH.
+ *
+ * The absolute-to-relative conversion goes through `findChunkLineIndex` rather
+ * than a bare `callSiteLine - startLine`: for a module-level chunk the content
+ * has had its leading blank lines trimmed while `startLine` still names the
+ * untrimmed start, so the subtraction overshoots — centring the window on a
+ * later statement, or exceeding the content and dropping the snippet entirely.
+ * See that function's module doc. `symbolName` is what lets it find the real
+ * line; without it the old arithmetic is all that is available.
  */
-export function extractSnippetWindow(chunk: CodeChunk, callSiteLine: number): string | null {
+export function extractSnippetWindow(
+  chunk: CodeChunk,
+  callSiteLine: number,
+  symbolName?: string,
+): string | null {
   const lines = chunk.content.split('\n');
-  const relativeLine = callSiteLine - chunk.metadata.startLine;
+  const relativeLine = symbolName
+    ? findChunkLineIndex(lines, callSiteLine, chunk.metadata.startLine, symbolName)
+    : callSiteLine - chunk.metadata.startLine;
 
-  if (relativeLine < 0 || relativeLine >= lines.length) return null;
+  if (relativeLine === null || relativeLine < 0 || relativeLine >= lines.length) return null;
 
   const start = Math.max(0, relativeLine - CONTEXT_LINES_BEFORE);
   const end = Math.min(lines.length - 1, relativeLine + CONTEXT_LINES_AFTER);
@@ -192,7 +222,11 @@ export function formatDependentContext(ctx: DependentContext): string {
   const snippetBlocks = ctx.snippets
     .map(s => {
       const complexityNote = s.callerComplexity ? ` (complexity: ${s.callerComplexity})` : '';
-      return `\`\`\`\n// ${s.filepath}:${s.line} — in ${s.callerSymbol}()${complexityNote}\n${s.snippet}\n\`\`\``;
+      // The `()` reads as "the function named X"; a module-level caller is not
+      // a function, so `in (module-level)()` would be nonsense.
+      const caller =
+        s.callerSymbol === MODULE_LEVEL_CALLER ? s.callerSymbol : `${s.callerSymbol}()`;
+      return `\`\`\`\n// ${s.filepath}:${s.line} — in ${caller}${complexityNote}\n${s.snippet}\n\`\`\``;
     })
     .join('\n\n');
 

--- a/packages/review/test/dependent-context.test.ts
+++ b/packages/review/test/dependent-context.test.ts
@@ -24,6 +24,7 @@ function makeChunk(overrides: {
   callSites?: Array<{ symbol: string; line: number }>;
   imports?: string[];
   exports?: string[];
+  type?: 'function' | 'class' | 'block';
 }): CodeChunk {
   const startLine = overrides.startLine ?? 1;
   const content = overrides.content ?? 'line1\nline2\nline3\nline4\nline5\nline6\nline7';
@@ -34,7 +35,7 @@ function makeChunk(overrides: {
       file: overrides.file,
       startLine,
       endLine: overrides.endLine ?? startLine + lineCount - 1,
-      type: 'function',
+      type: overrides.type ?? 'function',
       language: 'typescript',
       symbolName: overrides.symbolName,
       complexity: overrides.complexity,
@@ -240,6 +241,35 @@ describe('extractSnippetWindow', () => {
     expect(extractSnippetWindow(chunk, 20)).toBeNull();
   });
 
+  it('centres on the real line for a module-level chunk whose content was trimmed (#1087)', () => {
+    // Range was lines 10-16, but line 10 was blank and `createChunkFromRange`
+    // trimmed it away, so content[0] is really file line 11. Bare arithmetic
+    // (13 - 10 = 3) would centre on `filler2`, one line late.
+    const chunk = makeChunk({
+      file: 'src/wiring.ts',
+      type: 'block',
+      startLine: 10,
+      endLine: 16,
+      content: 'import x\nfiller1\nregisterRoute(handler);\nfiller2\nfiller3\nfiller4',
+    });
+
+    expect(extractSnippetWindow(chunk, 13, 'registerRoute')).toContain('registerRoute(handler);');
+  });
+
+  it('drops nothing when the trimmed offset would push past the content end', () => {
+    // Two blank lines trimmed: bare arithmetic gives index 6 for a 5-line
+    // content, which returned null and silently dropped the snippet.
+    const chunk = makeChunk({
+      file: 'src/wiring.ts',
+      type: 'block',
+      startLine: 10,
+      endLine: 20,
+      content: 'a\nb\nc\nd\nregisterRoute(handler);',
+    });
+
+    expect(extractSnippetWindow(chunk, 16, 'registerRoute')).toContain('registerRoute(handler);');
+  });
+
   it('truncates lines longer than 120 characters', () => {
     const longLine = 'x'.repeat(200);
     const chunk = makeChunk({
@@ -282,6 +312,24 @@ describe('findCallSitesForSymbol', () => {
     expect(result[0].callerSymbol).toBe('processInput');
     expect(result[0].line).toBe(2);
     expect(result[0].callerComplexity).toBe(12);
+  });
+
+  it('names a module-level caller "(module-level)", not "unknown" (#1087)', () => {
+    const chunks = [
+      makeChunk({
+        file: 'src/wiring.ts',
+        type: 'block',
+        startLine: 1,
+        content: 'import { validate } from "./validate";\nexport const checked = validate(config);',
+        symbolName: undefined,
+        callSites: [{ symbol: 'validate', line: 2 }],
+      }),
+    ];
+
+    const result = findCallSitesForSymbol('validate', ['src/wiring.ts'], chunks);
+    expect(result).toHaveLength(1);
+    expect(result[0].callerSymbol).toBe('(module-level)');
+    expect(result[0].snippet).toContain('export const checked = validate(config);');
   });
 
   it('returns empty when no matching call sites', () => {


### PR DESCRIPTION
Closes #1087.

## The gate

`ast/chunker.ts` extracted call sites behind `shouldCalcComplexity` — the same
flag as cognitive/Halstead. Complexity genuinely only means something for a
function or method. Call sites do not have that restriction, and sharing the
flag left three kinds of code contributing no reference evidence at all:

| shape | why it produced nothing |
|---|---|
| `export const client = createClient(loadConfig())` | a top-level declaration holding no function isn't a `'function'`/`'method'` symbol, so `createChunk` skipped it |
| bare top-level statements — route/DI registration, `app.use(...)` | they reach `createChunkFromRange` from a raw line range, which has no `SyntaxNode` to extract from |
| almost all of any Vitest/Jest file | it is bare top-level statements end to end, so a test never registered as calling what it tests |

Measured on this repo, that silence covered **81%** of the call expressions
actually in the tree (12,118 of 63,847 emitted). Split by file kind it was
94.4% coverage in production source and **2.9% in test files**.

## What changed

Call sites are now extracted for every chunk whose line range no other chunk
overlaps, plus the module-level chunks that previously had no node to extract
from (`withModuleLevelCallSites`, which works from the file's `rootNode` minus
the ranges the top-level chunks already claim).

Containers stay excluded, and that is the load-bearing constraint: a class
chunk's range *contains* its method chunks', and neither
`dependency-analyzer.ts`'s `extractSymbolUsagesFromChunks` nor `review`'s
`buildCallerEdges` dedupes call sites across a file's chunks, so extracting
there would report every method's calls a second time and inflate
`totalUsageCount` and caller-edge counts.

The container predicate checks `getContainerBody() !== null` as well as
`shouldExtractChildren`, because a language may state the intent to descend and
then decline per node. Python's `decorated_definition` is in `containerTypes`
but returns no body for a decorated *function*. Getting this wrong showed up as
a **regression**, not a missing improvement: psf/requests lost 384 of 2580
references on the first pass, which is how it was caught.

## Consumer map — what moves and what does not

| consumer | reads `callSites`? | effect |
|---|---|---|
| precomputed `dependentCount` (`dependent-count-index.ts`, #1071) | **no** — imports/`importedSymbols` only | **none.** Verified: the `dependent_counts` table is identical before/after (314 rows, total 1701, `diff` empty) |
| `search_code` structural ranking (`applyStructuralBoost`) | no — consumes the count above | **none** |
| test associations (`test-associations.ts`) | **no** — imports + filename conventions | **none** |
| `get_dependents` symbol-level (`findSymbolUsages`) | yes — `fileImportsSymbolFromAny` fallback + `extractSymbolUsagesFromChunks` | more usages, and more symbol-level dependents. Still gated on the file importing from the target first |
| `review`'s caller graph (`buildCallerEdges`) | yes — 5 of the 7 provenance tiers | more call-site-backed edges; the `import-only`/`require-only` fallback tiers shrink correspondingly (a precision improvement — they exist for exactly the absence this fixes) |
| `get_files_context` | yes (only tool with `callSites` in its `metadata-shaper` allowlist) | more call sites returned |
| `search_code` / `list_functions` / `find_similar` | no — not in their allowlists | **none** |
| complexity metrics | n/a | **none** — see below |

## Complexity metrics did not move

`shouldCalcComplexity` still gates cognitive/Halstead exactly as before; only
call-site extraction widened. Verified row-for-row against two isolated indexes
of the same tree:

```
== before
chunks|10579
complexity_sum|10646|cognitive_sum|9220
halstead_volume_sum|1791020.91|halstead_effort_sum|39396968.0
boundary_digest|10579
callsite_entries|14262
== after
chunks|10579
complexity_sum|10646|cognitive_sum|9220
halstead_volume_sum|1791020.91|halstead_effort_sum|39396968.0
boundary_digest|10579
callsite_entries|66345

== row-level diff of (file, startLine, endLine, type, symbolName, complexity,
   cognitiveComplexity, halsteadVolume) across all 10,579 chunks
(diff lines:        0)
```

## Before/after — 12 corpora, 11 of them the ones the E2E suite names

Identifier-join graph (references × declarations), the same shape as the
evaluation that surfaced this. `conn%` is the share of files referencing an
identifier declared in the same corpus; `dupes` is call sites attributed to
more than one chunk of the same file.

```
corpus           files             refs         join%         conn%      edges/file  dupes
MediatR (C#)       154       2578->2578    25.3->25.3    56.5->56.5      4.23->4.23      0
SwiftyJSON          23       1815->1923    39.5->40.9    91.3->95.7    31.17->34.22      0
anyhow (Rust)       37        997->1006    51.6->51.2    75.7->75.7    13.89->13.92      0
chi (Go)            78       3508->3518    63.7->63.6    94.9->94.9    28.63->28.67      0
express (JS)       141       243->11282      14->15.4    12.1->84.4     0.24->12.33      0
javapoet (Java)     39       5402->5402        45->45      100->100    62.31->62.31      0
klaxon (Kotlin)    101       1982->2137    52.9->50.9    79.2->81.2    10.38->10.76      0
monolog (PHP)      216       5793->5799    43.9->43.9        88->88    11.78->11.78      0
requests (Py)       37       2580->2650    56.9->55.8    62.2->70.3       39.68->40      0
sinatra (Ruby)     147       2215->8347    56.3->45.8    42.9->82.3     8.48->26.02      0
zod (TS)           405      3390->34065      65.1->50    26.9->85.4     5.45->42.04      0
lien (self)        617     12129->63838    40.8->28.7    53.6->87.5     8.02->29.66      0
```

No corpus regressed on any measure. The class-based languages (C#, Java, PHP,
Go, Rust) barely move — they put everything in methods, which already worked.
The movers are exactly the corpora where the module level does the composition:
express, zod, sinatra, and us.

**This repo was the second-weakest of the twelve and is now mid-pack**, which
is the point of the issue: anyone evaluating ranking or graph quality on this
repo was measuring the corpus the gate depressed most.

### False-hub check (#928 family) — looked for specifically, not found

Per-reference join precision *dilutes* in the corpora that gain a lot (zod
65.1% → 50%, us 40.8% → 28.7%). That is the expected shape, not a hub: the
newly-added references skew toward member-property names, and the ones that
don't name a declared identifier (`expect`, `it`, `toBe`, `describe` — 20,000+
on this repo alone) cannot join anything, so they cost bytes and create no
edges.

The one measured hub candidate was `readFile`: `fs.readFile` resolves to the
property name, and `review/src/plugins/agent/agent-tools.ts` exports a
`readFile`. 462 new module-level references across 15 files. Real
`get_dependents` output, same query against both indexes:

```
BEFORE  dependentCount: 2   totalUsageCount: 1
AFTER   dependentCount: 2   totalUsageCount: 4
```

`dependentCount` unchanged. The symbol path still requires the caller file to
import from the target (`fileImportsSymbolFromAny`), so `fs.readFile`
everywhere else never becomes a caller. The three added usages are the real
ones, in the one test file that does import it.

Structurally: **0 duplicate attributions** across all 12 corpora
(65k+ entries), and a unit test pins it.

## Index cost, measured

Isolated `LIEN_HOME` per run, two runs each, 766 files:

| | before | after | delta |
|---|---|---|---|
| wall time | 3116 / 3030 ms | 3407 / 2870 ms | within noise (~+2% on means) |
| `chunks.db` | 26.52 / 26.26 MB | 29.29 / 29.51 MB | **+11.2%** |
| whole index dir | 26084 / 25828 KiB | 28792 / 29004 KiB | **+11.6%** (+2.9 MiB) |

4.65x the stored call sites for +11% bytes and no measurable time cost —
`callSites` is a `TEXT` column on `chunks` and is not FTS-indexed, so nothing
else grows.

## Dogfood — real MCP server, real index, before vs after

`lien serve` over stdio against two isolated indexes of this tree.

`get_dependents` for a symbol whose test callers were previously invisible:

```
BEFORE  dependentCount: 1  totalUsageCount: 0
        dependents: [ annotate-cmd.test.ts ]   (no usages at all)

AFTER   dependentCount: 3  totalUsageCount: 5
        packages/cli/test/integration/index-state-matrix.test.ts
          (module-level)  L1217  const result = await handleGetDependents({ filepath: 'math.ts' }, makeCtx(vectorDB));
          (module-level)  L1229  { filepath: 'does/not/exist.ts' },
          (module-level)  L1243  const result = await handleGetDependents({ filepath: 'math.ts' }, makeCtx(vectorDB));
        packages/cli/src/mcp/handlers/get-dependents.test.ts
          (module-level)  ...
```

`get_files_context` on `cli/src/mcp/schemas/dependents.schema.ts` — a file that
is one `z.object({...})` and nothing else, i.e. the issue's first example:

```
BEFORE  0 call sites
AFTER   28 call sites
```

## A third instance of the same root cause, found by the review gate

Lien Review flagged two findings on the first push, both in
`packages/review/src/dependent-context.ts`: review's own copy of the
`callerSymbol` fallback and of the snippet arithmetic, neither of which the
second commit had touched. Both correct. Fixed in the third commit by
extracting the mechanism into `parser`'s `findChunkLineIndex` and having both
call sites use it, rather than fixing the same decision twice.

The second one mattered more than its 🟡 suggested. Dogfooded through
`assembleDependentContext` on this repo's chunks, symbol `chunkByAST`:

```
BEFORE  **Dependent Usage Context** (no call-site data available):
        - 54 file(s) depend on `chunkByAST`

AFTER   **Dependent Usage Context** (top 3 of 54 dependents):
        // packages/parser/src/ast/chunker.test.ts:56 — in (module-level)
              const chunks = chunkByAST('test.ts', content);
              expect(chunks.length).toBeGreaterThan(0);
```

The review agent was getting **no code at all** for a symbol with 54
dependents, falling back to a filename list, because every caller is
module-level. `formatDependentContext` was also rendering `in (module-level)()`,
which claims module-level code is a function; the `()` is now dropped for it.

## Two knock-on fixes (second commit)

Both are output that only becomes common once module-level code carries call
sites, and both were found by reading the dogfood output rather than by tests:

- `callerSymbol` fell back to `'unknown'` for any chunk with no symbol name,
  which module-level chunks never have. Now `'(module-level)'` for a `'block'`
  chunk, matching the wording `review`'s `dependency-graph.ts` already uses.
- `snippet` was computed as `callLine - startLine`, exact only when a chunk's
  content starts on the line `startLine` names. `createChunkFromRange` trims a
  range's leading blank lines out of the content while `startLine` keeps naming
  the untrimmed start, so the arithmetic landed a line late and returned the
  neighbouring statement (`") as ToolResult;"` for a call to `readFile`). Now
  located by finding the nearby line that mentions the symbol. Deliberately
  corrects the lookup rather than narrowing the chunk's `startLine`/`endLine`
  to match its content — `isValidChunk` measures `minChunkSize` from exactly
  those fields, so shrinking them would silently drop small module-level chunks
  (the #772 failure mode). The `line` a usage reports was always correct.

## E2E floors — no floor and no tripwire moves, verified per corpus

`expectedMinDependencyEdges` is computed by `computeDependencyStats` →
`countDependents` → `findDependents`, which resolves *imports*;
`expectedMinTestAssociations` comes from `findTestAssociationsFromChunks`,
which reads no call sites. Rather than assert that from the code, I replicated
both computations (same 100-file sweep, same helpers) against both parser
builds on all 11 cloned corpora:

```
                     totalEdges   orphans   testAssociations
MediatR      before/after   393/393     39/39      194/194
SwiftyJSON   before/after       0/0     23/23          0/0   <- exact-zero tripwire
anyhow       before/after     32/32     23/23          6/6
chi          before/after     64/64     68/68        20/20
express      before/after 2239/2239     66/66    1605/1605
javapoet     before/after     18/18     36/36        16/16
klaxon       before/after       4/4     97/97          0/0   <- exact-zero tripwire
monolog      before/after   186/186     84/84        32/32
requests     before/after   350/350       3/3      136/136
sinatra      before/after     77/77     85/85        45/45
zod          before/after   545/545     73/73          5/5
```

Every number identical, including both `toBe(0)` tripwires
(`KNOWN_ZERO_EDGE_LANGUAGES` for Swift edges,
`KNOWN_ZERO_TESTASSOC_LANGUAGES` for Swift/Kotlin associations) — those assert
*exact* zero, so a call-site-driven leak into either would have failed CI
rather than merely shifted a floor. Nothing to update.

Worth noting for #1053's family: there is no E2E assertion on call-site volume
at all, so this metric could have collapsed to near-zero silently — as it in
fact was, at 19% coverage, while the suite stayed green. Filed as #1090 rather
than bolted onto this PR, with the measured per-corpus values to derive floors
from.

## Gates

| gate | result |
|---|---|
| `format:check` | pass |
| `lint` | 0 errors (41 pre-existing warnings) |
| `typecheck` | 0 errors |
| `build` | pass |
| `npm test` | 5794 tests pass (1845 parser / 1766 / 1684 / 431 / 41 / 27) |
| `lien delta` | exit 0 — new functions at cognitive 6, 5, 2, 2 |

New coverage:

- 7 tests in `parser/src/ast/chunker.test.ts` — the gate being changed had
  **zero** `callSites` assertions before this. Covers the
  declaration-without-function shape, bare top-level statements, a test file
  with no top-level declaration, the no-double-attribution invariant,
  complexity staying untouched, and both Python decorated-function and
  decorated-class cases.
- 7 tests in `parser/src/chunk-line-lookup.test.ts` on the shared lookup,
  including both misalignment directions and the search-radius boundary.
- 1 snippet-alignment regression test in
  `cli/src/mcp/handlers/dependency-analyzer.test.ts`.
- 3 in `review/test/dependent-context.test.ts` — module-level caller label,
  trimmed-offset centring, and the overshoot-past-content case that used to
  return `null` and drop the snippet.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR widens call-site extraction from function/method bodies to module-level code in the AST chunker, adds a shared `findChunkLineIndex` lookup to correct snippet alignment for trimmed module-level chunks, and unifies caller labeling as `(module-level)` across parser and review. The core logic is well-tested (new tests cover the declaration-without-function shape, bare top-level statements, test files, no-double-attribution, complexity preservation, Python decorated functions/classes, Ruby module bare calls, and snippet alignment), and the two issues flagged in the prior review run are both addressed in the current diff: `dependency-graph.ts` now uses `callerSymbolFor`, and `chunker.ts` handles transparent-container gaps. No output-breaking or caller-breaking bugs remain.
>
> - Call sites extracted for all non-container AST chunks plus module-level uncovered ranges
> - Shared `findChunkLineIndex` lookup used by both `get_dependents` snippets and review dependent context
> - `callerSymbolFor` exported and used consistently to label module-level callers as `(module-level)`

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 16bea4f. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

