### PR TITLE
fix(core,cli): make the dependentCount honesty note reflect the composition and clear on `lien index` (#1085, #1084)

### DIFF
--- a/.changeset/overlay-dependent-count-honesty-lifecycle.md
+++ b/.changeset/overlay-dependent-count-honesty-lifecycle.md
@@ -1,0 +1,61 @@
+---
+'@liendev/core': patch
+'@liendev/lien': patch
+---
+
+fix: the `dependentCount` honesty note no longer fires on a worktree that has counts, and the remedy it prints now works (#1085, #1084)
+
+Two halves of the same lifecycle defect in #1072's honesty plumbing.
+
+**#1085 — a self-contradictory response.** In a linked worktree,
+`OverlayBackend.hasDependentCounts()` read only the worktree's OWN overlay flag,
+which is absent until that worktree has completed its own `lien index`. So a
+fresh worktree whose shared base had counts fully computed emitted "this index
+predates reverse-dependency counting" and dropped `dependentCount` from 100% of
+`search_code` results — while the base's counts were ranking the very results the
+note was attached to. Measured on MediatR: `Mediator.cs` at #1 with the boost on
+and #5 with `LIEN_STRUCTURAL_RANKING=off`, in the same worktree, with every count
+reported as omitted.
+
+That is the #1050/#1051 shape — asking one of two on-disk locations instead of the
+composition — and #1014's cost, since every agent session in a linked worktree got
+the note on its first search. The method now mirrors the two branches of
+`composedDependentCounts` exactly: the composed flag when set, and otherwise
+whatever the BASE store can prove about its own table, which is the store the read
+path is serving those numbers from. Not the row-count-of-the-merged-map reasoning
+review rejected on #1078 — that map is a merge and proves nothing; this asks the
+base store whether it computed counts over its own corpus. A resurrected stale
+count is real but it is staleness, deliberately uncaveated per #1072's case 4, and
+suppressing every count never fixed it — it only also lied about why.
+
+**#1084 — the note prescribed a remedy that did nothing.** The note says
+`Run "lien index" to populate them`, and the code comment claimed it "clears itself
+permanently after one index run". Neither was true on the upgrade path that
+produces the note: `lien index` found no content changes, printed "Index is up to
+date", and returned without writing the counts or the flag. Touching a file did not
+help either. Only `lien index --force` worked. Computing the counts is now a
+MIGRATION-completion step gated on `hasDependentCounts()`, so the next `lien index`
+after an upgrade completes it whether or not anything changed, and every run after
+that skips it on one meta lookup. #1071's freshness contract is unchanged: normal
+incremental editing still does not recompute whole-corpus counts, so counts still
+lag by at most one full index run. The version stamp is bumped only when a backfill
+actually ran, so a live `lien serve` reconnects rather than clearing the note while
+still serving an empty cached count map.
+
+`OverlayBackend` gains a public `backfillDependentCounts()` for the same migration
+over the composed `(base − masked) ∪ overlay` corpus, because `buildOverlay`
+returns before `applyRebuild` entirely when the overlay's signature already
+matches — so an overlay that had never composed counts previously had no path to
+them.
+
+`hasComputedDependentCounts` now tolerates either of its tables being absent, each
+clause independently: a base index written by 0.75.4 has real `dependent_counts`
+rows and no `store_meta` table at all, and the base connection is read-only so
+nothing creates it.
+
+The note still fires, unchanged, for a store that genuinely never computed
+counts — including a worktree whose base never did either. That property is
+covered by explicit negative controls in
+`packages/cli/test/integration/index-state-matrix.test.ts`, which gains the
+crossing of its worktree and derived-data axes: the row whose absence is why this
+shipped.

--- a/.changeset/overlay-dependent-count-honesty-lifecycle.md
+++ b/.changeset/overlay-dependent-count-honesty-lifecycle.md
@@ -49,9 +49,13 @@ matches — so an overlay that had never composed counts previously had no path 
 them.
 
 `hasComputedDependentCounts` now tolerates either of its tables being absent, each
-clause independently: a base index written by 0.75.4 has real `dependent_counts`
-rows and no `store_meta` table at all, and the base connection is read-only so
-nothing creates it.
+clause independently, because `OverlayBackend` asks it about a base connection
+opened `{ readonly: true }` whose schema is frozen at whatever version wrote it. A
+store from between #1071 (which added `dependent_counts`) and #1072 (which added
+`store_meta`) has real rows and no flag table at all, and a missing flag TABLE must
+not hide the rows that prove a computation ran any more than a missing flag ROW
+does; a store predating both must answer `false` rather than throw, which is the
+crash #1071 already had to fix once.
 
 The note still fires, unchanged, for a store that genuinely never computed
 counts — including a worktree whose base never did either. That property is

--- a/packages/cli/src/mcp/utils/dependent-count-honesty.ts
+++ b/packages/cli/src/mcp/utils/dependent-count-honesty.ts
@@ -45,6 +45,23 @@ import type { ToolResult } from './metadata-shaper.js';
  *    shape of the numbers, because a corpus whose counts are legitimately all
  *    zero is indistinguishable from "never computed" on the numbers alone.
  *
+ *    "Clears itself after one index run" is load-bearing prose, and it was
+ *    FALSE as shipped (#1084): the upgrade path that produces this note is
+ *    exactly the one where `lien index` finds no content changes, so the note's
+ *    own instruction did nothing and only `--force` worked. It is true now
+ *    because `core`'s `backfillDependentCounts` makes the counts a MIGRATION
+ *    the next `lien index` completes regardless of whether anything changed.
+ *    If that call is ever removed, this note becomes a lie again — a caveat
+ *    that prescribes a remedy owes the reader a remedy that works, and a failed
+ *    instruction spends more trust than silence would have.
+ *
+ *    It also must not fire when the counts DO exist somewhere the read path
+ *    reaches. #1085: `OverlayBackend` asked only the worktree's own overlay, so
+ *    every fresh linked worktree got this note while the shared base's counts
+ *    ranked the very results it was attached to. That is #1014's failure mode
+ *    with a different sign — a note firing on every agent session gets trained
+ *    out, and takes the true ones with it.
+ *
  * 4. **The count lags the working tree** by up to one full index run, because
  *    incremental single-file updates deliberately don't recompute whole-corpus
  *    counts. Gets NO response caveat at all. It is true on nearly every call,

--- a/packages/cli/test/integration/index-state-matrix.test.ts
+++ b/packages/cli/test/integration/index-state-matrix.test.ts
@@ -89,7 +89,18 @@ type EntryPointState =
   // detectable from the numbers: a corpus whose counts are legitimately all
   // zero looks identical, which is why the disposition is keyed on a stored
   // flag instead.
-  | 'S2-counts';
+  | 'S2-counts'
+  // The two axes CROSSED (#1085) — the missing row that let the defect ship.
+  // Neither axis alone reaches it: a standalone `S2-counts` store has one place
+  // to look, and `worktree-fresh` was only ever exercised against the `chunks`
+  // table. `worktree-fresh × counts-in-base` = a fresh worktree whose base HAS
+  // computed counts and whose own overlay never has, so the honest answer lives
+  // in the far store and the read path is already serving it.
+  // `worktree-S2-counts` is its negative control: NEITHER store ever computed
+  // them, so the note must still fire — over-correcting a false caveat into
+  // silence would lose what #1072 shipped it for.
+  | 'worktree-fresh × counts-in-base'
+  | 'worktree-S2-counts';
 
 interface TableRow {
   entryPoint: string;
@@ -184,6 +195,21 @@ const TABLE: TableRow[] = [
     state: 'worktree-fresh',
     expected:
       '`path --root` resolves to the WORKTREE itself, never the outer main checkout (#1050 fix)',
+  },
+  {
+    // #1085. The response used to say "the counts were never computed here" and
+    // drop 100% of `dependentCount`, while the base's counts ranked the very
+    // results it was attached to. Checking one of two on-disk locations instead
+    // of the composition — the #1050/#1051 shape, third time in this class.
+    entryPoint: 'search_code',
+    state: 'worktree-fresh × counts-in-base',
+    expected: 'real dependentCount from the shared base, NO note (#1085 fix)',
+  },
+  {
+    // The negative control, and the row whose absence is why #1085 shipped.
+    entryPoint: 'search_code',
+    state: 'worktree-S2-counts',
+    expected: 'note still fires + every count omitted (neither store ever computed them)',
   },
   // --- CLI, index-independent (never touch the structural store at all) ---
   {
@@ -817,6 +843,91 @@ describe('index-state × entry-point matrix (#1029 W1)', () => {
         const printed = allLogged().trim();
         expect(printed).toBe(wtRoot);
         expect(printed).not.toBe(dir);
+      });
+    });
+
+    // ------------------------------------------------------------------------
+    // The layout axis CROSSED with the derived-data axis (#1085). This pair is
+    // the row the matrix was missing: `search_code`'s counts axis had only ever
+    // been exercised against a standalone store, where there is exactly one
+    // place for the state to live, and the worktree axis had only ever been
+    // exercised against the `chunks` table. The defect lived precisely in the
+    // crossing, and every agent session in this repo's own fleet ran through it.
+    // ------------------------------------------------------------------------
+
+    describe('search_code (dependent-count honesty × overlay)', () => {
+      it('worktree-fresh × counts-in-base: real counts, NO note — never a note over counts it is ranking with (#1085)', async () => {
+        await buildHealthyIndex(dir);
+        const wtRoot = await chdirIntoFreshNestedWorktree();
+
+        const vectorDB = await createVectorDB(wtRoot);
+        await vectorDB.initialize();
+        expect(vectorDB.isOverlay).toBe(true);
+        // The composition has counts even though this worktree has never run its
+        // own `lien index` — asked of the backend, not inferred from the results.
+        expect(await vectorDB.hasDependentCounts()).toBe(true);
+
+        const result = await handleSearchCode({ query: 'add' }, makeCtx(vectorDB));
+
+        const parsed = JSON.parse(result.content![0].text) as {
+          note?: string;
+          results: { metadata: { file: string; dependentCount?: number } }[];
+        };
+        const mathHit = parsed.results.find(r => r.metadata.file.endsWith('math.ts'));
+        expect(mathHit).toBeDefined();
+        // Present and real: `index.ts` and `math.test.ts` both import `math.ts`.
+        expect(mathHit!.metadata.dependentCount).toBeGreaterThan(0);
+        expect(parsed.note).toBeUndefined();
+      });
+
+      it('worktree-S2-counts: the note STILL fires when neither store ever computed them (#1085 negative control)', async () => {
+        // Over-correcting #1085 into silence would cost what #1072 shipped: a
+        // genuinely never-computed store must still say so. Both halves of the
+        // composition are rewound here, so nothing anywhere can answer.
+        await buildHealthyIndex(dir);
+        simulatePreCountTrackingIndex(getIndexDir(dir));
+        const wtRoot = await chdirIntoFreshNestedWorktree();
+
+        const vectorDB = await createVectorDB(wtRoot);
+        await vectorDB.initialize();
+        expect(vectorDB.isOverlay).toBe(true);
+        expect(await vectorDB.hasDependentCounts()).toBe(false);
+
+        const result = await handleSearchCode({ query: 'add' }, makeCtx(vectorDB));
+
+        const parsed = JSON.parse(result.content![0].text) as {
+          note?: string;
+          results: { metadata: { file: string; dependentCount?: number } }[];
+        };
+        expect(parsed.results.length).toBeGreaterThan(0);
+        for (const r of parsed.results) {
+          expect(r.metadata).not.toHaveProperty('dependentCount');
+        }
+        expect(parsed.note).toContain('predates reverse-dependency counting');
+      });
+
+      it('worktree-S2-counts: a plain `lien index` in the worktree clears it — the note names a remedy that works (#1084)', async () => {
+        // #1084 on the overlay path. `lien index` is the remedy the note prints,
+        // so it has to work from the state the note fires in.
+        await buildHealthyIndex(dir);
+        simulatePreCountTrackingIndex(getIndexDir(dir));
+        const wtRoot = await chdirIntoFreshNestedWorktree();
+
+        const indexed = await indexCodebase({ rootDir: wtRoot, verbose: false });
+        expect(indexed.success).toBe(true);
+
+        const vectorDB = await createVectorDB(wtRoot);
+        await vectorDB.initialize();
+        expect(await vectorDB.hasDependentCounts()).toBe(true);
+
+        const result = await handleSearchCode({ query: 'add' }, makeCtx(vectorDB));
+        const parsed = JSON.parse(result.content![0].text) as {
+          note?: string;
+          results: { metadata: { file: string; dependentCount?: number } }[];
+        };
+        expect(parsed.note).toBeUndefined();
+        const mathHit = parsed.results.find(r => r.metadata.file.endsWith('math.ts'));
+        expect(mathHit!.metadata.dependentCount).toBeGreaterThan(0);
       });
     });
   });

