### PR TITLE
fix(cli): refuse to index home directory or filesystem root without explicit override (#1025)

### DIFF
--- a/.changeset/silly-mangos-jog.md
+++ b/.changeset/silly-mangos-jog.md
@@ -1,0 +1,13 @@
+---
+"@liendev/parser": patch
+"@liendev/core": patch
+"@liendev/lien": patch
+---
+
+`lien index` now refuses to index your home directory or a filesystem root (`/`, `C:\`, a Windows user-profile root) unless explicitly overridden with `--allow-unsafe-root`. This closes the incident behind #1025: running `lien index` from `$HOME` swept macOS Keychain databases, `.npm` debug logs, and Claude Code agent caches into a 10.5 GB index with no warning. The refusal names the exact path and the override flag; a genuine reason to index an unusual root is always one flag away.
+
+As defense in depth, an extra set of OS/credential exclusions (`Library/`, `AppData/`, `.npm/`, `.cache/`, `.claude/`, `.ssh/`, `.aws/`, `.gnupg/`, `*.keychain`/`*.keychain-db`) now applies whenever the indexed root IS the home directory itself — scoped so an ordinary project is never affected, even one with its own legitimate `Library/` directory (Arduino, Unity, some Java layouts) or one that simply lives directly under `$HOME` (`~/myproject`).
+
+Indexing also now skips any single file over 5 MB instead of chunking it whole — a backstop against the same disk-blowup class independent of path filtering, for a legitimately huge binary in an otherwise ordinary project just as much as for an overridden home-root scan.
+
+`lien status` now reports the index's on-disk size (`Index size:` in text output, `indexSizeBytes` in `--format json`), so an anomalously large index is visible instead of sitting unnoticed.

--- a/packages/cli/src/cli/index-cmd.test.ts
+++ b/packages/cli/src/cli/index-cmd.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import os from 'os';
 
 // Mock @liendev/core
 const mockIndexCodebase = vi.fn();
@@ -152,5 +153,53 @@ describe('indexCommand', () => {
         onProgress: expect.any(Function),
       }),
     );
+  });
+
+  describe('unsafe-root refusal (#1025)', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('refuses to index the home directory and never calls indexCodebase', async () => {
+      vi.spyOn(os, 'homedir').mockReturnValue('/Users/fakehome');
+      vi.spyOn(process, 'cwd').mockReturnValue('/Users/fakehome');
+
+      await indexCommand({});
+
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+      expect(mockIndexCodebase).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('your home directory'));
+      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('--allow-unsafe-root'));
+    });
+
+    it('refuses to index a filesystem root and never calls indexCodebase', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('/');
+
+      await indexCommand({});
+
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+      expect(mockIndexCodebase).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('filesystem root'));
+    });
+
+    it('proceeds when --allow-unsafe-root overrides a home-directory refusal', async () => {
+      vi.spyOn(os, 'homedir').mockReturnValue('/Users/fakehome');
+      vi.spyOn(process, 'cwd').mockReturnValue('/Users/fakehome');
+
+      await indexCommand({ allowUnsafeRoot: true });
+
+      expect(processExitSpy).not.toHaveBeenCalled();
+      expect(mockIndexCodebase).toHaveBeenCalled();
+    });
+
+    it('does not refuse an ordinary project directory that lives under $HOME (no over-refusal)', async () => {
+      vi.spyOn(os, 'homedir').mockReturnValue('/Users/fakehome');
+      vi.spyOn(process, 'cwd').mockReturnValue('/Users/fakehome/myproject');
+
+      await indexCommand({});
+
+      expect(processExitSpy).not.toHaveBeenCalled();
+      expect(mockIndexCodebase).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/cli/src/cli/index-cmd.ts
+++ b/packages/cli/src/cli/index-cmd.ts
@@ -6,6 +6,7 @@ import type { IndexingProgress } from '@liendev/core';
 import { showCompactBanner } from '../utils/banner.js';
 import { getIndexingMessage, getModelLoadingMessage } from '../utils/loading-messages.js';
 import { formatDuration } from './utils.js';
+import { checkRootSafety, formatUnsafeRootMessage } from './unsafe-root.js';
 
 /**
  * Clears the existing index and manifest (for --force flag).
@@ -172,8 +173,23 @@ function displayFinalResult(
   }
 }
 
-export async function indexCommand(options: { verbose?: boolean; force?: boolean }) {
+export async function indexCommand(options: {
+  verbose?: boolean;
+  force?: boolean;
+  allowUnsafeRoot?: boolean;
+}) {
   showCompactBanner();
+
+  // Refuse to index the home directory or a filesystem root unless
+  // explicitly overridden (#1025). `lien index` always indexes
+  // `process.cwd()` — there's no `--root`/`--path` to sanity-check instead —
+  // so this has to run before any scanning starts.
+  const rootSafety = checkRootSafety(process.cwd());
+  if (rootSafety.unsafe && !options.allowUnsafeRoot) {
+    console.error(chalk.red(formatUnsafeRootMessage(rootSafety)));
+    process.exit(1);
+    return;
+  }
 
   try {
     // Clear index if --force flag is set

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -64,6 +64,10 @@ program
   .description('Index the codebase for lexical (FTS5) search and dependency analysis')
   .option('-f, --force', 'Force full reindex (skip incremental)')
   .option('-v, --verbose', 'Show detailed logging during indexing')
+  .option(
+    '--allow-unsafe-root',
+    'Allow indexing your home directory or a filesystem root (dangerous, see #1025)',
+  )
   .action(indexCommand);
 
 program

--- a/packages/cli/src/cli/status.ts
+++ b/packages/cli/src/cli/status.ts
@@ -18,6 +18,8 @@ import {
   getLienHome,
   getIndexDir,
   ManifestManager,
+  computeDirSize,
+  formatBytes,
 } from '@liendev/core';
 import { DEFAULT_CHUNK_SIZE, DEFAULT_CHUNK_OVERLAP } from '@liendev/parser';
 import { showCompactBanner } from '../utils/banner.js';
@@ -118,6 +120,10 @@ async function printIndexStatus(indexPath: string) {
   console.log(chalk.dim('Index status:'), chalk.green('✓ Exists'));
 
   console.log(chalk.dim('Index files:'), await getIndexedFileCount(indexPath));
+  // Store size on disk (#1025): the 10.5 GB home-directory index this issue
+  // was filed over sat unnoticed for three days — this is the signal that
+  // would have surfaced it immediately.
+  console.log(chalk.dim('Index size:'), formatBytes(await computeDirSize(indexPath)));
 
   console.log(chalk.dim('Last modified:'), stats.mtime.toLocaleString());
 
@@ -286,6 +292,7 @@ async function outputJson(rootDir: string, indexPath: string) {
     indexPath,
     indexStatus: 'not_indexed',
     indexFiles: 0,
+    indexSizeBytes: 0,
     lastModified: null as string | null,
     lastReindex: null as string | null,
     git: { enabled: false, branch: null, commit: null },
@@ -304,6 +311,7 @@ async function outputJson(rootDir: string, indexPath: string) {
     data.indexStatus = 'exists';
     data.lastModified = stats.mtime.toISOString();
     data.indexFiles = await getIndexedFileCount(indexPath);
+    data.indexSizeBytes = await computeDirSize(indexPath);
 
     const reindexTs = await getLastReindex(indexPath);
     if (reindexTs !== null) {

--- a/packages/cli/src/cli/unsafe-root.test.ts
+++ b/packages/cli/src/cli/unsafe-root.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
+import { checkRootSafety, formatUnsafeRootMessage } from './unsafe-root.js';
+
+describe('checkRootSafety (#1025)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('refuses the filesystem root', () => {
+    const result = checkRootSafety('/');
+
+    expect(result.unsafe).toBe(true);
+    expect(result.unsafe && result.kind).toBe('filesystem-root');
+  });
+
+  it('refuses the home directory exactly', () => {
+    vi.spyOn(os, 'homedir').mockReturnValue('/Users/fakehome');
+
+    const result = checkRootSafety('/Users/fakehome');
+
+    expect(result.unsafe).toBe(true);
+    expect(result.unsafe && result.kind).toBe('home');
+  });
+
+  it('does NOT refuse a project directory that lives directly under $HOME (no over-refusal)', () => {
+    vi.spyOn(os, 'homedir').mockReturnValue('/Users/fakehome');
+
+    const result = checkRootSafety('/Users/fakehome/myproject');
+
+    expect(result.unsafe).toBe(false);
+  });
+
+  it('does NOT refuse an ordinary project directory unrelated to $HOME', () => {
+    vi.spyOn(os, 'homedir').mockReturnValue('/Users/fakehome');
+
+    const result = checkRootSafety('/code/some-repo');
+
+    expect(result.unsafe).toBe(false);
+  });
+
+  it('resolves relative paths before comparing', () => {
+    vi.spyOn(os, 'homedir').mockReturnValue('/Users/fakehome');
+    vi.spyOn(process, 'cwd').mockReturnValue('/Users/fakehome');
+
+    // A relative '.' resolves against process.cwd(), which we've mocked to
+    // be the home directory itself.
+    const result = checkRootSafety('.');
+
+    expect(result.unsafe).toBe(true);
+    expect(result.resolved).toBe('/Users/fakehome');
+  });
+
+  it('always reports the resolved absolute path', () => {
+    const result = checkRootSafety('/some/project');
+
+    expect(result.resolved).toBe(path.resolve('/some/project'));
+  });
+});
+
+describe('formatUnsafeRootMessage', () => {
+  it('names the path and mentions the override flag for a home refusal', () => {
+    const message = formatUnsafeRootMessage({
+      unsafe: true,
+      kind: 'home',
+      resolved: '/Users/fakehome',
+    });
+
+    expect(message).toContain('/Users/fakehome');
+    expect(message).toContain('your home directory');
+    expect(message).toContain('--allow-unsafe-root');
+  });
+
+  it('names the path and mentions the override flag for a filesystem-root refusal', () => {
+    const message = formatUnsafeRootMessage({
+      unsafe: true,
+      kind: 'filesystem-root',
+      resolved: '/',
+    });
+
+    expect(message).toContain('a filesystem root');
+    expect(message).toContain('--allow-unsafe-root');
+  });
+});

--- a/packages/cli/src/cli/unsafe-root.test.ts
+++ b/packages/cli/src/cli/unsafe-root.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
+import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { checkRootSafety, formatUnsafeRootMessage } from './unsafe-root.js';
@@ -56,6 +57,32 @@ describe('checkRootSafety (#1025)', () => {
     const result = checkRootSafety('/some/project');
 
     expect(result.resolved).toBe(path.resolve('/some/project'));
+  });
+
+  describe('symlink to the filesystem root (review finding)', () => {
+    const tmpDirs: string[] = [];
+
+    afterEach(() => {
+      for (const dir of tmpDirs.splice(0)) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('refuses a symlink whose target is the filesystem root, not just a literal "/"', () => {
+      // A plain path.resolve() only normalizes '.'/'..' segments -- it does
+      // not resolve a symlink target, so a cwd that is itself a symlink to
+      // '/' would lexically read as this link's own path and slip past the
+      // fsRoot check.
+      const base = fs.mkdtempSync(path.join(os.tmpdir(), 'lien-unsafe-root-'));
+      tmpDirs.push(base);
+      const link = path.join(base, 'root-link');
+      fs.symlinkSync(path.parse(base).root, link, 'dir');
+
+      const result = checkRootSafety(link);
+
+      expect(result.unsafe).toBe(true);
+      expect(result.unsafe && result.kind).toBe('filesystem-root');
+    });
   });
 });
 

--- a/packages/cli/src/cli/unsafe-root.ts
+++ b/packages/cli/src/cli/unsafe-root.ts
@@ -1,0 +1,68 @@
+import path from 'path';
+import { isHomeDirectory } from '@liendev/parser';
+
+/** Why `checkRootSafety` refused a root. */
+export type UnsafeRootKind = 'home' | 'filesystem-root';
+
+/**
+ * Result of {@link checkRootSafety}. `resolved` is always the fully resolved
+ * absolute path that was checked, so callers never need to re-resolve it for
+ * logging or error messages.
+ */
+export type RootSafetyResult =
+  | { unsafe: true; kind: UnsafeRootKind; resolved: string }
+  | { unsafe: false; resolved: string };
+
+/**
+ * Detect whether `dir` (resolved) IS — not merely contains or sits under —
+ * the user's home directory or a filesystem root (`/`, `C:\`, a Windows
+ * user-profile root). Exact-match only: a real project that happens to live
+ * directly under `$HOME` (`~/myproject`) must never match. That scoping is
+ * deliberate — see #1025: `lien index` run from `$HOME` swept macOS Keychain
+ * databases, `.npm` debug logs, and Claude Code agent caches into a 10.5 GB
+ * index, and there was no guard anywhere against it. `lien index` always
+ * indexes `process.cwd()` (it has no `--root`/`--path` option), so this is
+ * the one place that needs to ask "is this cwd almost certainly a mistake?"
+ * before scanning a single file.
+ *
+ * The home check delegates to {@link isHomeDirectory} (`@liendev/parser`) —
+ * the same symlink-safe comparison `getEffectiveAlwaysIgnorePatterns` uses —
+ * rather than a second, parallel `os.homedir()` comparison here.
+ */
+export function checkRootSafety(dir: string): RootSafetyResult {
+  const resolved = path.resolve(dir);
+  const fsRoot = path.parse(resolved).root;
+
+  if (resolved === fsRoot) {
+    return { unsafe: true, kind: 'filesystem-root', resolved };
+  }
+
+  if (isHomeDirectory(resolved)) {
+    return { unsafe: true, kind: 'home', resolved };
+  }
+
+  return { unsafe: false, resolved };
+}
+
+/**
+ * Build the hard-error message for an unsafe root. Names the exact path and
+ * the override that lets someone with a genuine reason proceed deliberately
+ * (`--allow-unsafe-root`) — a refusal must be actionable, never a dead end
+ * (CLAUDE.md's index-state-honesty policy: gate-shaped commands hard-error,
+ * but always with a way forward).
+ */
+export function formatUnsafeRootMessage(
+  result: Extract<RootSafetyResult, { unsafe: true }>,
+): string {
+  const what = result.kind === 'home' ? 'your home directory' : 'a filesystem root';
+
+  return (
+    `Refusing to index ${what} (${result.resolved}).\n\n` +
+    'Indexing this path would sweep OS caches, credential stores (SSH keys, ' +
+    'cloud CLI configs, keychains), and every unrelated project underneath it ' +
+    'into one index — this is almost never intentional, and it has previously ' +
+    'produced a multi-gigabyte index built entirely from OS and agent cache ' +
+    'files (see https://github.com/getlien/lien/issues/1025).\n\n' +
+    'If this is really what you want, rerun with --allow-unsafe-root.'
+  );
+}

--- a/packages/cli/src/cli/unsafe-root.ts
+++ b/packages/cli/src/cli/unsafe-root.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { isHomeDirectory } from '@liendev/parser';
+import { isHomeDirectory, toComparablePath } from '@liendev/parser';
 
 /** Why `checkRootSafety` refused a root. */
 export type UnsafeRootKind = 'home' | 'filesystem-root';
@@ -28,9 +28,18 @@ export type RootSafetyResult =
  * The home check delegates to {@link isHomeDirectory} (`@liendev/parser`) —
  * the same symlink-safe comparison `getEffectiveAlwaysIgnorePatterns` uses —
  * rather than a second, parallel `os.homedir()` comparison here.
+ *
+ * `resolved` comes from {@link toComparablePath} (`@liendev/parser`), not a
+ * plain `path.resolve`: the latter only normalizes `.`/`..` segments and
+ * leaves a symlink target unresolved, so a `cwd` that is itself a symlink to
+ * `/` would lexically read as some other path and slip past the
+ * `resolved === fsRoot` check below (review finding — a false negative in a
+ * safety check is worse than a false positive, same rationale
+ * `toComparablePath`'s own doc comment gives for the home-directory half of
+ * this same guard).
  */
 export function checkRootSafety(dir: string): RootSafetyResult {
-  const resolved = path.resolve(dir);
+  const resolved = toComparablePath(dir);
   const fsRoot = path.parse(resolved).root;
 
   if (resolved === fsRoot) {

--- a/packages/cli/src/watcher/index.test.ts
+++ b/packages/cli/src/watcher/index.test.ts
@@ -366,6 +366,45 @@ describe('FileWatcher', () => {
 
       await fw.stop();
     });
+
+    // #1025: an explicitly-overridden (--allow-unsafe-root) `lien index` at
+    // $HOME, followed by `lien serve`, must have its file watcher apply the
+    // same OS/credential exclusions as the initial scan -- otherwise a
+    // watched change under Library/ or .ssh/ would re-add exactly what the
+    // guard was built to keep out.
+    it('should add home-root-only exclusions when the watched root IS the home directory', async () => {
+      vi.spyOn(os, 'homedir').mockReturnValue(testDir);
+      await mockEcosystems([], []);
+
+      const watchSpy = vi.spyOn(chokidar, 'watch');
+      const fw = new FileWatcher(testDir);
+      await fw.start(vi.fn());
+
+      const options = watchSpy.mock.calls[0][1] as chokidar.WatchOptions;
+      const ignored = options.ignored as string[];
+
+      expect(ignored).toContain('Library/**');
+      expect(ignored).toContain('.ssh/**');
+
+      await fw.stop();
+    });
+
+    it('should NOT add home-root-only exclusions for an ordinary project directory', async () => {
+      vi.spyOn(os, 'homedir').mockReturnValue(path.join(testDir, 'unrelated-home'));
+      await mockEcosystems([], []);
+
+      const watchSpy = vi.spyOn(chokidar, 'watch');
+      const fw = new FileWatcher(testDir);
+      await fw.start(vi.fn());
+
+      const options = watchSpy.mock.calls[0][1] as chokidar.WatchOptions;
+      const ignored = options.ignored as string[];
+
+      expect(ignored).not.toContain('Library/**');
+      expect(ignored).not.toContain('.ssh/**');
+
+      await fw.stop();
+    });
   });
 
   describe('watchGit - Stage 3: Event-Driven Git Detection', () => {

--- a/packages/cli/src/watcher/index.ts
+++ b/packages/cli/src/watcher/index.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import {
   detectEcosystems,
   getEcosystemExcludePatterns,
-  ALWAYS_IGNORE_PATTERNS,
+  getEffectiveAlwaysIgnorePatterns,
 } from '@liendev/parser';
 
 /**
@@ -77,7 +77,8 @@ export class FileWatcher {
     try {
       const ecosystems = await detectEcosystems(this.rootDir);
       const ecosystemExcludes = getEcosystemExcludePatterns(ecosystems);
-      const mergedExcludes = [...new Set([...ALWAYS_IGNORE_PATTERNS, ...ecosystemExcludes])];
+      const alwaysIgnorePatterns = getEffectiveAlwaysIgnorePatterns(this.rootDir);
+      const mergedExcludes = [...new Set([...alwaysIgnorePatterns, ...ecosystemExcludes])];
       return { include: ['**/*'], exclude: mergedExcludes };
     } catch {
       return this.getDefaultPatterns();
@@ -90,7 +91,7 @@ export class FileWatcher {
   private getDefaultPatterns(): WatchPatterns {
     return {
       include: ['**/*'],
-      exclude: [...ALWAYS_IGNORE_PATTERNS],
+      exclude: getEffectiveAlwaysIgnorePatterns(this.rootDir),
     };
   }
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -23,6 +23,23 @@ export const VERSION_CHECK_INTERVAL_MS = 2000;
 // Git detection
 export const DEFAULT_GIT_POLL_INTERVAL_MS = 10000; // Check every 10 seconds
 
+// Indexable-file size ceiling (#1025): a single file this large is almost
+// never real source, and chunking it whole is what turned 462 files into a
+// 10.5 GB index on a maintainer's machine (the files responsible were OS
+// cache/binary blobs, not source at any plausible size). This is a backstop
+// independent of path-based filtering (ALWAYS_IGNORE_PATTERNS, the
+// home-root guard in cli/unsafe-root.ts) — it protects an ordinary project
+// against an accidentally committed multi-GB blob exactly as much as it
+// protects an explicitly-overridden home-root index against a keychain
+// database. 5 MB comfortably clears every real source/config/doc file this
+// codebase (or any typical one) produces.
+export const MAX_INDEXABLE_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+
+/** Whether `sizeBytes` exceeds {@link MAX_INDEXABLE_FILE_SIZE_BYTES}. */
+export function isOversizedForIndexing(sizeBytes: number): boolean {
+  return sizeBytes > MAX_INDEXABLE_FILE_SIZE_BYTES;
+}
+
 // Index format version - bump on ANY breaking change to indexing
 // Examples that require version bump:
 // - Chunking algorithm changes

--- a/packages/core/src/gc/dir-size.test.ts
+++ b/packages/core/src/gc/dir-size.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
@@ -42,5 +42,15 @@ describe('computeDirSize', () => {
 
   it('returns 0 for a missing directory', async () => {
     expect(await computeDirSize(path.join(dir, 'nope'))).toBe(0);
+  });
+
+  it('skips a malformed entry instead of throwing (e.g. a test double whose readdir mock is not Dirent-shaped)', async () => {
+    const readdirSpy = vi
+      .spyOn(fs, 'readdir')
+      .mockResolvedValueOnce(['not-a-dirent'] as unknown as import('fs').Dirent[]);
+
+    await expect(computeDirSize(dir)).resolves.toBe(0);
+
+    readdirSpy.mockRestore();
   });
 });

--- a/packages/core/src/gc/dir-size.ts
+++ b/packages/core/src/gc/dir-size.ts
@@ -22,8 +22,12 @@ export async function computeDirSize(dir: string): Promise<number> {
   }
 
   for (const entry of entries) {
-    const full = path.join(dir, entry.name);
+    // The whole per-entry body — including path.join(entry.name) — is inside
+    // this try: an entry that vanishes mid-walk, can't be stat'd, or isn't a
+    // well-formed Dirent (e.g. a caller/test double that isn't the real fs)
+    // must contribute 0 rather than throw, matching this function's contract.
     try {
+      const full = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         total += await computeDirSize(full);
       } else if (entry.isFile()) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -225,6 +225,8 @@ export {
   DEFAULT_GIT_POLL_INTERVAL_MS,
   INDEX_FORMAT_VERSION,
   MAX_CHUNKS_PER_FILE,
+  MAX_INDEXABLE_FILE_SIZE_BYTES,
+  isOversizedForIndexing,
 } from './constants.js';
 
 // =============================================================================

--- a/packages/core/src/indexer/chunk-batch-processor.test.ts
+++ b/packages/core/src/indexer/chunk-batch-processor.test.ts
@@ -212,6 +212,41 @@ describe('ChunkBatchProcessor', () => {
     });
   });
 
+  describe('recordZeroChunkFile (#1025)', () => {
+    it('records a manifest entry without adding to the chunk accumulator', async () => {
+      const processor = new ChunkBatchProcessor(
+        mockVectorDB,
+        { batchThreshold: 100 },
+        mockProgressTracker,
+      );
+
+      processor.recordZeroChunkFile('huge.ts', 1234, 'hash-huge');
+
+      const results = processor.getResults();
+      expect(results.indexedFiles).toEqual([
+        { filepath: 'huge.ts', chunkCount: 0, mtime: 1234, contentHash: 'hash-huge' },
+      ]);
+      expect(results.processedChunks).toBe(0);
+      expect(mockVectorDB.insertBatch).not.toHaveBeenCalled();
+    });
+
+    it('coexists with addChunks entries in getResults', async () => {
+      const processor = new ChunkBatchProcessor(
+        mockVectorDB,
+        { batchThreshold: 100 },
+        mockProgressTracker,
+      );
+
+      await processor.addChunks([createMockChunk(1)], 'normal.ts', 1000, 'hash-normal');
+      processor.recordZeroChunkFile('huge.ts', 2000, 'hash-huge');
+
+      const results = processor.getResults();
+      expect(results.indexedFiles).toHaveLength(2);
+      expect(results.indexedFiles.map(f => f.filepath).sort()).toEqual(['huge.ts', 'normal.ts']);
+      expect(results.indexedFiles.find(f => f.filepath === 'huge.ts')?.chunkCount).toBe(0);
+    });
+  });
+
   describe('batch processing', () => {
     it('should write accumulated chunks straight to the store on threshold', async () => {
       const processor = new ChunkBatchProcessor(

--- a/packages/core/src/indexer/chunk-batch-processor.ts
+++ b/packages/core/src/indexer/chunk-batch-processor.ts
@@ -137,6 +137,22 @@ export class ChunkBatchProcessor {
   }
 
   /**
+   * Record a file that produced zero chunks — a genuinely empty file, or one
+   * skipped for being oversized (see `isOversizedForIndexing`, #1025) —
+   * directly in the manifest bookkeeping, without adding anything to the
+   * chunk accumulator. Distinct from `addChunks` (itself a no-op for
+   * `chunks.length === 0`) so a caller can explicitly choose to persist the
+   * zero-chunk fact instead of silently omitting the file from the manifest:
+   * otherwise the very next incremental run would see it as "new" and
+   * reprocess it for no reason. A single synchronous array push — unlike
+   * `addChunks`, nothing here ever yields to the event loop mid-mutation, so
+   * no mutex is needed.
+   */
+  recordZeroChunkFile(filepath: string, mtime: number, contentHash: string): void {
+    this.indexedFiles.push({ filepath, chunkCount: 0, mtime, contentHash });
+  }
+
+  /**
    * Get processing results.
    */
   getResults(): { processedChunks: number; indexedFiles: FileIndexEntry[] } {

--- a/packages/core/src/indexer/incremental.test.ts
+++ b/packages/core/src/indexer/incremental.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
 import { indexSingleFile, indexMultipleFiles } from './incremental.js';
@@ -118,9 +118,15 @@ describe('Incremental Indexing', () => {
       // without writing gigabytes to disk in a test.
       await fs.writeFile(testFile, 'x'.repeat(MAX_INDEXABLE_FILE_SIZE_BYTES + 1));
 
+      // Proves the size check runs before any content read -- not just that
+      // the result ends up empty -- by asserting fs.readFile is never even
+      // called with this file's path.
+      const readFileSpy = vi.spyOn(fs, 'readFile');
       await expect(
         indexSingleFile(testFile, vectorDB, { rootDir: testDir }),
       ).resolves.not.toThrow();
+      expect(readFileSpy.mock.calls.some(call => call[0] === testFile)).toBe(false);
+      readFileSpy.mockRestore();
 
       // Recorded as processed (chunkCount: 0) rather than left unindexed --
       // so it doesn't get re-attempted every run -- but no chunks were
@@ -210,6 +216,7 @@ describe('Incremental Indexing', () => {
       await fs.writeFile(normalFile, 'export function normal() {}');
       await fs.writeFile(hugeFile, 'x'.repeat(MAX_INDEXABLE_FILE_SIZE_BYTES + 1));
 
+      const readFileSpy = vi.spyOn(fs, 'readFile');
       const count = await indexMultipleFiles([normalFile, hugeFile], vectorDB, {
         rootDir: testDir,
       });
@@ -217,6 +224,12 @@ describe('Incremental Indexing', () => {
       // Both are still "processed" (the oversized one is recorded, just with
       // 0 chunks) -- this isn't an error path, it's a deliberate skip.
       expect(count).toBe(2);
+
+      // Proves the size check runs before any content read for the batch
+      // path too: the normal file is read, the oversized one never is.
+      expect(readFileSpy.mock.calls.some(call => call[0] === normalFile)).toBe(true);
+      expect(readFileSpy.mock.calls.some(call => call[0] === hugeFile)).toBe(false);
+      readFileSpy.mockRestore();
 
       const manifest = await new ManifestManager(vectorDB.dbPath).load();
       expect(manifest?.files['normal.ts']?.chunkCount).toBeGreaterThan(0);

--- a/packages/core/src/indexer/incremental.test.ts
+++ b/packages/core/src/indexer/incremental.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
 import { indexSingleFile, indexMultipleFiles } from './incremental.js';
+import { ManifestManager } from './manifest.js';
 import { SqliteBackend } from '../vectordb/sqlite/sqlite-backend.js';
 import { createTestDir, cleanupTestDir } from '../test/helpers/test-db.js';
+import { MAX_INDEXABLE_FILE_SIZE_BYTES } from '../constants.js';
 
 describe('Incremental Indexing', () => {
   let testDir: string;
@@ -109,6 +111,36 @@ describe('Incremental Indexing', () => {
       // Should complete without throwing
       await expect(indexSingleFile(testFile, vectorDB)).resolves.not.toThrow();
     });
+
+    it('should skip an oversized file instead of chunking it (#1025)', async () => {
+      const testFile = path.join(testDir, 'huge.ts');
+      // One byte over the cap -- still exercises the boundary precisely
+      // without writing gigabytes to disk in a test.
+      await fs.writeFile(testFile, 'x'.repeat(MAX_INDEXABLE_FILE_SIZE_BYTES + 1));
+
+      await expect(
+        indexSingleFile(testFile, vectorDB, { rootDir: testDir }),
+      ).resolves.not.toThrow();
+
+      // Recorded as processed (chunkCount: 0) rather than left unindexed --
+      // so it doesn't get re-attempted every run -- but no chunks were
+      // actually produced from its content.
+      const manifest = await new ManifestManager(vectorDB.dbPath).load();
+      expect(manifest?.files['huge.ts']?.chunkCount).toBe(0);
+
+      const results = await vectorDB.search('huge');
+      expect(results.filter(r => r.metadata.file === 'huge.ts')).toHaveLength(0);
+    });
+
+    it('should still index a file just under the size cap', async () => {
+      const testFile = path.join(testDir, 'justunder.ts');
+      await fs.writeFile(testFile, `export function underCap() { return "${'y'.repeat(1000)}"; }`);
+
+      await indexSingleFile(testFile, vectorDB, { rootDir: testDir });
+
+      const manifest = await new ManifestManager(vectorDB.dbPath).load();
+      expect(manifest?.files['justunder.ts']?.chunkCount).toBeGreaterThan(0);
+    });
   });
 
   describe('indexMultipleFiles', () => {
@@ -169,6 +201,26 @@ describe('Incremental Indexing', () => {
       });
 
       expect(count).toBe(2);
+    });
+
+    it('should skip an oversized file among a batch instead of chunking it (#1025)', async () => {
+      const normalFile = path.join(testDir, 'normal.ts');
+      const hugeFile = path.join(testDir, 'huge.ts');
+
+      await fs.writeFile(normalFile, 'export function normal() {}');
+      await fs.writeFile(hugeFile, 'x'.repeat(MAX_INDEXABLE_FILE_SIZE_BYTES + 1));
+
+      const count = await indexMultipleFiles([normalFile, hugeFile], vectorDB, {
+        rootDir: testDir,
+      });
+
+      // Both are still "processed" (the oversized one is recorded, just with
+      // 0 chunks) -- this isn't an error path, it's a deliberate skip.
+      expect(count).toBe(2);
+
+      const manifest = await new ManifestManager(vectorDB.dbPath).load();
+      expect(manifest?.files['normal.ts']?.chunkCount).toBeGreaterThan(0);
+      expect(manifest?.files['huge.ts']?.chunkCount).toBe(0);
     });
 
     it('should handle mixed existing and non-existing files', async () => {

--- a/packages/core/src/indexer/incremental.ts
+++ b/packages/core/src/indexer/incremental.ts
@@ -7,7 +7,9 @@ import {
   DEFAULT_CHUNK_OVERLAP,
   DEFAULT_CONCURRENCY,
   getParseStageConcurrency,
+  isOversizedForIndexing,
 } from '../constants.js';
+import { formatBytes } from '../gc/dir-size.js';
 import { ManifestManager } from './manifest.js';
 import type { Result } from '../utils/result.js';
 import { Ok, Err, isOk } from '../utils/result.js';
@@ -118,6 +120,29 @@ async function processFileContent(
 }
 
 /**
+ * Record a file as indexed with zero chunks — shared by the "genuinely
+ * empty" and "skipped for being oversized" (#1025) cases in
+ * {@link indexSingleFile}. Removes any stale chunks from the vector DB and
+ * records `chunkCount: 0` in the manifest so the file isn't repeatedly
+ * reprocessed as new.
+ */
+async function recordZeroChunkFile(
+  normalizedPath: string,
+  mtime: number,
+  contentHash: string,
+  vectorDB: VectorDBInterface,
+  manifest: ManifestManager,
+): Promise<void> {
+  await vectorDB.deleteByFile(normalizedPath);
+  await manifest.updateFile(normalizedPath, {
+    filepath: normalizedPath,
+    lastModified: mtime,
+    chunkCount: 0,
+    contentHash,
+  });
+}
+
+/**
  * Indexes a single file incrementally by updating its chunks in the vector database.
  * This is the core function for incremental reindexing - it handles file changes,
  * deletions, and additions.
@@ -160,26 +185,29 @@ export async function indexSingleFile(
       return;
     }
 
+    // Stat before reading content, so an oversized file (#1025) can skip the
+    // read+chunk entirely instead of loading a multi-GB blob into memory.
+    const stats = await fs.stat(absolutePath);
+    const contentHash = await computeContentHash(absolutePath);
+    const manifest = new ManifestManager(vectorDB.dbPath);
+
+    if (isOversizedForIndexing(stats.size)) {
+      console.error(
+        `[Lien] Skipped oversized file (${formatBytes(stats.size)} exceeds the indexable cap): ${normalizedPath}`,
+      );
+      await recordZeroChunkFile(normalizedPath, stats.mtimeMs, contentHash, vectorDB, manifest);
+      return;
+    }
+
     // Read file content
     const content = await fs.readFile(absolutePath, 'utf-8');
 
     // Process file content (chunking) - use normalized path for storage
     const result = await processFileContent(normalizedPath, content, verbose || false, rootDir);
 
-    // Get actual file mtime and compute content hash for manifest
-    const stats = await fs.stat(absolutePath);
-    const contentHash = await computeContentHash(absolutePath);
-    const manifest = new ManifestManager(vectorDB.dbPath);
-
     if (result === null) {
       // Empty file - remove from vector DB but keep in manifest with chunkCount: 0
-      await vectorDB.deleteByFile(normalizedPath);
-      await manifest.updateFile(normalizedPath, {
-        filepath: normalizedPath,
-        lastModified: stats.mtimeMs,
-        chunkCount: 0,
-        contentHash,
-      });
+      await recordZeroChunkFile(normalizedPath, stats.mtimeMs, contentHash, vectorDB, manifest);
       return;
     }
 
@@ -227,10 +255,26 @@ async function processSingleFileForIndexing(
       ? filepath
       : path.resolve(rootDir || process.cwd(), filepath);
 
-    // Read file stats and content using the absolute path
+    // Stat before reading content, so an oversized file (#1025) can skip the
+    // read+chunk entirely instead of loading a multi-GB blob into memory.
     const stats = await fs.stat(absolutePath);
-    const content = await fs.readFile(absolutePath, 'utf-8');
     const contentHash = await computeContentHash(absolutePath);
+
+    if (isOversizedForIndexing(stats.size)) {
+      console.error(
+        `[Lien] Skipped oversized file (${formatBytes(stats.size)} exceeds the indexable cap): ${normalizedPath}`,
+      );
+      // Treated like an empty file (result: null) — removed from the vector
+      // DB and recorded in the manifest with chunkCount: 0 by the caller.
+      return Ok({
+        filepath: normalizedPath,
+        result: null,
+        mtime: stats.mtimeMs,
+        contentHash,
+      });
+    }
+
+    const content = await fs.readFile(absolutePath, 'utf-8');
 
     // Process content using normalized path (for storage)
     const result = await processFileContent(normalizedPath, content, verbose, rootDir);

--- a/packages/core/src/indexer/incremental.ts
+++ b/packages/core/src/indexer/incremental.ts
@@ -1,4 +1,5 @@
 import fs from 'fs/promises';
+import type { Stats } from 'fs';
 import path from 'path';
 import pLimit from 'p-limit';
 import type { VectorDBInterface } from '../vectordb/types.js';
@@ -143,6 +144,28 @@ async function recordZeroChunkFile(
 }
 
 /**
+ * Handle the #1025 size-cap case for {@link indexSingleFile}: log the skip,
+ * then record the file with zero chunks. Hashing here still uses
+ * `computeContentHash`'s >1MB fingerprint fast path (first/last 8KB, never
+ * the whole file), so this never reads an oversized file's full content —
+ * only the size check itself needs to run before anything else. Extracted
+ * so `indexSingleFile`'s own branching stays flat.
+ */
+async function handleOversizedFile(
+  normalizedPath: string,
+  absolutePath: string,
+  stats: Stats,
+  vectorDB: VectorDBInterface,
+  manifest: ManifestManager,
+): Promise<void> {
+  console.error(
+    `[Lien] Skipped oversized file (${formatBytes(stats.size)} exceeds the indexable cap): ${normalizedPath}`,
+  );
+  const contentHash = await computeContentHash(absolutePath);
+  await recordZeroChunkFile(normalizedPath, stats.mtimeMs, contentHash, vectorDB, manifest);
+}
+
+/**
  * Indexes a single file incrementally by updating its chunks in the vector database.
  * This is the core function for incremental reindexing - it handles file changes,
  * deletions, and additions.
@@ -185,17 +208,14 @@ export async function indexSingleFile(
       return;
     }
 
-    // Stat before reading content, so an oversized file (#1025) can skip the
-    // read+chunk entirely instead of loading a multi-GB blob into memory.
+    // Stat FIRST, and check the size cap before anything else touches the
+    // file's content -- including hashing -- so an oversized file (#1025)
+    // never gets read at all, not even for its content hash.
     const stats = await fs.stat(absolutePath);
-    const contentHash = await computeContentHash(absolutePath);
     const manifest = new ManifestManager(vectorDB.dbPath);
 
     if (isOversizedForIndexing(stats.size)) {
-      console.error(
-        `[Lien] Skipped oversized file (${formatBytes(stats.size)} exceeds the indexable cap): ${normalizedPath}`,
-      );
-      await recordZeroChunkFile(normalizedPath, stats.mtimeMs, contentHash, vectorDB, manifest);
+      await handleOversizedFile(normalizedPath, absolutePath, stats, vectorDB, manifest);
       return;
     }
 
@@ -204,6 +224,7 @@ export async function indexSingleFile(
 
     // Process file content (chunking) - use normalized path for storage
     const result = await processFileContent(normalizedPath, content, verbose || false, rootDir);
+    const contentHash = await computeContentHash(absolutePath);
 
     if (result === null) {
       // Empty file - remove from vector DB but keep in manifest with chunkCount: 0
@@ -236,6 +257,27 @@ export async function indexSingleFile(
 }
 
 /**
+ * Build the #1025 size-cap skip result for {@link processSingleFileForIndexing}:
+ * treated like an empty file (`result: null`) so the caller removes any
+ * stale chunks and records `chunkCount: 0`. Hashing still uses
+ * `computeContentHash`'s >1MB fingerprint fast path (first/last 8KB, never
+ * the whole file) -- the size check itself is what has to run before
+ * anything else touches the file. Extracted so
+ * `processSingleFileForIndexing`'s own branching stays flat.
+ */
+async function buildOversizedSkipResult(
+  normalizedPath: string,
+  absolutePath: string,
+  stats: Stats,
+): Promise<Result<FileProcessResult, string>> {
+  console.error(
+    `[Lien] Skipped oversized file (${formatBytes(stats.size)} exceeds the indexable cap): ${normalizedPath}`,
+  );
+  const contentHash = await computeContentHash(absolutePath);
+  return Ok({ filepath: normalizedPath, result: null, mtime: stats.mtimeMs, contentHash });
+}
+
+/**
  * Process a single file, returning a Result type.
  * This helper makes error handling explicit and testable.
  *
@@ -255,26 +297,17 @@ async function processSingleFileForIndexing(
       ? filepath
       : path.resolve(rootDir || process.cwd(), filepath);
 
-    // Stat before reading content, so an oversized file (#1025) can skip the
-    // read+chunk entirely instead of loading a multi-GB blob into memory.
+    // Stat FIRST, and check the size cap before anything else touches the
+    // file -- including hashing -- so an oversized file (#1025) never gets
+    // read at all, not even for its content hash.
     const stats = await fs.stat(absolutePath);
-    const contentHash = await computeContentHash(absolutePath);
 
     if (isOversizedForIndexing(stats.size)) {
-      console.error(
-        `[Lien] Skipped oversized file (${formatBytes(stats.size)} exceeds the indexable cap): ${normalizedPath}`,
-      );
-      // Treated like an empty file (result: null) — removed from the vector
-      // DB and recorded in the manifest with chunkCount: 0 by the caller.
-      return Ok({
-        filepath: normalizedPath,
-        result: null,
-        mtime: stats.mtimeMs,
-        contentHash,
-      });
+      return buildOversizedSkipResult(normalizedPath, absolutePath, stats);
     }
 
     const content = await fs.readFile(absolutePath, 'utf-8');
+    const contentHash = await computeContentHash(absolutePath);
 
     // Process content using normalized path (for storage)
     const result = await processFileContent(normalizedPath, content, verbose, rootDir);

--- a/packages/core/src/indexer/index.test.ts
+++ b/packages/core/src/indexer/index.test.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { indexCodebase } from './index.js';
 import { createVectorDB } from '../vectordb/factory.js';
 import { createTestDir, cleanupTestDir, createTestFile } from '../test/helpers/test-db.js';
+import { MAX_INDEXABLE_FILE_SIZE_BYTES } from '../constants.js';
 
 const MATH_TS = `export function add(a: number, b: number): number {
   return a + b;
@@ -90,5 +91,21 @@ describe('indexCodebase (lexical FTS5 structural index)', () => {
     } finally {
       await cleanupTestDir(emptyDir);
     }
+  });
+
+  it('skips an oversized file instead of chunking it, but still indexes the rest (#1025)', async () => {
+    await createTestFile(testDir, 'src/huge.ts', 'x'.repeat(MAX_INDEXABLE_FILE_SIZE_BYTES + 1));
+
+    const result = await indexCodebase({ rootDir: testDir, force: true });
+
+    expect(result.success).toBe(true);
+    expect(result.chunksCreated).toBeGreaterThan(0);
+
+    const db = await createVectorDB(testDir);
+    await db.initialize();
+    const rows = await db.scanAll();
+
+    expect(rows.some(r => r.metadata.file.endsWith('main.ts'))).toBe(true);
+    expect(rows.some(r => r.metadata.file.endsWith('huge.ts'))).toBe(false);
   });
 });

--- a/packages/core/src/indexer/index.test.ts
+++ b/packages/core/src/indexer/index.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
 import { indexCodebase } from './index.js';
 import { createVectorDB } from '../vectordb/factory.js';
+import { ManifestManager } from './manifest.js';
 import { createTestDir, cleanupTestDir, createTestFile } from '../test/helpers/test-db.js';
 import { MAX_INDEXABLE_FILE_SIZE_BYTES } from '../constants.js';
 
@@ -94,9 +95,18 @@ describe('indexCodebase (lexical FTS5 structural index)', () => {
   });
 
   it('skips an oversized file instead of chunking it, but still indexes the rest (#1025)', async () => {
-    await createTestFile(testDir, 'src/huge.ts', 'x'.repeat(MAX_INDEXABLE_FILE_SIZE_BYTES + 1));
+    const hugePath = await createTestFile(
+      testDir,
+      'src/huge.ts',
+      'x'.repeat(MAX_INDEXABLE_FILE_SIZE_BYTES + 1),
+    );
 
+    // Proves the size check runs before any content read on the full-index
+    // path too -- not just that the result ends up empty.
+    const readFileSpy = vi.spyOn(fs, 'readFile');
     const result = await indexCodebase({ rootDir: testDir, force: true });
+    expect(readFileSpy.mock.calls.some(call => call[0] === hugePath)).toBe(false);
+    readFileSpy.mockRestore();
 
     expect(result.success).toBe(true);
     expect(result.chunksCreated).toBeGreaterThan(0);
@@ -107,5 +117,10 @@ describe('indexCodebase (lexical FTS5 structural index)', () => {
 
     expect(rows.some(r => r.metadata.file.endsWith('main.ts'))).toBe(true);
     expect(rows.some(r => r.metadata.file.endsWith('huge.ts'))).toBe(false);
+
+    // Recorded in the manifest with chunkCount: 0 -- not silently absent --
+    // so the very next incremental run doesn't see it as "new" and retry it.
+    const manifest = await new ManifestManager(db.dbPath).load();
+    expect(manifest?.files['src/huge.ts']?.chunkCount).toBe(0);
   });
 });