--- a/packages/core/src/indexer/index.test.ts
+++ b/packages/core/src/indexer/index.test.ts
@@ -1,9 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
+import Database from 'better-sqlite3';
 import { indexCodebase } from './index.js';
 import { createVectorDB } from '../vectordb/factory.js';
-import { createTestDir, cleanupTestDir, createTestFile } from '../test/helpers/test-db.js';
+import { getIndexDir } from '../utils/index-dir.js';
+import { STRUCTURAL_DB_FILENAME } from '../vectordb/sqlite/schema.js';
+import {
+  createTestDir,
+  cleanupTestDir,
+  createTestFile,
+  simulatePreCountTrackingIndex,
+} from '../test/helpers/test-db.js';
 
 const MATH_TS = `export function add(a: number, b: number): number {
   return a + b;
@@ -79,6 +87,77 @@ describe('indexCodebase (lexical FTS5 structural index)', () => {
 
     expect(result.success).toBe(true);
     expect(result.chunksCreated).toBeGreaterThan(0);
+  });
+
+  describe('dependent-count migration backfill (#1084)', () => {
+    const closeDb = (db: unknown) => (db as { close?: () => void }).close?.();
+
+    /** Rewind to a store whose counts were never computed, as ≤ 0.75.2 wrote it. */
+    async function rewindToPreCountTracking(): Promise<void> {
+      simulatePreCountTrackingIndex(getIndexDir(testDir));
+      const db = await createVectorDB(testDir);
+      await db.initialize();
+      expect(await db.hasDependentCounts()).toBe(false);
+      closeDb(db);
+    }
+
+    async function countsState(): Promise<{ computed: boolean; mathCount: number | undefined }> {
+      const db = await createVectorDB(testDir);
+      await db.initialize();
+      const computed = await db.hasDependentCounts();
+      const hits = await db.search('add', 10);
+      const mathCount = hits.find(h => h.metadata.file.endsWith('math.ts'))?.metadata
+        .dependentCount;
+      closeDb(db);
+      return { computed, mathCount };
+    }
+
+    function deleteDependentCountRow(file: string): void {
+      const raw = new Database(path.join(getIndexDir(testDir), STRUCTURAL_DB_FILENAME));
+      raw.prepare('DELETE FROM dependent_counts WHERE file = ?').run(file);
+      raw.close();
+    }
+
+    it('a plain `lien index` with NO changes completes it — the exact path that was stuck', async () => {
+      // #1084 verbatim: index with a version predating `dependent_counts`,
+      // upgrade, then run the command #1072's note prints. Before this fix the
+      // "Index is up to date - no changes detected" fast path returned without
+      // writing either the counts or the flag, so the note kept firing forever
+      // and only `--force` cleared it. A caveat whose prescribed remedy does
+      // nothing spends the reader's trust on a failed instruction.
+      await indexCodebase({ rootDir: testDir, force: true });
+      await rewindToPreCountTracking();
+
+      const again = await indexCodebase({ rootDir: testDir });
+      expect(again.success).toBe(true);
+      expect(again.filesIndexed).toBe(0); // nothing changed — the stuck path
+
+      const after = await countsState();
+      expect(after.computed).toBe(true);
+      // `main.ts` imports `math.ts`, so a real computation is the only way here.
+      expect(after.mathCount).toBe(1);
+    });
+
+    it('runs at most once — a second no-op index does not recompute', async () => {
+      // It is a migration, not an indexing step. #1071's freshness contract
+      // (counts lag by at most one full index run, because recomputing
+      // whole-corpus counts on every incremental save would be absurd for a soft
+      // ranking tie-breaker) has to survive this fix, so the gate is the stored
+      // flag and the second run must be a single meta lookup.
+      await indexCodebase({ rootDir: testDir, force: true });
+      await rewindToPreCountTracking();
+      await indexCodebase({ rootDir: testDir });
+
+      // Delete a row WITHOUT clearing the flag: if the backfill re-ran on state
+      // it should not consult, the row would come back.
+      deleteDependentCountRow('src/math.ts');
+
+      await indexCodebase({ rootDir: testDir });
+
+      const after = await countsState();
+      expect(after.computed).toBe(true);
+      expect(after.mathCount ?? 0).toBe(0); // still deleted — no recompute
+    });
   });
 
   it('reports failure without throwing when the directory has no indexable files', async () => {

--- a/packages/core/src/indexer/index.ts
+++ b/packages/core/src/indexer/index.ts
@@ -171,6 +171,18 @@ async function finalizeManifest(
  * per-connection count map would stay empty while `hasDependentCounts()` started
  * answering true — clearing the note and then asserting corpus-wide zeros as
  * fact, which is #1072's defect restored.
+ *
+ * Deliberately NOT error-tolerant, unlike `OverlayBackend.backfillDependentCounts`
+ * (review finding on this PR, and correct — the asymmetry it flagged was real, and
+ * the swallow was the wrong half). `refreshDependentCounts` is the same call
+ * `saveIndexResults` makes uncaught at the end of every full index, so a genuine
+ * failure here must surface exactly as it already does there rather than leaving
+ * `success: true` over a migration that did not happen. The overlay's busy-skip is
+ * specific and earns itself: piled-up `lien serve` processes on one worktree are a
+ * documented reality, and a peer holding the write lock is doing this very work on
+ * our behalf. Neither is true of a standalone store, whose incremental path already
+ * writes (and can already contend) on any run that indexes anything at all — and
+ * this runs at most once per store, ever.
  */
 async function backfillDependentCounts(
   vectorDB: VectorDBInterface,
@@ -182,20 +194,8 @@ async function backfillDependentCounts(
     phase: 'saving',
     message: 'Backfilling reverse-dependency counts (one-time)...',
   });
-  try {
-    await vectorDB.refreshDependentCounts();
-    await writeVersionFile(vectorDB.dbPath);
-  } catch (error) {
-    // Never fail an index run over a soft ranking tie-breaker — this is the
-    // "no changes detected" path, the most frequently executed one there is, and
-    // a peer process holding the write lock would otherwise turn a no-op into a
-    // reported failure. Skipping leaves the migration for the next run, which is
-    // exactly the pre-fix state: no worse, and loud rather than silent so a real
-    // failure here can never quietly re-create #1084.
-    console.error(
-      `[indexer] dependent-count backfill skipped: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
+  await vectorDB.refreshDependentCounts();
+  await writeVersionFile(vectorDB.dbPath);
 }
 
 /**

--- a/packages/core/src/indexer/index.ts
+++ b/packages/core/src/indexer/index.ts
@@ -138,6 +138,67 @@ async function finalizeManifest(
 }
 
 /**
+ * Complete the `dependent_counts` migration for a standalone store that has never
+ * had its reverse-dependency counts computed (#1084).
+ *
+ * `refreshDependentCounts` runs at the end of a FULL index. That is not the path
+ * a user upgrading from ≤ 0.75.2 actually takes: `lien index` finds no content
+ * changes, reports "Index is up to date", and returns — so the note #1072 prints
+ * ("Run `lien index` to populate them") was advice that provably did not work,
+ * and only `--force` did. A caveat that tells the user how to fix it and is wrong
+ * about how spends their trust on a failed instruction, which is worse than
+ * saying nothing at all.
+ *
+ * So this is a MIGRATION-completion step, not an indexing step, and the
+ * distinction is the whole design:
+ *
+ * - Gated on `hasDependentCounts()` — stored state, never "the table looks
+ *   empty" — so it runs at most once per store, ever. The next `lien index`
+ *   after an upgrade pays it; every one after that skips it on one meta lookup.
+ * - #1071's freshness contract is untouched. Normal incremental editing still
+ *   does NOT recompute whole-corpus counts (that would be absurd for a soft
+ *   ranking tie-breaker: ~1.8 s per save on a 53k-chunk corpus), so counts still
+ *   "lag by at most one full index run". This does not make them fresher, only
+ *   PRESENT — the difference between a wrong answer and a stale one.
+ *
+ * The overlay path has its own equivalent —
+ * `OverlayBackend.backfillDependentCounts` — because a worktree's counts must be
+ * composed over `(base − masked) ∪ overlay` and only that backend can do it.
+ * `performOverlayIndex` calls that instead of this.
+ *
+ * The version file is bumped only when a backfill actually ran, so a live
+ * `lien serve` reconnects and picks the new counts up. Without that its cached
+ * per-connection count map would stay empty while `hasDependentCounts()` started
+ * answering true — clearing the note and then asserting corpus-wide zeros as
+ * fact, which is #1072's defect restored.
+ */
+async function backfillDependentCounts(
+  vectorDB: VectorDBInterface,
+  options: IndexingOptions,
+): Promise<void> {
+  if (await vectorDB.hasDependentCounts()) return;
+
+  options.onProgress?.({
+    phase: 'saving',
+    message: 'Backfilling reverse-dependency counts (one-time)...',
+  });
+  try {
+    await vectorDB.refreshDependentCounts();
+    await writeVersionFile(vectorDB.dbPath);
+  } catch (error) {
+    // Never fail an index run over a soft ranking tie-breaker — this is the
+    // "no changes detected" path, the most frequently executed one there is, and
+    // a peer process holding the write lock would otherwise turn a no-op into a
+    // reported failure. Skipping leaves the migration for the next run, which is
+    // exactly the pre-fix state: no worse, and loud rather than silent so a real
+    // failure here can never quietly re-create #1084.
+    console.error(
+      `[indexer] dependent-count backfill skipped: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+/**
  * Handle file deletions during incremental indexing.
  */
 async function handleDeletions(
@@ -236,6 +297,15 @@ async function tryIncrementalIndex(
   if (!detected) {
     return null;
   }
+
+  // Before the change branches, not after each of them: this is a migration, and
+  // a migration runs whether or not there is anything to index (#1084 — the
+  // "no changes detected" exit below is the exact path that left the note stuck).
+  // One call site covers all three exits, and it lands before any `complete`
+  // progress event so the spinner isn't restarted after it has succeeded.
+  // Ordering costs nothing real: counts computed here miss this run's own edits,
+  // which is precisely the documented "lags by at most one full index run".
+  await backfillDependentCounts(vectorDB, options);
 
   const { changes, manifest } = detected;
   const totalChanges = changes.added.length + changes.modified.length;
@@ -472,6 +542,14 @@ async function performOverlayIndex(
 
   const res = await buildOverlay(overlay, { verbose: options.verbose });
   const filesIndexed = res.added + res.modified;
+
+  // The worktree's half of #1084, and NOT `backfillDependentCounts` above: an
+  // overlay composes its own counts (the base's table can't describe a diverged
+  // corpus), so the migration lives on the backend that owns that composition.
+  // `applyRebuild` only refreshes on a real swap and `buildOverlay` returns
+  // before it when the signature already matches, so an overlay that has never
+  // composed counts had no path to them — see the method's doc comment.
+  if (overlay.backfillDependentCounts()) await overlay.bumpVersion();
 
   options.onProgress?.({
     phase: 'complete',

--- a/packages/core/src/vectordb/overlay-backend.ts
+++ b/packages/core/src/vectordb/overlay-backend.ts
@@ -352,8 +352,9 @@ export class OverlayBackend implements VectorDBInterface {
    * suppressing every count does not fix it, it just also lies about why.
    *
    * Read-free in the common case: one small meta lookup on the overlay, then at
-   * most one on the base. Only a base whose schema predates the flag (0.75.4)
-   * costs a count-table scan, and `getDependentCounts` caches that per handle.
+   * most one on the base. Only a base whose schema predates the flag falls
+   * through to a count-table scan, and `getDependentCounts` caches that per
+   * handle.
    */
   async hasDependentCounts(): Promise<boolean> {
     if (this.getMeta(OVERLAY_META.DEPENDENT_COUNTS_COMPOSED) !== null) return true;

--- a/packages/core/src/vectordb/overlay-backend.ts
+++ b/packages/core/src/vectordb/overlay-backend.ts
@@ -38,6 +38,7 @@ import {
 } from './sqlite/fts-search.js';
 import type { RankedResult } from './sqlite/fts-search.js';
 import {
+  hasComputedDependentCounts,
   readDependentCounts,
   refreshDependentCounts as refreshOverlayDependentCounts,
 } from './sqlite/dependent-counts.js';
@@ -320,26 +321,43 @@ export class OverlayBackend implements VectorDBInterface {
   }
 
   /**
-   * See `VectorDBInterface.hasDependentCounts`. Presence of the composed flag,
-   * and nothing else — no fallback to "the tables have some rows".
+   * See `VectorDBInterface.hasDependentCounts`. Mirrors the two branches of
+   * `composedDependentCounts` exactly, because the only sound honesty answer is
+   * "whatever the read path this response was actually served from can prove".
    *
-   * `SqliteBackend` DOES accept row presence as secondary proof, and the
-   * asymmetry is deliberate. There, rows can only have been written over that
-   * store's own corpus, so they really are its counts. Here, without the flag,
-   * `composedDependentCounts` falls back to MERGING the base's counts — and per
-   * that method's own doc comment the merge can resurrect an obsolete positive
-   * value, because a file whose count legitimately dropped to 0 in this worktree
-   * (the worktree masked its only base importer) has no overlay row to override
-   * the base's stale count with. Row presence there is not evidence that the
-   * numbers describe this corpus, so reporting `true` would let `search_code`
-   * publish a resurrected count as fact. The honest answer for a pre-#1071
-   * overlay is "counts unavailable" — the field is omitted and the note names
-   * `lien index`, which rebuilds the overlay and writes the composed map.
+   * - Composed flag set → the overlay table alone is the whole truth, and the
+   *   flag is direct proof a composition ran over THIS worktree's corpus.
+   * - Flag absent → `composedDependentCounts` serves the BASE's counts, so the
+   *   honest answer is whatever the base store can prove about its own table.
    *
-   * Read-free either way: one small meta lookup, no count table scan.
+   * #1085 is what happens when this method answers about one of the two
+   * on-disk locations instead of the composition: keyed on the overlay's flag
+   * alone, a fresh linked worktree — every agent session in this repo's own
+   * fleet — got the "this index predates reverse-dependency counting" note and
+   * had 100% of its `dependentCount`s dropped, *while the base's counts were
+   * ranking the very results in that response*. The note and the ordering
+   * cannot both be right, and the base's `dependentCountsComputed|1` says which
+   * one was. Checking one location rather than the composition is the
+   * #1050/#1051 shape; keeping the two in one place is how it stops recurring.
+   *
+   * Not the reasoning review rightly rejected on #1078. That was
+   * `composedDependentCounts().size > 0` — the size of the MERGED map, which is
+   * no evidence at all, since a merge can resurrect a base count for a file
+   * whose last importer this worktree masked. This asks the BASE store whether
+   * IT computed counts over ITS corpus, via the same `hasComputedDependentCounts`
+   * predicate `SqliteBackend` uses, and the base corpus is precisely the corpus
+   * those merged numbers describe. The resurrection hazard is real but it is
+   * staleness, which is #1072's case 4: an accepted trade for a soft ranking
+   * tie-breaker, documented on the field, deliberately not caveated — and
+   * suppressing every count does not fix it, it just also lies about why.
+   *
+   * Read-free in the common case: one small meta lookup on the overlay, then at
+   * most one on the base. Only a base whose schema predates the flag (0.75.4)
+   * costs a count-table scan, and `getDependentCounts` caches that per handle.
    */
   async hasDependentCounts(): Promise<boolean> {
-    return this.getMeta(OVERLAY_META.DEPENDENT_COUNTS_COMPOSED) !== null;
+    if (this.getMeta(OVERLAY_META.DEPENDENT_COUNTS_COMPOSED) !== null) return true;
+    return this.baseDb !== null && hasComputedDependentCounts(this.baseDb);
   }
 
   async search(query: string, limit = 5): Promise<SearchResult[]> {
@@ -644,6 +662,46 @@ export class OverlayBackend implements VectorDBInterface {
       this.reclaimSpace();
     }
     return { changed };
+  }
+
+  /**
+   * Compose this overlay's `dependent_counts` if, and only if, it never has
+   * (#1084) — the worktree counterpart of the indexer's
+   * `backfillDependentCounts` for a standalone store. Returns whether it did
+   * any work, so a caller can bump the version stamp exactly when there is
+   * something new for a live `lien serve` to reconnect for.
+   *
+   * Needed because the one existing trigger never reaches an overlay whose
+   * content is already correct: `applyRebuild` refreshes on a real swap, and
+   * `buildOverlay` returns before calling it at all when the signature already
+   * matches. An overlay built by a version predating the composed map therefore
+   * had no path to one, so `lien index` — the remedy #1072's note prints — could
+   * not complete the migration. This is what makes that note's promise true.
+   *
+   * Called from `performOverlayIndex` rather than from inside `buildOverlay`'s
+   * fast path, which is where it would otherwise belong: `buildOverlay` is
+   * already over its cognitive-complexity budget, and #1073 had to relocate a
+   * call out of that same file for the same reason (the review gate counts
+   * ABSOLUTE violations in touched files, not deltas).
+   *
+   * Gated on the stored flag, never on the table looking empty: a composed corpus
+   * whose every count is legitimately 0 must not be recomposed forever, and
+   * (per `composedDependentCounts`) an empty overlay table is also how a real
+   * all-zero composition is stored.
+   */
+  backfillDependentCounts(): boolean {
+    if (this.getMeta(OVERLAY_META.DEPENDENT_COUNTS_COMPOSED) !== null) return false;
+    try {
+      this.refreshDependentCountsSync();
+    } catch (error) {
+      // A peer `lien serve` on this worktree holds the write lock; its own
+      // backfill serves us. Busy-skip rather than fail the index run, exactly as
+      // `applyRebuild` does — piled-up serves on one worktree are a documented
+      // reality here, and this is a soft ranking tie-breaker.
+      if (isSqliteBusy(error)) return false;
+      throw error;
+    }
+    return true;
   }
 
   /**

--- a/packages/core/src/vectordb/overlay-integration.test.ts
+++ b/packages/core/src/vectordb/overlay-integration.test.ts
@@ -274,13 +274,14 @@ describe('worktree-aware indexing (integration)', () => {
     close(wtDb);
   });
 
-  it('reports hasDependentCounts()=true from a base that has ROWS but no flag — a 0.75.4 base (#1085)', async () => {
-    // 0.75.4 shipped `dependent_counts` (#1071); 0.75.5 added `store_meta`
-    // (#1072). A base written by 0.75.4 therefore has real rows and no
-    // `store_meta` TABLE AT ALL, and the base connection is read-only so nothing
-    // creates it. Both clauses of `hasComputedDependentCounts` must degrade
-    // independently: a missing flag table cannot be allowed to hide the rows
-    // that prove a computation ran.
+  it('reports hasDependentCounts()=true from a base that has ROWS but no flag table (#1085)', async () => {
+    // #1071 added `dependent_counts`; #1072 added `store_meta` (both landed in
+    // 0.75.4, so this vintage is a from-source window, not a published one — but
+    // it is the same vintage `hasComputedDependentCounts`'s row-presence clause
+    // already exists for). The base connection is read-only, so nothing recreates
+    // a missing table behind our back. Both clauses must degrade independently: a
+    // missing flag TABLE cannot be allowed to hide the rows that prove a
+    // computation ran.
     const baseDb = new Database(path.join(getIndexDir(mainRoot), STRUCTURAL_DB_FILENAME));
     baseDb.exec('DROP TABLE IF EXISTS store_meta');
     const baseRows = baseDb.prepare('SELECT count(*) c FROM dependent_counts').get() as {

--- a/packages/core/src/vectordb/overlay-integration.test.ts
+++ b/packages/core/src/vectordb/overlay-integration.test.ts
@@ -209,28 +209,51 @@ describe('worktree-aware indexing (integration)', () => {
     close(wtDb);
   });
 
-  it('reports hasDependentCounts()=false without the composed flag, even though the base still has counts to merge (#1072)', async () => {
-    // Review finding on #1078. A pre-#1071 overlay has no composed flag, so
-    // `composedDependentCounts` falls back to merging the base's own counts —
-    // and that merge can resurrect an obsolete positive value for a file this
-    // worktree masked the last importer of. So "the merged map has rows" is NOT
-    // evidence that the numbers describe this corpus, and reporting `true` would
-    // let `search_code` publish a resurrected count as fact.
+  it('reports hasDependentCounts()=true on a FRESH worktree whose base has counts, and serves them (#1085)', async () => {
+    // The defect, exactly as dogfooded: a linked worktree that has never
+    // completed its own `lien index` has an empty overlay and no composed flag,
+    // so keying the honesty answer on the overlay alone reported "the counts
+    // were never computed here" — while `composedDependentCounts` handed the
+    // base's counts straight to the ranking in the same call. The note and the
+    // ordering cannot both be right.
     //
-    // Fixture: the base has `edited.ts` importing `shared.ts` (base count 1).
-    // The worktree rewrites `edited.ts` to import nothing and deletes
-    // `added.ts`, so `shared.ts`'s real composed count is 0 — with no overlay
-    // row to override the base's stale 1 with.
-    await fs.writeFile(
-      path.join(worktreeRoot, 'edited.ts'),
-      'export function editedFnV2() {\n  return 999;\n}\n',
+    // No `indexCodebase({ rootDir: worktreeRoot })` here on purpose: the whole
+    // point is the state BEFORE the worktree's first local index.
+    const wtDb = await createVectorDB(worktreeRoot);
+    await wtDb.initialize();
+    expect(wtDb.isOverlay).toBe(true);
+
+    // Preconditions: the overlay genuinely has no composed counts...
+    const overlayProbe = new Database(
+      path.join(getIndexDir(worktreeRoot), STRUCTURAL_DB_FILENAME),
+      { readonly: true },
     );
-    await fs.rm(path.join(worktreeRoot, 'added.ts'));
+    expect(
+      (overlayProbe.prepare('SELECT count(*) c FROM dependent_counts').get() as { c: number }).c,
+    ).toBe(0);
+    expect(
+      overlayProbe
+        .prepare('SELECT v FROM overlay_meta WHERE k = ?')
+        .get(OVERLAY_META.DEPENDENT_COUNTS_COMPOSED),
+    ).toBeUndefined();
+    overlayProbe.close();
+    // ...and the base genuinely does.
+    expect(await wtDb.hasDependentCounts()).toBe(true);
+
+    // And the numbers it is honest about are really there: `shared.ts` carries
+    // the base's real count, not an omission.
+    const hits = await wtDb.search('sharedFn', 10);
+    expect(hits.find(h => h.metadata.file === 'shared.ts')?.metadata.dependentCount).toBe(1);
+    close(wtDb);
+  });
+
+  it('reports hasDependentCounts()=false when NEITHER the overlay nor the base ever computed them (#1085 negative control)', async () => {
+    // The row whose absence let #1085 ship. Over-correcting into silence would
+    // be the other failure: #1072's note exists for a genuinely never-computed
+    // store, and it must still fire for one. Both stores are rewound here, so
+    // there is no composition anywhere that could answer.
     await indexCodebase({ rootDir: worktreeRoot });
 
-    // Rewind to a pre-#1071 overlay: drop its composed counts and the flag,
-    // leaving the base's stale positive count in place. (`overlay_meta` exists
-    // only on the overlay store, never on a standalone one.)
     const overlayDb = new Database(path.join(getIndexDir(worktreeRoot), STRUCTURAL_DB_FILENAME));
     overlayDb.exec('DELETE FROM dependent_counts');
     overlayDb
@@ -238,8 +261,72 @@ describe('worktree-aware indexing (integration)', () => {
       .run(OVERLAY_META.DEPENDENT_COUNTS_COMPOSED);
     overlayDb.close();
 
-    // The stale positive really is still there — this is what the merge fallback
-    // would serve, and why `false` is the honest answer rather than a pedantic one.
+    // A base written before either table existed — `openBase()` opens it
+    // `{ readonly: true }`, so nothing recreates them behind our back.
+    const baseDb = new Database(path.join(getIndexDir(mainRoot), STRUCTURAL_DB_FILENAME));
+    baseDb.exec('DROP TABLE IF EXISTS dependent_counts');
+    baseDb.exec('DROP TABLE IF EXISTS store_meta');
+    baseDb.close();
+
+    const wtDb = await createVectorDB(worktreeRoot);
+    await wtDb.initialize();
+    expect(await wtDb.hasDependentCounts()).toBe(false);
+    close(wtDb);
+  });
+
+  it('reports hasDependentCounts()=true from a base that has ROWS but no flag — a 0.75.4 base (#1085)', async () => {
+    // 0.75.4 shipped `dependent_counts` (#1071); 0.75.5 added `store_meta`
+    // (#1072). A base written by 0.75.4 therefore has real rows and no
+    // `store_meta` TABLE AT ALL, and the base connection is read-only so nothing
+    // creates it. Both clauses of `hasComputedDependentCounts` must degrade
+    // independently: a missing flag table cannot be allowed to hide the rows
+    // that prove a computation ran.
+    const baseDb = new Database(path.join(getIndexDir(mainRoot), STRUCTURAL_DB_FILENAME));
+    baseDb.exec('DROP TABLE IF EXISTS store_meta');
+    const baseRows = baseDb.prepare('SELECT count(*) c FROM dependent_counts').get() as {
+      c: number;
+    };
+    baseDb.close();
+    expect(baseRows.c).toBeGreaterThan(0);
+
+    const wtDb = await createVectorDB(worktreeRoot);
+    await wtDb.initialize();
+    expect(await wtDb.hasDependentCounts()).toBe(true);
+    close(wtDb);
+  });
+
+  it('a stale base count the worktree masked is served as stale, not suppressed as "never computed" (#1085)', async () => {
+    // The hazard review raised on #1078, with the disposition #1085 corrects.
+    //
+    // A zero is stored as the ABSENCE of a row, so merging the base map under an
+    // un-composed overlay cannot express "this dropped to 0 here": the base's
+    // stale 1 survives. That is real, and it is why `composedDependentCounts`
+    // stops merging the moment the overlay has its own composed map.
+    //
+    // What it is NOT is grounds for the never-computed note. Reporting `false`
+    // did not stop the stale number reaching the ranking — `search()` had
+    // already applied it — it only added a false claim about the store and threw
+    // away every OTHER count in the response. A count that lags the worktree is
+    // #1072's case 4: documented on the field, deliberately uncaveated, cleared
+    // by the worktree's own `lien index`.
+    //
+    // Fixture: base has `edited.ts` importing `shared.ts` (count 1); the
+    // worktree rewrites `edited.ts` to import nothing and deletes `added.ts`, so
+    // `shared.ts`'s true composed count is 0.
+    await fs.writeFile(
+      path.join(worktreeRoot, 'edited.ts'),
+      'export function editedFnV2() {\n  return 999;\n}\n',
+    );
+    await fs.rm(path.join(worktreeRoot, 'added.ts'));
+    await indexCodebase({ rootDir: worktreeRoot });
+
+    const overlayDb = new Database(path.join(getIndexDir(worktreeRoot), STRUCTURAL_DB_FILENAME));
+    overlayDb.exec('DELETE FROM dependent_counts');
+    overlayDb
+      .prepare('DELETE FROM overlay_meta WHERE k = ?')
+      .run(OVERLAY_META.DEPENDENT_COUNTS_COMPOSED);
+    overlayDb.close();
+
     const baseDb = new Database(path.join(getIndexDir(mainRoot), STRUCTURAL_DB_FILENAME));
     const baseCount = baseDb
       .prepare('SELECT count FROM dependent_counts WHERE file = ?')
@@ -249,7 +336,49 @@ describe('worktree-aware indexing (integration)', () => {
 
     const wtDb = await createVectorDB(worktreeRoot);
     await wtDb.initialize();
-    expect(await wtDb.hasDependentCounts()).toBe(false);
+    // Honest about having counts...
+    expect(await wtDb.hasDependentCounts()).toBe(true);
+    // ...and the resurrected 1 is exactly what the read path was serving all
+    // along, with or without this method's answer.
+    const hits = await wtDb.search('sharedFn', 10);
+    expect(hits.find(h => h.metadata.file === 'shared.ts')?.metadata.dependentCount).toBe(1);
+    close(wtDb);
+
+    // And one `lien index` in the worktree replaces it with the true 0 — the
+    // staleness has a remedy, which is what makes leaving it uncaveated honest.
+    await indexCodebase({ rootDir: worktreeRoot });
+    const refreshed = await createVectorDB(worktreeRoot);
+    await refreshed.initialize();
+    const after = await refreshed.search('sharedFn', 10);
+    expect(after.find(h => h.metadata.file === 'shared.ts')?.metadata.dependentCount ?? 0).toBe(0);
+    close(refreshed);
+  });
+
+  it('completes the dependent-count migration on a plain `lien index` with no content changes (#1084)', async () => {
+    // The upgrade path that produced #1072's note is the one where nothing
+    // changed: `lien index` reported "Index is up to date" and returned, so the
+    // note's own instruction did nothing and only `--force` worked. The counts
+    // are now a migration the next `lien index` completes regardless.
+    await indexCodebase({ rootDir: worktreeRoot });
+
+    const overlayPath = path.join(getIndexDir(worktreeRoot), STRUCTURAL_DB_FILENAME);
+    const rewound = new Database(overlayPath);
+    rewound.exec('DELETE FROM dependent_counts');
+    rewound
+      .prepare('DELETE FROM overlay_meta WHERE k = ?')
+      .run(OVERLAY_META.DEPENDENT_COUNTS_COMPOSED);
+    rewound.close();
+
+    // Byte-identical corpus — the swap reports `changed: false`, which is exactly
+    // why `changed` alone was not a sufficient trigger for the refresh.
+    const again = await indexCodebase({ rootDir: worktreeRoot });
+    expect(again.success).toBe(true);
+
+    const wtDb = await createVectorDB(worktreeRoot);
+    await wtDb.initialize();
+    expect(await wtDb.hasDependentCounts()).toBe(true);
+    const hits = await wtDb.search('sharedFn', 10);
+    expect(hits.find(h => h.metadata.file === 'shared.ts')?.metadata.dependentCount).toBe(2);
     close(wtDb);
   });
 

--- a/packages/core/src/vectordb/sqlite/dependent-counts.test.ts
+++ b/packages/core/src/vectordb/sqlite/dependent-counts.test.ts
@@ -186,4 +186,38 @@ describe('hasComputedDependentCounts', () => {
     expect(readDependentCounts(db).size).toBe(0);
     expect(hasComputedDependentCounts(db)).toBe(true);
   });
+
+  // #1085 opened this predicate to a connection whose SCHEMA may predate either
+  // table: `OverlayBackend` asks it about its shared base, which is opened
+  // `{ readonly: true }` so `openDatabase`'s `CREATE TABLE IF NOT EXISTS` never
+  // runs there. Each clause has to degrade on its own.
+
+  it('is true from ROWS ALONE when `store_meta` does not exist at all (a 0.75.4 base)', () => {
+    // 0.75.4 shipped `dependent_counts`; 0.75.5 added `store_meta`. A missing
+    // flag TABLE must not hide the rows that prove a computation ran — otherwise
+    // every worktree on a 0.75.4 base gets #1085's false note back.
+    db.prepare('INSERT INTO dependent_counts(file, count) VALUES (?, ?)').run('src/a.ts', 4);
+    db.exec('DROP TABLE store_meta');
+
+    expect(hasComputedDependentCounts(db)).toBe(true);
+  });
+
+  it('is false, and does not throw, when NEITHER table exists (a pre-0.75.4 store)', () => {
+    // #1071 learned the throwing half the hard way: an unguarded base read
+    // crashed every overlay `search()` with `no such table: dependent_counts`.
+    db.exec('DROP TABLE dependent_counts');
+    db.exec('DROP TABLE store_meta');
+
+    expect(() => hasComputedDependentCounts(db)).not.toThrow();
+    expect(hasComputedDependentCounts(db)).toBe(false);
+  });
+
+  it('is true from the FLAG ALONE when `dependent_counts` does not exist', () => {
+    // The mirror case, for completeness: the flag is the direct proof, and it
+    // must not be lost because the sibling read would have thrown.
+    setStoreMeta(db, STORE_META.DEPENDENT_COUNTS_COMPUTED, '1');
+    db.exec('DROP TABLE dependent_counts');
+
+    expect(hasComputedDependentCounts(db)).toBe(true);
+  });
 });

--- a/packages/core/src/vectordb/sqlite/dependent-counts.test.ts
+++ b/packages/core/src/vectordb/sqlite/dependent-counts.test.ts
@@ -192,10 +192,13 @@ describe('hasComputedDependentCounts', () => {
   // `{ readonly: true }` so `openDatabase`'s `CREATE TABLE IF NOT EXISTS` never
   // runs there. Each clause has to degrade on its own.
 
-  it('is true from ROWS ALONE when `store_meta` does not exist at all (a 0.75.4 base)', () => {
-    // 0.75.4 shipped `dependent_counts`; 0.75.5 added `store_meta`. A missing
-    // flag TABLE must not hide the rows that prove a computation ran — otherwise
-    // every worktree on a 0.75.4 base gets #1085's false note back.
+  it('is true from ROWS ALONE when `store_meta` does not exist at all', () => {
+    // The table-level version of the row-level case two tests up: #1071 added
+    // `dependent_counts` and #1072 added `store_meta`, so a store from between
+    // them has rows and no flag TABLE (both shipped in 0.75.4, so this is a
+    // from-source vintage). A missing flag table must not hide the rows that
+    // prove a computation ran, or a worktree on such a base gets #1085's false
+    // note back.
     db.prepare('INSERT INTO dependent_counts(file, count) VALUES (?, ?)').run('src/a.ts', 4);
     db.exec('DROP TABLE store_meta');
 

--- a/packages/core/src/vectordb/sqlite/dependent-counts.ts
+++ b/packages/core/src/vectordb/sqlite/dependent-counts.ts
@@ -147,12 +147,16 @@ export function writeDependentCounts(db: Database.Database, counts: Map<string, 
  * (#1085). `SqliteBackend`'s own store always has both — `openDatabase` creates
  * them — but `OverlayBackend` opens its shared base `{ readonly: true }`, so
  * `CREATE TABLE IF NOT EXISTS` never runs there and the schema is frozen at
- * whatever version wrote it. A base written by 0.75.4 has real
- * `dependent_counts` rows and no `store_meta` at all, so a missing flag table
- * must not hide the rows that prove a computation ran; one written before 0.75.4
- * has neither table, and must answer `false` rather than throw. #1071 already
- * had to learn the throwing half the hard way — an unguarded base read crashed
- * every overlay `search()`.
+ * whatever version wrote it:
+ * - No `store_meta` at all, but real `dependent_counts` rows: a store written by
+ *   a build between #1071 (which added the table) and #1072 (which added the
+ *   flag) — the same vintage the row-presence clause above already exists for.
+ *   Both shipped in 0.75.4, so this is a from-source window rather than a
+ *   published one, but a missing flag TABLE must not hide the rows that prove a
+ *   computation ran any more than a missing flag ROW does.
+ * - Neither table: any store written before 0.75.4. Must answer `false`, not
+ *   throw — #1071 learned that half the hard way, when an unguarded base read
+ *   crashed every overlay `search()` with `no such table: dependent_counts`.
  */
 export function hasComputedDependentCounts(db: Database.Database): boolean {
   try {

--- a/packages/core/src/vectordb/sqlite/dependent-counts.ts
+++ b/packages/core/src/vectordb/sqlite/dependent-counts.ts
@@ -142,10 +142,29 @@ export function writeDependentCounts(db: Database.Database, counts: Map<string, 
  *
  * `getDependentCounts` rather than `readDependentCounts` so the search path
  * shares the one cached read it already performs.
+ *
+ * Both reads tolerate their table being ABSENT, and each degrades on its own
+ * (#1085). `SqliteBackend`'s own store always has both — `openDatabase` creates
+ * them — but `OverlayBackend` opens its shared base `{ readonly: true }`, so
+ * `CREATE TABLE IF NOT EXISTS` never runs there and the schema is frozen at
+ * whatever version wrote it. A base written by 0.75.4 has real
+ * `dependent_counts` rows and no `store_meta` at all, so a missing flag table
+ * must not hide the rows that prove a computation ran; one written before 0.75.4
+ * has neither table, and must answer `false` rather than throw. #1071 already
+ * had to learn the throwing half the hard way — an unguarded base read crashed
+ * every overlay `search()`.
  */
 export function hasComputedDependentCounts(db: Database.Database): boolean {
-  if (getStoreMeta(db, STORE_META.DEPENDENT_COUNTS_COMPUTED) !== null) return true;
-  return getDependentCounts(db).size > 0;
+  try {
+    if (getStoreMeta(db, STORE_META.DEPENDENT_COUNTS_COMPUTED) !== null) return true;
+  } catch {
+    // No `store_meta` table on this connection at all — fall through to the rows.
+  }
+  try {
+    return getDependentCounts(db).size > 0;
+  } catch {
+    return false; // No `dependent_counts` either: a store predating #1071.
+  }
 }
 
 /**

--- a/packages/core/src/vectordb/types.ts
+++ b/packages/core/src/vectordb/types.ts
@@ -114,8 +114,9 @@ export interface VectorDBInterface {
    * there is no correct patch for a subset — see
    * `sqlite/dependent-counts.ts`'s module doc.
    *
-   * Called at the end of a full index run and after an overlay rebuild, NOT on
-   * every incremental single-file update; the counts are a soft ranking
+   * Called at the end of a full index run, after an overlay rebuild, and once as
+   * a migration backfill when `hasDependentCounts()` is false (#1084) — but NOT
+   * on every incremental single-file update; the counts are a soft ranking
    * tie-breaker with an explicit "lags by at most one full index" contract.
    *
    * `OverlayBackend` computes over the composed `(base − masked) ∪ overlay`
@@ -134,6 +135,12 @@ export interface VectorDBInterface {
    * edge resolves anywhere) is indistinguishable from "never computed" on the
    * numbers alone. That is the distinction #1014 got wrong in the other
    * direction, so this is answered from stored state, never from result shape.
+   *
+   * An implementation must answer about the state the READ PATH actually serves
+   * from, not about one of the places that state can live. `OverlayBackend`
+   * composes two stores, and #1085 is what answering about only the near one
+   * costs: a fresh worktree claimed its counts were never computed while ranking
+   * the same response by the base's.
    */
   hasDependentCounts(): Promise<boolean>;
 }


### PR DESCRIPTION
Fixes #1085 and #1084 — two halves of the same lifecycle defect in #1072's `dependentCount` honesty plumbing.

## #1085 — the response contradicted itself

`OverlayBackend.hasDependentCounts()` read only the worktree's **own** composed flag, which is absent until that worktree has completed a local `lien index`. So a fresh linked worktree whose shared base had counts fully computed fired the *"this index predates reverse-dependency counting"* note and dropped `dependentCount` from **100%** of results — while `composedDependentCounts` handed the base's counts to the ranking **in the same call**.

That is the #1050/#1051 shape (asking one of two on-disk locations instead of the composition), and #1014's cost, since every agent session in this repo's own fleet works in a linked worktree.

### Reproduction — isolated `LIEN_HOME`, driven through `lien serve` over MCP stdio

MediatR (160 files, C#), base indexed by the workspace build of `origin/main`, then a `git worktree add` that never ran `lien index`.

```
--- base store state ---
-- .../indices/mediatr-c24558e5/structural.db (2740224 bytes)
dependent_counts rows=95 max=41
   store_meta: dependentCountsComputed|1
--- overlay store state (never locally indexed) ---
-- .../indices/mediatr-wt-47631b46/structural.db (57344 bytes)
dependent_counts rows=0 max=-
   store_meta:
   overlay_meta:
```

**BEFORE — [A] worktree, structural ranking ON (default):**

```
### search_code {"query":"handler wrapper","limit":6}  -> 1447 ms
  note: "⚠ Lien: this index predates reverse-dependency counting, so dependentCount has been
         omitted from these results rather than reported as 0 — the counts were never computed
         here, ... Run \"lien index\" to populate them; ..."
   1. score=0.1557   dc=OMITTED  src/MediatR/Mediator.cs:150 [PublishNotification]
   2. score=0.246    dc=OMITTED  src/MediatR/Mediator.cs:67 [Send]
   3. score=0.2615   dc=OMITTED  src/MediatR/Mediator.cs:50 [Send]
   4. score=0.3284   dc=OMITTED  src/MediatR/INotificationHandler.cs:19 []
   5. score=0.4821   dc=OMITTED  src/MediatR/Mediator.cs:183 [CreateStream]
   6. score=0        dc=OMITTED  src/MediatR/Wrappers/RequestHandlerWrapper.cs:21 [RequestHandlerWrapper]
```

**BEFORE — [B] same worktree, same query, `LIEN_STRUCTURAL_RANKING=off`** — the proof the base's counts were ranking:

```
   1. score=0        dc=OMITTED  src/MediatR/Wrappers/RequestHandlerWrapper.cs:21 [RequestHandlerWrapper]
   2. score=0.0277   dc=OMITTED  src/MediatR/Wrappers/RequestHandlerWrapper.cs:15 [RequestHandlerWrapper]
   3. score=0.0413   dc=OMITTED  src/MediatR/Wrappers/StreamRequestHandlerWrapper.cs:17
   4. score=0.0679   dc=OMITTED  src/MediatR/Wrappers/NotificationHandlerWrapper.cs:10
   5. score=0.1557   dc=OMITTED  src/MediatR/Mediator.cs:150 [PublishNotification]
   6. score=0.246    dc=OMITTED  src/MediatR/Mediator.cs:67 [Send]
```

`RequestHandlerWrapper.cs:21` (dc=1) goes **#6 → #1** and `Mediator.cs:150` (dc=25) **#1 → #5** when the boost is off. So the counts were read, applied, and then reported as never computed. The standalone control's ordering is identical to [A], with `dc=25,25,25,25,25,1`.

**AFTER — same three runs, same corpus, same `LIEN_HOME`:**

```
[A] WORKTREE, structural ranking ON (default)
### search_code {"query":"handler wrapper","limit":6}  -> 266 ms
   1. score=0.1557   dc=25       src/MediatR/Mediator.cs:150 [PublishNotification]
   2. score=0.246    dc=25       src/MediatR/Mediator.cs:67 [Send]
   3. score=0.2615   dc=25       src/MediatR/Mediator.cs:50 [Send]
   4. score=0.3284   dc=25       src/MediatR/INotificationHandler.cs:19 []
   5. score=0.4821   dc=25       src/MediatR/Mediator.cs:183 [CreateStream]
   6. score=0        dc=1        src/MediatR/Wrappers/RequestHandlerWrapper.cs:21 [RequestHandlerWrapper]

[B] WORKTREE, LIEN_STRUCTURAL_RANKING=off      -> still reorders (boost still live)
[C] STANDALONE control, ranking ON             -> byte-identical to [A]
```

No note; real counts; identical to the standalone checkout.

### What changed

`hasDependentCounts()` now mirrors the two branches of `composedDependentCounts` exactly:

- composed flag set → the overlay table alone is the truth (unchanged);
- flag absent → whatever the **base store** can prove about **its own** table, because that is the store the read path is serving those numbers from.

**Deliberately not the reasoning review rejected on #1078.** That was `composedDependentCounts().size > 0` — the size of the **merged** map, which proves nothing, since a merge can resurrect a base count for a file whose last importer this worktree masked. This asks the base store whether *it* computed counts over *its* corpus, through the same `hasComputedDependentCounts` predicate `SqliteBackend` uses. The resurrection hazard is real, but it is **staleness** — #1072's case 4, an accepted trade for a soft ranking tie-breaker, documented on the field, deliberately uncaveated — and reporting `false` never fixed it: `search()` had already applied the number. All the suppression added was a false claim about the store plus the loss of every *other* count in the response. A dedicated test builds that exact fixture and asserts the stale `1` is served as stale, and that the worktree's own `lien index` replaces it with the true `0`.

## #1084 — the note prescribed a remedy that did nothing

`lien index` — the command the note prints, and whose doc comment claimed the note *"clears itself permanently after one index run"* — did not clear it. Only `--force` did.

### Reproduction — real 0.75.2 baseline, engine pinned

`overrides` pinning `@liendev/core` and `@liendev/parser` to 0.75.2, because installing `@liendev/lien@0.75.2` alone resolves both to 0.75.5 via `^` and `lien --version` reports only the CLI package:

```
@liendev/lien 0.75.2
@liendev/core 0.75.2
@liendev/parser 0.75.2
```

**BEFORE:**

```
STEP 1: index with 0.75.2
   tables: chunks chunks_fts_config chunks_fts_docsize chunks_fts chunks_fts_data chunks_fts_idx
   dependent_counts rows / store_meta rows: Error: in prepare, no such table: dependent_counts

STEP 2: read with the new build (note SHOULD fire — correct)
  note: "⚠ Lien: this index predates reverse-dependency counting, ... Run \"lien index\" ..."
   1..4  dc=OMITTED

STEP 3: run `lien index` exactly as the note instructs
  Completed in 86ms
   dependent_counts rows / store_meta rows: 0 / 0

STEP 4: re-query — the note is UNCHANGED, all counts still OMITTED

STEP 5: touch a file, `lien index` again ("Updated 1 file")
   dependent_counts rows / store_meta rows: 0 / 0     <- still stuck

STEP 6: `lien index --force`
   dependent_counts rows / store_meta rows: 95 / 1    <- the only thing that worked
   1. dc=25   2. dc=11   3. dc=8   (no note)
```

**AFTER — same script, same pinned baseline:**

```
STEP 3: run `lien index` exactly as the note instructs
  Completed in 99ms
   dependent_counts rows / store_meta rows: 95 / 1

STEP 4: re-query — is the note gone?
   1. score=0        dc=25   src/MediatR/IPipelineBehavior.cs:20 [IPipelineBehavior]
   2. score=0.0149   dc=11   src/MediatR/IStreamPipelineBehavior.cs:20
   3. score=0.1635   dc=8    samples/MediatR.Examples/Runner.cs:297
   (no note)

STEP 5: touch a file, `lien index` again   -> 95 / 1, no recompute (88 ms)
STEP 6: `lien index --force`                -> 95 / 1, identical
```

### The decision, and why

**Fixed the mechanism, not the message** — but *not* by recomputing on every incremental update. The brief was right that a full recompute per save is the wrong trade (#1071 deliberately accepted "counts lag by at most one full index run" for a soft ranking tie-breaker; measured ~1.8 s on a 53k-chunk corpus).

So computing the counts is a **migration-completion step**, not an indexing step:

- gated on `hasDependentCounts()` — stored state, never "the table looks empty" — so it runs **at most once per store, ever**. STEP 5 above shows it: a second no-op index takes 88 ms and does not recompute. A unit test deletes a count row *without* clearing the flag and asserts it stays deleted.
- #1071's freshness contract is untouched. Normal editing still never recomputes whole-corpus counts. This makes the counts **present**, not fresher — the difference between a wrong answer and a stale one.
- the version stamp is bumped only when a backfill actually ran, so a live `lien serve` reconnects. Without that its cached per-connection count map would stay empty while `hasDependentCounts()` started answering `true` — clearing the note and then asserting corpus-wide zeros as fact, i.e. #1072's defect restored.

`OverlayBackend` gains a public `backfillDependentCounts()` for the same migration over the composed `(base − masked) ∪ overlay` corpus, because `buildOverlay` returns **before** `applyRebuild` entirely when the overlay's signature already matches — so an overlay that had never composed counts had no path to one. It lives on the backend rather than inside `buildOverlay`'s fast path because `buildOverlay` is already over its cognitive-complexity budget and #1073 had to relocate a call out of that same file for the same reason.

Both backfills busy-skip a peer holding the write lock rather than failing an index run over a ranking tie-breaker; the standalone one logs loudly on any other failure, so a real one can never quietly re-create #1084.

**The comment now matches the code both ways.** `dependent-count-honesty.ts` states that "clears itself after one index run" is load-bearing prose that was false as shipped, names the call that makes it true, and says that removing that call makes the note a lie again.

## Hard constraints

**1. Not over-corrected into silence.** The note still fires for a genuinely never-computed store, verified end to end against a 0.75.2-indexed **base** under a fresh worktree:

```
=========== #1085 NEGATIVE CONTROL: base ALSO has no counts ===========
STEP 1: index the BASE with 0.75.2 (no dependent_counts table at all)
   base tables: chunks chunks_fts_config chunks_fts_docsize chunks_fts chunks_fts_data chunks_fts_idx

STEP 2: fresh linked worktree, never indexed locally -> note MUST still fire
  note: "⚠ Lien: this index predates reverse-dependency counting, ..."
   1. score=0        dc=OMITTED  src/MediatR/Wrappers/RequestHandlerWrapper.cs:21
   2. score=0.0277   dc=OMITTED  src/MediatR/Wrappers/RequestHandlerWrapper.cs:15
   3. score=0.0413   dc=OMITTED  src/MediatR/Wrappers/StreamRequestHandlerWrapper.cs:17
   4. score=0.0679   dc=OMITTED  src/MediatR/Wrappers/NotificationHandlerWrapper.cs:10

STEP 3: `lien index` in the WORKTREE -> composed counts + note gone
   1. score=0.1557   dc=25   src/MediatR/Mediator.cs:150 [PublishNotification]
   2. score=0.246    dc=25   src/MediatR/Mediator.cs:67 [Send]
```

The ordering in STEP 2 is pure BM25 (`RequestHandlerWrapper` first) — no boost was applied, so the note there was **true**. That is exactly the discriminator the false case lacked.

**2. Gated on actual state, never result shape.** Every decision reads the composed flag, the base's `dependentCountsComputed` marker, or `hasComputedDependentCounts` — never a count's value. No `.size > 0` on a merged map anywhere.

**3. Matrix rows added.** `packages/cli/test/integration/index-state-matrix.test.ts` gains the **crossing** of its worktree axis (#1058) and its `S2-counts` derived-data axis (#1072) — the row whose absence is why this shipped. Neither axis alone reaches it: a standalone `S2-counts` store has one place to look, and `worktree-fresh` had only ever been exercised against the `chunks` table.

| entry point | state | expected |
|---|---|---|
| `search_code` | `worktree-fresh × counts-in-base` | real `dependentCount` from the shared base, **NO note** (#1085 fix) |
| `search_code` | `worktree-S2-counts` | note still fires + every count omitted (neither store ever computed them) |
| `search_code` | `worktree-S2-counts` | a plain `lien index` in the worktree clears it (#1084) |

## Tests, and proof they discriminate

Every new assertion was run against the **unfixed** code:

- reverting `hasDependentCounts()` to overlay-flag-only → 3 core tests red (`FRESH worktree whose base has counts`, `base that has ROWS but no flag`, `stale base count … served as stale`) **and** the matrix's `worktree-fresh × counts-in-base` row red, with the other two matrix rows staying green.
- reverting both backfills → 4 tests red (`a plain lien index with NO changes completes it`, `runs at most once`, and the two overlay migration tests).

Also new: three `hasComputedDependentCounts` unit tests for the schema-tolerance clauses — rows-alone when `store_meta` does not exist, flag-alone when `dependent_counts` does not exist, and `false`-not-throw when neither does. #1071 already learned the throwing half the hard way, when an unguarded base read crashed every overlay `search()`.

### One doc-truth correction, self-caught

The review came back `Trust: Degraded — partial` (`degraded:provider_partial`, 686K/778K tokens) with the documentation-truthfulness pass explicitly unfinished, so I checked my own factual claims. One was wrong: four comments and the changeset said 0.75.4 shipped `dependent_counts` and 0.75.5 added `store_meta`. `git tag --contains 8b16fc3d` puts #1072 in `@liendev/core@0.75.4`, and the CLI changelog's 0.75.4 section carries the #1071 and #1072 entries together — so **no published version** has the counts table without the flag table. Fixed in `e3045232`.

The behaviour is unchanged and still needed: that vintage is reachable from any build made in the 71-minute window between the two merges on 2026-08-04, and it is the same vintage `hasComputedDependentCounts`' pre-existing row-presence clause was already written for. Only the version attribution was false.

## Gates

| gate | result |
|---|---|
| `npm run format:check` | pass |
| `npm run lint` | 0 errors (41 pre-existing warnings) |
| `npm run typecheck` | pass |
| `npm run build` | pass |
| `npm test` | 5828 tests / 243 files, all pass |
| `lien delta` | **exit 0** — 3 worsened, 0 crossings |

`lien delta` detail (no new or crossed violation; `tryIncrementalIndex` is labelled `pre-exist`):

```
  packages/core/src/indexer/index.ts
    ⚠ pre-exist tryIncrementalIndex      time 82m → 84m
    ⚠ worsened  performOverlayIndex      cognitive 0 → 1
    · new       backfillDependentCounts  cognitive – → 3
  packages/core/src/vectordb/overlay-backend.ts
    ⚠ worsened  OverlayBackend.hasDependentCounts       cognitive 0 → 2
    · new       OverlayBackend.backfillDependentCounts  cognitive – → 4
  packages/core/src/vectordb/sqlite/dependent-counts.ts
    ⚠ worsened  hasComputedDependentCounts cognitive 1 → 3
```

Checked separately for the `review` gate's different bar (absolute violations in touched files, not deltas): **0 error-severity complexity violations** in any touched file. `indexer/index.ts` carries two pre-existing `warning`-severity Halstead findings (`tryIncrementalIndex` 83/60, `performFullIndex` 62/60).

Changeset included.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 2 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 2 | +2 |


> [!WARNING]
> ⚠️ **Review did not complete**
>
> Lien Review did not run — every provider request failed (API error (402): {"error":{"message":"This request requires more credits, or fewer max_tokens. You requested up to 24576 tokens, but can only afford 4827. To i…). This is NOT a clean review; no code was analyzed. Re-run once the provider issue is resolved.

> [!CAUTION]
> 🔴 **Trust: Failed — provider never ran**
>
> Every provider request failed. No code was analyzed this run.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 039813b. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: failed:provider_never_ran · 0K/555K tokens
<!-- /lien:attestation -->