--- a/packages/core/src/indexer/index.ts
+++ b/packages/core/src/indexer/index.ts
@@ -17,7 +17,9 @@ import {
   DEFAULT_CHUNK_OVERLAP,
   DEFAULT_CONCURRENCY,
   getParseStageConcurrency,
+  isOversizedForIndexing,
 } from '../constants.js';
+import { formatBytes } from '../gc/dir-size.js';
 import { createVectorDB } from '../vectordb/factory.js';
 import { writeVersionFile } from '../vectordb/version.js';
 import { ManifestManager } from './manifest.js';
@@ -331,6 +333,17 @@ async function processFileForIndexing(
     const relativePath = normalizeToRelativePath(file, rootDir);
     // Get file stats to capture actual modification time
     const stats = await fs.stat(absolutePath);
+
+    // Size cap (#1025): skip before reading content, so an oversized file
+    // never gets loaded into memory or chunked in the first place.
+    if (isOversizedForIndexing(stats.size)) {
+      console.error(
+        `[indexer] Skipped oversized file (${formatBytes(stats.size)} exceeds the indexable cap): ${relativePath}`,
+      );
+      progressTracker.incrementFiles();
+      return false;
+    }
+
     const content = await fs.readFile(absolutePath, 'utf-8');
 
     const chunks = chunkFile(relativePath, content, {

--- a/packages/core/src/indexer/index.ts
+++ b/packages/core/src/indexer/index.ts
@@ -335,11 +335,17 @@ async function processFileForIndexing(
     const stats = await fs.stat(absolutePath);
 
     // Size cap (#1025): skip before reading content, so an oversized file
-    // never gets loaded into memory or chunked in the first place.
+    // never gets loaded into memory or chunked in the first place. Still
+    // recorded with chunkCount: 0 (like a genuinely empty file below), so a
+    // full index doesn't leave it silently absent from the manifest --
+    // otherwise the very next incremental run would see it as "new" and
+    // reprocess it for no reason.
     if (isOversizedForIndexing(stats.size)) {
       console.error(
         `[indexer] Skipped oversized file (${formatBytes(stats.size)} exceeds the indexable cap): ${relativePath}`,
       );
+      const contentHash = await computeContentHash(absolutePath);
+      batchProcessor.recordZeroChunkFile(relativePath, stats.mtimeMs, contentHash);
       progressTracker.incrementFiles();
       return false;
     }
@@ -354,13 +360,15 @@ async function processFileForIndexing(
       workspaceRoot: rootDir,
     });
 
+    // Compute content hash for change detection -- needed for both the
+    // empty and non-empty outcomes below, so computed once regardless.
+    const contentHash = await computeContentHash(absolutePath);
+
     if (chunks.length === 0) {
+      batchProcessor.recordZeroChunkFile(relativePath, stats.mtimeMs, contentHash);
       progressTracker.incrementFiles();
       return false;
     }
-
-    // Compute content hash for change detection
-    const contentHash = await computeContentHash(absolutePath);
 
     // Add chunks to batch processor (handles mutex internally)
     await batchProcessor.addChunks(chunks, relativePath, stats.mtimeMs, contentHash);

--- a/packages/core/src/indexer/overlay-index.test.ts
+++ b/packages/core/src/indexer/overlay-index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
 import Database from 'better-sqlite3';
@@ -6,8 +6,10 @@ import { getIndexDir } from '../utils/index-dir.js';
 import { createTestDir, cleanupTestDir } from '../test/helpers/test-db.js';
 import { indexCodebase } from './index.js';
 import { buildOverlay, computeOverlaySignature } from './overlay-index.js';
+import { ManifestManager } from './manifest.js';
 import { OverlayBackend } from '../vectordb/overlay-backend.js';
 import { writeVersionFile } from '../vectordb/version.js';
+import { MAX_INDEXABLE_FILE_SIZE_BYTES } from '../constants.js';
 
 /** Files (relative path -> content) for the base checkout. */
 const BASE_FILES: Record<string, string> = {
@@ -131,6 +133,36 @@ describe('buildOverlay', () => {
     // And the fast path resumes once the current-format signature is stored.
     const again = await buildOverlay(overlay);
     expect(again.changed).toBe(false);
+  });
+
+  it('skips an oversized diverged file instead of chunking it, but still builds the rest of the overlay (#1025)', async () => {
+    const hugePath = path.join(worktreeDir, 'huge.ts');
+    await fs.writeFile(hugePath, 'x'.repeat(MAX_INDEXABLE_FILE_SIZE_BYTES + 1));
+
+    // Proves the size check runs before any content read on the overlay
+    // rebuild path too -- not just that the result ends up empty. (The
+    // content-hash diff pass above always stats+hashes every file via
+    // computeContentHash's fingerprint fast path; what must never happen is
+    // a full fs.readFile of the oversized file during the chunk pass.)
+    const readFileSpy = vi.spyOn(fs, 'readFile');
+    const res = await buildOverlay(overlay);
+    expect(readFileSpy.mock.calls.some(call => call[0] === hugePath)).toBe(false);
+    readFileSpy.mockRestore();
+
+    expect(res.changed).toBe(true);
+    expect(res.added).toBe(2); // d.ts (normal) + huge.ts (oversized), both new vs base
+
+    const files = await filesInIndex(overlay);
+    expect(files.has('d.ts')).toBe(true);
+    // Oversized -- never chunked or served, exactly like the full/incremental
+    // index paths' same size cap.
+    expect(files.has('huge.ts')).toBe(false);
+
+    // Still recorded in the overlay manifest with chunkCount: 0, so it isn't
+    // silently re-attempted as "new" on the next rebuild.
+    const overlayManifest = new ManifestManager(overlay.dbPath);
+    const manifest = await overlayManifest.load();
+    expect(manifest?.files['huge.ts']?.chunkCount).toBe(0);
   });
 });
 

--- a/packages/core/src/indexer/overlay-index.ts
+++ b/packages/core/src/indexer/overlay-index.ts
@@ -10,7 +10,9 @@ import {
   DEFAULT_CHUNK_OVERLAP,
   INDEX_FORMAT_VERSION,
   getParseStageConcurrency,
+  isOversizedForIndexing,
 } from '../constants.js';
+import { formatBytes } from '../gc/dir-size.js';
 import type { OverlayBackend } from '../vectordb/overlay-backend.js';
 import { ManifestManager, type FileEntry } from './manifest.js';
 import { scanFilesToIndex } from './index.js';
@@ -100,6 +102,66 @@ async function reconcileOverlayManifest(
   if (manifestEntries.length > 0) {
     await overlayManifest.updateFiles(manifestEntries);
   }
+}
+
+/** What one diverged file contributes to an overlay rebuild. */
+interface DivergedFileResult {
+  /** Chunk batch to persist, or null for a zero-chunk file (empty, or oversized). */
+  chunkBatch: { metadatas: ChunkMetadata[]; contents: string[] } | null;
+  manifestEntry: FileEntry;
+}
+
+/**
+ * Process one diverged file into its chunk batch plus manifest entry — or,
+ * if it exceeds `MAX_INDEXABLE_FILE_SIZE_BYTES`, skip chunking it and record
+ * it with `chunkCount: 0` instead (#1025's oversized-file backstop, applied
+ * here too: a >5MB modified/added file could otherwise blow up an overlay
+ * rebuild the exact same way a full or incremental index run was already
+ * guarded against). Extracted out of `buildOverlay` to keep that function's
+ * own branching flat.
+ */
+async function processDivergedFile(d: DivergedFile, verbose: boolean): Promise<DivergedFileResult> {
+  const stats = await fs.stat(d.abs);
+
+  if (isOversizedForIndexing(stats.size)) {
+    console.error(
+      `[Lien] overlay: skipped oversized file (${formatBytes(stats.size)} exceeds the indexable cap): ${d.rel}`,
+    );
+    return {
+      chunkBatch: null,
+      manifestEntry: {
+        filepath: d.rel,
+        lastModified: stats.mtimeMs,
+        chunkCount: 0,
+        contentHash: d.hash,
+      },
+    };
+  }
+
+  const content = await fs.readFile(d.abs, 'utf-8');
+  const chunks = chunkFile(d.rel, content, {
+    chunkSize: DEFAULT_CHUNK_SIZE,
+    chunkOverlap: DEFAULT_CHUNK_OVERLAP,
+    useAST: true,
+    astFallback: 'line-based',
+  });
+
+  if (verbose) {
+    console.error(`[Lien] overlay: staged ${d.rel} (${chunks.length} chunks)`);
+  }
+
+  return {
+    chunkBatch:
+      chunks.length > 0
+        ? { metadatas: chunks.map(c => c.metadata), contents: chunks.map(c => c.content) }
+        : null,
+    manifestEntry: {
+      filepath: d.rel,
+      lastModified: stats.mtimeMs,
+      chunkCount: chunks.length,
+      contentHash: d.hash,
+    },
+  };
 }
 
 /**
@@ -204,29 +266,12 @@ export async function buildOverlay(
   await Promise.all(
     diverged.map(d =>
       parseLimit(async () => {
-        const content = await fs.readFile(d.abs, 'utf-8');
-        const chunks = chunkFile(d.rel, content, {
-          chunkSize: DEFAULT_CHUNK_SIZE,
-          chunkOverlap: DEFAULT_CHUNK_OVERLAP,
-          useAST: true,
-          astFallback: 'line-based',
-        });
-        const stats = await fs.stat(d.abs);
-        if (chunks.length > 0) {
-          chunkBatches.push({
-            metadatas: chunks.map(c => c.metadata),
-            contents: chunks.map(c => c.content),
-          });
-        }
-        manifestEntries.push({
-          filepath: d.rel,
-          lastModified: stats.mtimeMs,
-          chunkCount: chunks.length,
-          contentHash: d.hash,
-        });
-        if (options.verbose) {
-          console.error(`[Lien] overlay: staged ${d.rel} (${chunks.length} chunks)`);
-        }
+        const { chunkBatch, manifestEntry } = await processDivergedFile(
+          d,
+          options.verbose ?? false,
+        );
+        if (chunkBatch) chunkBatches.push(chunkBatch);
+        manifestEntries.push(manifestEntry);
       }),
     ),
   );

--- a/packages/parser/src/gitignore.test.ts
+++ b/packages/parser/src/gitignore.test.ts
@@ -381,6 +381,12 @@ describe('createGitignoreFilter', () => {
       expect(isIgnored('random.keychain-db')).toBe(true);
       // Ordinary files at the home root are unaffected.
       expect(isIgnored('myproject/src/index.ts')).toBe(false);
+      // A project living directly under $HOME (root IS home, so this path is
+      // reachable) must keep its own nested Library/ and keychain-named
+      // files -- these patterns are root-anchored (no `**/` variant), so
+      // they must not match at any depth below the home root.
+      expect(isIgnored('myproject/Library/Sketchbook/sketch.ino')).toBe(false);
+      expect(isIgnored('myproject/notes.keychain-db')).toBe(false);
     });
 
     it('never rescues a tracked .ssh/config at the home root, even though tracked files are normally rescued', async () => {

--- a/packages/parser/src/gitignore.test.ts
+++ b/packages/parser/src/gitignore.test.ts
@@ -1,10 +1,17 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { createGitignoreFilter } from './gitignore.js';
+import {
+  createGitignoreFilter,
+  isHomeDirectory,
+  getEffectiveAlwaysIgnorePatterns,
+  getEffectiveNeverIndexPatterns,
+  ALWAYS_IGNORE_PATTERNS,
+  NEVER_INDEX_EVEN_IF_TRACKED_PATTERNS,
+} from './gitignore.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -315,6 +322,79 @@ describe('createGitignoreFilter', () => {
       const isIgnored = await createGitignoreFilter(testDir);
 
       expect(isIgnored('node_modules/leftpad/index.js')).toBe(true);
+    });
+  });
+
+  // #1025: `lien index` run from $HOME swept macOS Keychain databases, .npm
+  // debug logs, and Claude Code caches into a 10.5 GB index. These extra
+  // patterns are scoped to "the indexed root IS the home directory" so an
+  // ordinary project is never affected, even one containing a real `Library/`
+  // directory (Arduino/Unity/some Java layouts) or living directly under
+  // `$HOME` (`~/myproject`).
+  describe('home-root scoping (#1025)', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('isHomeDirectory matches the home dir exactly but not a project under it', () => {
+      vi.spyOn(os, 'homedir').mockReturnValue(testDir);
+
+      expect(isHomeDirectory(testDir)).toBe(true);
+      expect(isHomeDirectory(path.join(testDir, 'myproject'))).toBe(false);
+      expect(isHomeDirectory(path.dirname(testDir))).toBe(false);
+    });
+
+    it('getEffectiveAlwaysIgnorePatterns/getEffectiveNeverIndexPatterns are unchanged for a non-home root', () => {
+      vi.spyOn(os, 'homedir').mockReturnValue(path.join(testDir, 'unrelated-home'));
+
+      expect(getEffectiveAlwaysIgnorePatterns(testDir)).toEqual(ALWAYS_IGNORE_PATTERNS);
+      expect(getEffectiveNeverIndexPatterns(testDir)).toEqual(NEVER_INDEX_EVEN_IF_TRACKED_PATTERNS);
+    });
+
+    it('does NOT exclude Library/, .ssh/, or .npm/ for an ordinary project root (no over-refusal)', async () => {
+      // testDir is a plain project directory here -- home is somewhere else.
+      vi.spyOn(os, 'homedir').mockReturnValue(path.join(testDir, 'unrelated-home'));
+
+      const isIgnored = await createGitignoreFilter(testDir);
+
+      // A legitimate project's own Library/ directory (Arduino, Unity, some
+      // Java layouts) must be indexed normally.
+      expect(isIgnored('Library/Sketchbook/sketch.ino')).toBe(false);
+      expect(isIgnored('.npm/README.md')).toBe(false);
+      expect(isIgnored('.ssh/notes.md')).toBe(false);
+      expect(isIgnored('src/index.ts')).toBe(false);
+    });
+
+    it('excludes OS caches and credential directories when the root IS the home directory', async () => {
+      vi.spyOn(os, 'homedir').mockReturnValue(testDir);
+
+      const isIgnored = await createGitignoreFilter(testDir);
+
+      expect(isIgnored('Library/Keychains/login.keychain-db')).toBe(true);
+      expect(isIgnored('Library/Caches/claude-cli-nodejs/transcript.json')).toBe(true);
+      expect(isIgnored('.npm/_logs/debug-0.log')).toBe(true);
+      expect(isIgnored('.cache/some-tool/data')).toBe(true);
+      expect(isIgnored('.claude/projects/session.jsonl')).toBe(true);
+      expect(isIgnored('.ssh/id_rsa')).toBe(true);
+      expect(isIgnored('.aws/credentials')).toBe(true);
+      expect(isIgnored('.gnupg/secring.gpg')).toBe(true);
+      expect(isIgnored('random.keychain-db')).toBe(true);
+      // Ordinary files at the home root are unaffected.
+      expect(isIgnored('myproject/src/index.ts')).toBe(false);
+    });
+
+    it('never rescues a tracked .ssh/config at the home root, even though tracked files are normally rescued', async () => {
+      vi.spyOn(os, 'homedir').mockReturnValue(testDir);
+
+      await fs.mkdir(path.join(testDir, '.ssh'), { recursive: true });
+      await fs.writeFile(path.join(testDir, '.ssh', 'config'), 'Host example.com\n');
+
+      await initGitRepo(testDir);
+      await gitCommitAll(testDir);
+
+      const isIgnored = await createGitignoreFilter(testDir);
+
+      expect(isIgnored('.ssh/config')).toBe(true);
     });
   });
 });

--- a/packages/parser/src/gitignore.ts
+++ b/packages/parser/src/gitignore.ts
@@ -87,9 +87,12 @@ export const HOME_ROOT_ONLY_IGNORE_PATTERNS = [
  * so a path built from an unresolved `$HOME`/`cwd` can differ textually from
  * the same real directory reached another way, causing this exact
  * comparison to silently miss a true match (a false negative in a safety
- * check is worse than a false positive).
+ * check is worse than a false positive). Exported so `checkRootSafety`
+ * (`@liendev/lien`'s `unsafe-root.ts`) can apply the same symlink-safe
+ * resolution to its filesystem-root check, matching what `isHomeDirectory`
+ * below already does for the home-directory half of the same guard.
  */
-function toComparablePath(p: string): string {
+export function toComparablePath(p: string): string {
   try {
     return realpathSync(p);
   } catch {

--- a/packages/parser/src/gitignore.ts
+++ b/packages/parser/src/gitignore.ts
@@ -48,35 +48,35 @@ export const ALWAYS_IGNORE_PATTERNS = [
  * names anywhere in a path avoids false positives: `Library/` is a
  * legitimate source directory in some ecosystems (Arduino sketches, Unity
  * projects, some Java layouts), so a universal `**\/Library/**` exclusion
- * would silently blind those projects. The only place these OS/credential
- * directories can appear as an indexing root's own top-level entries is when
- * the root really is `$HOME` — the exact shape that swept macOS Keychain
- * databases, `.npm` debug logs, and Claude Code caches into a 10.5 GB index
- * on a maintainer's machine (#1025). Also fed into
- * {@link getEffectiveNeverIndexPatterns} so a dotfiles repo that happens to
- * track one of these (e.g. `.ssh/config`) is never rescued back in either.
+ * would silently blind those projects. Deliberately root-anchored only —
+ * no `**\/` variants: the directory patterns contain a mid-pattern slash
+ * (`Library/**`) and the two basename globs carry an explicit leading slash
+ * (`/*.keychain`), both of which anchor to the root of the `ignore()`
+ * instance under gitignore semantics — i.e. `rootDir`, which this array is
+ * only ever added under when `rootDir` IS home (see
+ * {@link getEffectiveAlwaysIgnorePatterns}/{@link getEffectiveNeverIndexPatterns}).
+ * A bare `*.keychain` (no leading slash) or a `**\/`-prefixed sibling would
+ * both match these names at any depth, ignoring e.g. `~/myproject/Library/`
+ * too — exactly the false positive this pattern set exists to avoid. The
+ * only place these OS/credential directories can appear as an indexing
+ * root's own top-level entries is when the root really is `$HOME` — the
+ * exact shape that swept macOS Keychain databases, `.npm` debug logs, and
+ * Claude Code caches into a 10.5 GB index on a maintainer's machine (#1025).
+ * Also fed into {@link getEffectiveNeverIndexPatterns} so a dotfiles repo
+ * that happens to track one of these (e.g. `.ssh/config`) is never rescued
+ * back in either.
  */
 export const HOME_ROOT_ONLY_IGNORE_PATTERNS = [
   'Library/**',
-  '**/Library/**',
   'AppData/**',
-  '**/AppData/**',
   '.npm/**',
-  '**/.npm/**',
   '.cache/**',
-  '**/.cache/**',
   '.claude/**',
-  '**/.claude/**',
   '.ssh/**',
-  '**/.ssh/**',
   '.aws/**',
-  '**/.aws/**',
   '.gnupg/**',
-  '**/.gnupg/**',
-  '*.keychain-db',
-  '**/*.keychain-db',
-  '*.keychain',
-  '**/*.keychain',
+  '/*.keychain-db',
+  '/*.keychain',
 ];
 
 /**

--- a/packages/parser/src/gitignore.ts
+++ b/packages/parser/src/gitignore.ts
@@ -1,6 +1,8 @@
 import ignore, { type Ignore } from 'ignore';
 import fs from 'fs/promises';
 import type fsSync from 'fs';
+import { realpathSync } from 'fs';
+import os from 'os';
 import path from 'path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -38,6 +40,88 @@ export const ALWAYS_IGNORE_PATTERNS = [
   '**/pnpm-lock.yaml',
 ];
 
+/**
+ * Extra always-ignore patterns applied ONLY when the indexed root IS the
+ * user's home directory itself (see {@link isHomeDirectory}) — never applied
+ * to an ordinary project, even one that lives directly under `$HOME`
+ * (`~/myproject`). Scoping to "root IS home" rather than matching these
+ * names anywhere in a path avoids false positives: `Library/` is a
+ * legitimate source directory in some ecosystems (Arduino sketches, Unity
+ * projects, some Java layouts), so a universal `**\/Library/**` exclusion
+ * would silently blind those projects. The only place these OS/credential
+ * directories can appear as an indexing root's own top-level entries is when
+ * the root really is `$HOME` — the exact shape that swept macOS Keychain
+ * databases, `.npm` debug logs, and Claude Code caches into a 10.5 GB index
+ * on a maintainer's machine (#1025). Also fed into
+ * {@link getEffectiveNeverIndexPatterns} so a dotfiles repo that happens to
+ * track one of these (e.g. `.ssh/config`) is never rescued back in either.
+ */
+export const HOME_ROOT_ONLY_IGNORE_PATTERNS = [
+  'Library/**',
+  '**/Library/**',
+  'AppData/**',
+  '**/AppData/**',
+  '.npm/**',
+  '**/.npm/**',
+  '.cache/**',
+  '**/.cache/**',
+  '.claude/**',
+  '**/.claude/**',
+  '.ssh/**',
+  '**/.ssh/**',
+  '.aws/**',
+  '**/.aws/**',
+  '.gnupg/**',
+  '**/.gnupg/**',
+  '*.keychain-db',
+  '**/*.keychain-db',
+  '*.keychain',
+  '**/*.keychain',
+];
+
+/**
+ * Resolve `p` to its real, symlink-free path for comparison purposes,
+ * falling back to a plain lexical resolve when `p` doesn't exist on disk yet
+ * (e.g. a string used in a unit test) or can't be stat'd. `path.resolve`
+ * alone is not enough: on macOS `/tmp` is itself a symlink to `/private/tmp`,
+ * so a path built from an unresolved `$HOME`/`cwd` can differ textually from
+ * the same real directory reached another way, causing this exact
+ * comparison to silently miss a true match (a false negative in a safety
+ * check is worse than a false positive).
+ */
+function toComparablePath(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return path.resolve(p);
+  }
+}
+
+/**
+ * Whether `dir` IS the current user's home directory itself — not merely
+ * somewhere underneath it. Exact-match only: a real project living directly
+ * under `$HOME` (`~/myproject`) must never match, or an entirely ordinary
+ * project layout would start losing files the moment a caller applies
+ * {@link HOME_ROOT_ONLY_IGNORE_PATTERNS} (#1025's over-refusal requirement).
+ * Compares real (symlink-resolved) paths — see {@link toComparablePath}.
+ */
+export function isHomeDirectory(dir: string): boolean {
+  const homeDir = os.homedir();
+  if (!homeDir) return false;
+  return toComparablePath(dir) === toComparablePath(homeDir);
+}
+
+/**
+ * The always-ignore pattern set to apply for `rootDir`: the universal
+ * {@link ALWAYS_IGNORE_PATTERNS}, plus {@link HOME_ROOT_ONLY_IGNORE_PATTERNS}
+ * when (and only when) `rootDir` IS the home directory itself (#1025).
+ */
+export function getEffectiveAlwaysIgnorePatterns(rootDir: string): string[] {
+  return isHomeDirectory(rootDir)
+    ? [...ALWAYS_IGNORE_PATTERNS, ...HOME_ROOT_ONLY_IGNORE_PATTERNS]
+    : ALWAYS_IGNORE_PATTERNS;
+}
+
 /** Directories to skip during .gitignore discovery (no useful .gitignore inside) */
 const SKIP_DIRS = new Set(['node_modules', 'vendor', '.git', '.lien', 'dist', 'build']);
 
@@ -63,6 +147,20 @@ export const NEVER_INDEX_EVEN_IF_TRACKED_PATTERNS = [
   '.claude/worktrees/**',
   '**/.claude/worktrees/**',
 ];
+
+/**
+ * The never-index-even-if-tracked pattern set to apply for `rootDir`: the
+ * universal {@link NEVER_INDEX_EVEN_IF_TRACKED_PATTERNS}, plus
+ * {@link HOME_ROOT_ONLY_IGNORE_PATTERNS} when `rootDir` is the home
+ * directory itself — a dotfiles repo that legitimately tracks `.ssh/config`
+ * or a GPG key must still never have it rescued back into the index; the
+ * severity here outweighs the tracked-file exemption's usual rationale.
+ */
+export function getEffectiveNeverIndexPatterns(rootDir: string): string[] {
+  return isHomeDirectory(rootDir)
+    ? [...NEVER_INDEX_EVEN_IF_TRACKED_PATTERNS, ...HOME_ROOT_ONLY_IGNORE_PATTERNS]
+    : NEVER_INDEX_EVEN_IF_TRACKED_PATTERNS;
+}
 
 // git ls-files output can be large for repos with hundreds of thousands of
 // tracked files; keep the buffer generous so large repos never truncate
@@ -191,6 +289,10 @@ function isRescuedByGitTracking(
  * match the full scan behavior in scanner.ts. In a git repository, a path
  * git tracks is exempted from all of the above (see {@link getGitTrackedFiles})
  * except the narrow {@link NEVER_INDEX_EVEN_IF_TRACKED_PATTERNS} carve-out.
+ * When `rootDir` IS the user's home directory itself, the OS/credential
+ * carve-out in {@link HOME_ROOT_ONLY_IGNORE_PATTERNS} is layered on top of
+ * both sets (#1025) — see {@link getEffectiveAlwaysIgnorePatterns} and
+ * {@link getEffectiveNeverIndexPatterns}.
  *
  * Limitation: scoped evaluation is OR across .gitignore files, so a nested
  * .gitignore cannot un-ignore a pattern from a parent. Cross-scope negation
@@ -205,10 +307,10 @@ export async function createGitignoreFilter(
 ): Promise<(relativePath: string) => boolean> {
   // Always-ignore patterns in a separate instance (cannot be negated)
   const alwaysIg = ignore();
-  alwaysIg.add(ALWAYS_IGNORE_PATTERNS);
+  alwaysIg.add(getEffectiveAlwaysIgnorePatterns(rootDir));
 
   const neverIndexIg = ignore();
-  neverIndexIg.add(NEVER_INDEX_EVEN_IF_TRACKED_PATTERNS);
+  neverIndexIg.add(getEffectiveNeverIndexPatterns(rootDir));
 
   // Discover all .gitignore files and the tracked-file set in parallel --
   // independent I/O, no reason to serialize them.

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -110,7 +110,14 @@ export { chunkJSONTemplate } from './json-template-chunker.js';
 // GITIGNORE
 // =============================================================================
 
-export { createGitignoreFilter, ALWAYS_IGNORE_PATTERNS } from './gitignore.js';
+export {
+  createGitignoreFilter,
+  ALWAYS_IGNORE_PATTERNS,
+  HOME_ROOT_ONLY_IGNORE_PATTERNS,
+  isHomeDirectory,
+  getEffectiveAlwaysIgnorePatterns,
+  getEffectiveNeverIndexPatterns,
+} from './gitignore.js';
 
 // =============================================================================
 // ECOSYSTEM PRESETS

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -117,6 +117,7 @@ export {
   isHomeDirectory,
   getEffectiveAlwaysIgnorePatterns,
   getEffectiveNeverIndexPatterns,
+  toComparablePath,
 } from './gitignore.js';
 
 // =============================================================================

--- a/packages/parser/src/scanner.test.ts
+++ b/packages/parser/src/scanner.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
@@ -361,5 +361,55 @@ describe('scanCodebase — git-tracked-file rescue (#899, #900)', () => {
 
     expect(relative).toContain('src/real.ts');
     expect(relative).not.toContain('build/output.js');
+  });
+
+  // #1025: a full `lien index` scan must apply the same home-root scoping as
+  // createGitignoreFilter (gitignore.test.ts covers the filter in isolation;
+  // this covers the actual scanCodebase entry point `lien index` uses).
+  describe('home-root scoping (#1025)', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('indexes a real Library/ directory normally in an ordinary project (no over-refusal)', async () => {
+      testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-scanner-home-scoping-'));
+      vi.spyOn(os, 'homedir').mockReturnValue(path.join(testDir, 'unrelated-home'));
+
+      // Arduino/Unity-style project layout: a real, legitimate `Library/`.
+      await fs.mkdir(path.join(testDir, 'Library', 'Sketchbook'), { recursive: true });
+      await fs.writeFile(
+        path.join(testDir, 'Library', 'Sketchbook', 'sketch.h'),
+        '#define VERSION 1\n',
+      );
+
+      const files = await scanCodebase({ rootDir: testDir });
+      const relative = files.map(f => path.relative(testDir, f).replace(/\\/g, '/'));
+
+      expect(relative).toContain('Library/Sketchbook/sketch.h');
+    });
+
+    it('excludes Library/, .ssh/, .npm/ etc. when the scan root IS the home directory', async () => {
+      testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-scanner-home-scoping-'));
+      vi.spyOn(os, 'homedir').mockReturnValue(testDir);
+
+      await fs.mkdir(path.join(testDir, 'Library', 'Caches', 'claude-cli-nodejs'), {
+        recursive: true,
+      });
+      await fs.writeFile(
+        path.join(testDir, 'Library', 'Caches', 'claude-cli-nodejs', 'transcript.md'),
+        '# transcript\n',
+      );
+      await fs.mkdir(path.join(testDir, 'myproject', 'src'), { recursive: true });
+      await fs.writeFile(
+        path.join(testDir, 'myproject', 'src', 'real.ts'),
+        'export const real = true;\n',
+      );
+
+      const files = await scanCodebase({ rootDir: testDir });
+      const relative = files.map(f => path.relative(testDir, f).replace(/\\/g, '/'));
+
+      expect(relative).not.toContain('Library/Caches/claude-cli-nodejs/transcript.md');
+      expect(relative).toContain('myproject/src/real.ts');
+    });
   });
 });

--- a/packages/parser/src/scanner.ts
+++ b/packages/parser/src/scanner.ts
@@ -5,8 +5,8 @@ import fs from 'fs/promises';
 import path from 'path';
 import type { ScanOptions } from './types.js';
 import {
-  ALWAYS_IGNORE_PATTERNS,
-  NEVER_INDEX_EVEN_IF_TRACKED_PATTERNS,
+  getEffectiveAlwaysIgnorePatterns,
+  getEffectiveNeverIndexPatterns,
   getGitTrackedFiles,
 } from './gitignore.js';
 
@@ -47,7 +47,7 @@ function rescueTrackedFiles(
 ): string[] {
   if (trackedFiles.size === 0) return [];
 
-  const neverIndexIg = ignore().add(NEVER_INDEX_EVEN_IF_TRACKED_PATTERNS);
+  const neverIndexIg = ignore().add(getEffectiveNeverIndexPatterns(rootDir));
   const lexicalRelSet = new Set(
     lexicalFiles.map(file => path.relative(rootDir, file).replace(/\\/g, '/')),
   );
@@ -76,7 +76,8 @@ export async function scanCodebase(options: ScanOptions): Promise<string[]> {
   const { rootDir, includePatterns = [], excludePatterns = [] } = options;
 
   const ig = await loadGitignore(rootDir);
-  ig.add([...ALWAYS_IGNORE_PATTERNS, ...excludePatterns]);
+  const alwaysIgnorePatterns = getEffectiveAlwaysIgnorePatterns(rootDir);
+  ig.add([...alwaysIgnorePatterns, ...excludePatterns]);
 
   // Determine patterns to search for. The `.github/**` entry is required
   // alongside the brace pattern because glob's default `dot:false` blocks
@@ -92,7 +93,7 @@ export async function scanCodebase(options: ScanOptions): Promise<string[]> {
         ];
 
   // Combine always-ignored patterns with exclude patterns for glob
-  const globIgnorePatterns = [...ALWAYS_IGNORE_PATTERNS, ...excludePatterns];
+  const globIgnorePatterns = [...alwaysIgnorePatterns, ...excludePatterns];
 
   // Find all code files
   const allFiles: string[] = [];


### PR DESCRIPTION
## Summary

Closes #1025. `lien index` run from `$HOME` had no guard and swept macOS Keychain databases, `.npm` debug logs, and Claude Code caches into a 10.5 GB index on a maintainer's machine. This PR implements 3 of the 4 fixes the issue suggested, and skips the 4th with reasoning below.

**1. Hard refusal (the important one).** `lien index` now refuses when `process.cwd()` resolves to the home directory or a filesystem root (`/`, `C:\`, a Windows user-profile root), unless `--allow-unsafe-root` is passed. Implemented in `packages/cli/src/cli/unsafe-root.ts`. The home check delegates to a symlink-safe (`realpath`-compared) `isHomeDirectory` in `@liendev/parser` — needed because e.g. macOS's `/tmp` → `/private/tmp` symlink can make a naive string comparison silently miss a true match (a false negative in a safety check is worse than a false positive; caught this via manual reproduction, see Verification below).

**2. Extended ignore patterns — scoped, not universal.** `HOME_ROOT_ONLY_IGNORE_PATTERNS` (`Library/`, `AppData/`, `.npm/`, `.cache/`, `.claude/`, `.ssh/`, `.aws/`, `.gnupg/`, `*.keychain`/`*.keychain-db`) is layered on top of the existing `ALWAYS_IGNORE_PATTERNS` **only when the indexed root IS the home directory itself** (`packages/parser/src/gitignore.ts`'s `getEffectiveAlwaysIgnorePatterns`/`getEffectiveNeverIndexPatterns`). I scoped by "root IS home" rather than matching these names anywhere in a path, because `Library/` is a legitimate source directory in some ecosystems (Arduino, Unity, some Java layouts) — a universal exclusion would blind those projects. This also means the patterns only ever activate through the deliberate `--allow-unsafe-root` override (or another entry point that happens to resolve to home), never for an ordinary project.

**3. Oversized-file cap.** Indexing now skips (rather than chunks) any single file over 5 MB (`MAX_INDEXABLE_FILE_SIZE_BYTES` in `packages/core/src/constants.ts`), wired into all three read-then-chunk call sites (`indexer/index.ts`'s full-index path, `indexer/incremental.ts`'s single-file and batch paths). This is an independent backstop against the same disk-blowup class regardless of path filtering — it protects an ordinary project against an accidentally-committed multi-GB blob exactly as much as it protects an explicitly-overridden home-root scan against a keychain database. Skipped files are recorded with `chunkCount: 0` (like an empty file) so they aren't silently re-attempted every run.

**4. `lien status` now reports index size** (`Index size:` in text, `indexSizeBytes` in `--format json`) — the 10.5 GB index in the issue sat unnoticed for three days; this is the signal that would have surfaced it.

**Skipped:** the issue's further suggestion that `lien gc` flag anomalously large/stale indices. That's a separate feature (detection logic, thresholds, a new command surface) rather than a natural extension of this fix, and out of scope to keep this PR focused — left as a natural follow-up now that `lien status` exposes the raw number.

## Refusal message

```
Refusing to index your home directory (/private/tmp/lien-1025-fakehome-1).

Indexing this path would sweep OS caches, credential stores (SSH keys, cloud CLI configs, keychains), and every unrelated project underneath it into one index — this is almost never intentional, and it has previously produced a multi-gigabyte index built entirely from OS and agent cache files (see https://github.com/getlien/lien/issues/1025).

If this is really what you want, rerun with --allow-unsafe-root.
```
Exit code 1.

## Verification (manual, against isolated fixtures — never the real home directory or a shared index)

- **Refusal reproduced**: built `dist/index.js`, ran with `HOME`/`cwd` pointed at a constructed fake-home directory under `/tmp` → refused with the message above, exit 1. (This is also what caught the symlink bug: the first attempt silently did **not** refuse, because `/tmp` resolves to `/private/tmp` and the naive comparison missed it — fixed by comparing realpaths.)
- **Override works**: same fixture with `--allow-unsafe-root` → proceeded, indexed only the one legitimate file (`myproject-a/src/index.ts`); `Library/Caches/.../transcript.md`, `.npm/_logs/npm-debug.md`, and `.ssh/notes.md` were all correctly excluded (confirmed via the manifest).
- **No over-refusal**: a project directory living directly under the fake `$HOME` (`myproject-b`, containing its own `Library/Sketchbook/sketch.h`) indexed normally with no refusal — both `src/index.ts` and `Library/Sketchbook/sketch.h` ended up in the manifest, proving a real project's own `Library/` directory is unaffected.
- **`lien status` dogfooded** against both the fixture and this actual repo (read-only, on the existing overlay index — no `--force`, no real-home touch): shows `Index size: 40.6 KB` / `20.9 MB` respectively, and `indexSizeBytes` in JSON output.
- **Full dogfood in this repo**: ran `lien index` (incremental, no `--force`) against this actual worktree — completed in 4.7s, no false refusal, 505 files indexed.

## Test plan

- [x] `npm run format:check` — clean
- [x] `npm run lint` — 0 errors (42 pre-existing warnings, unrelated)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm test` (parser-native, parser, core, review, cli, action) — 1697+ tests pass across all packages
- [x] `lien delta` — exit 0, no new threshold crossings (several "worsened but still under threshold" entries from the added branching, all informational)
- [x] New/updated tests: `unsafe-root.test.ts` (new), `index-cmd.test.ts`, `gitignore.test.ts`, `scanner.test.ts`, `watcher/index.test.ts`, `incremental.test.ts`, `index.test.ts` (core indexer), `dir-size.test.ts`, `status.test.ts`
- [x] Changeset added (`@liendev/parser`, `@liendev/core`, `@liendev/lien`, patch)

---

<!-- lien-stats -->
### Lien Review

✅ **Improved!** Complexity reduced by 53. 5 pre-existing issues remain in touched files.
🔗 **Impact**: 1 high-risk file(s) with 14 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 1 | -17 |
| ⏱️ time to understand | 3 | -36 |


> [!NOTE]
> **Low Risk**
>
> This PR adds well-scoped safety guards for `lien index`: refusing to run from the home directory or filesystem root unless `--allow-unsafe-root` is passed, applying root-anchored OS/credential ignore patterns only when the indexed root IS the home directory, capping single files at 5 MB with `chunkCount: 0` recording across full/incremental/batch/overlay paths, and reporting index size in `lien status`. The implementation matches the stated intent and the added tests cover the key boundaries. No code paths were found that produce wrong output, break callers, or silently swallow errors.
>
> - CLI refuses home/root indexing without --allow-unsafe-root, with symlink-safe comparison via @liendev/parser
> - Home-root-only ignore patterns are root-anchored and do not affect nested project directories
> - 5 MB oversized-file cap applied consistently across full, incremental, batch, and overlay indexing paths
> - lien status reports on-disk index size in text and JSON output

> [!WARNING]
> 🟡 **Trust: Degraded — budget-starved**
>
> The review stopped after exhausting its token budget before finishing. Treat the findings above as partial.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit d812a06. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `lien index` now protects home-directory and filesystem-root scans by default, with an explicit override available.
  * Files larger than 5 MB are skipped safely while indexing continues.
  * Status output now reports index storage usage in text and JSON formats.
* **Bug Fixes**
  * Home-directory scans now exclude sensitive credentials, caches, and system folders.
  * Improved handling of empty, malformed, and oversized files prevents indexing interruptions.
* **Documentation**
  * Added release information for updated parser, core, and CLI packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 655K/722K tokens
<!-- /lien:attestation -->