### PR TITLE
refactor(parser,review): lift dependency-graph.ts from review into parser

### DIFF
--- a/.changeset/lift-dependency-graph-to-parser.md
+++ b/.changeset/lift-dependency-graph-to-parser.md
@@ -2,7 +2,7 @@
 '@liendev/parser': minor
 ---
 
-Export the call-site-level dependency graph (`buildDependencyGraph`, `isPreciseProvenance`, and the `DependencyGraph`/`SymbolNode`/`CallerEdge`/`EdgeProvenance` types) from `@liendev/parser`.
+Export the call-site-level dependency graph (`buildDependencyGraph`, `isPreciseProvenance`, and the `DependencyGraph`/`SymbolNode`/`CallerEdge`/`EdgeProvenance`/`TransitiveCallerEdge`/`TransitiveResult`/`TransitiveOptions` types) from `@liendev/parser`.
 
 This graph previously lived inside the private `@liendev/review` package,
 even though it imported nothing review-specific — only parser's own

--- a/.changeset/lift-dependency-graph-to-parser.md
+++ b/.changeset/lift-dependency-graph-to-parser.md
@@ -1,0 +1,16 @@
+---
+'@liendev/parser': minor
+---
+
+Export the call-site-level dependency graph (`buildDependencyGraph`, `isPreciseProvenance`, and the `DependencyGraph`/`SymbolNode`/`CallerEdge`/`EdgeProvenance` types) from `@liendev/parser`.
+
+This graph previously lived inside the private `@liendev/review` package,
+even though it imported nothing review-specific — only parser's own
+`walkBounded`, `importMatchesTarget`, `normalizePath`, `detectLanguage`,
+`findCSharpTypeReferenceDependents`, and `callerSymbolFor`. Lifting it into
+`parser/src/graph/dependency-graph.ts` (alongside the generic `walkBounded`
+BFS it already builds on) makes the symbol/call-site-level resolution it
+provides reachable from `@liendev/cli` too, not just `@liendev/review` —
+a prerequisite for a richer `get_dependents` and `lien api-delta` blast-radius
+nudge than today's file-level `findDependents` can give them. Pure
+relocation: no behavior change to any existing export.

--- a/.changeset/review-repoint-dependency-graph-consumers.md
+++ b/.changeset/review-repoint-dependency-graph-consumers.md
@@ -1,0 +1,13 @@
+---
+'@liendev/review': patch
+---
+
+Repoint review's internal consumers of the dependency graph at `@liendev/parser` now that `dependency-graph.ts` has moved there.
+
+`blast-radius.ts`, `blast-radius-render.ts`, and the agent plugin's
+`agent-tools.ts`/`types.ts`/`index.ts` now import `buildDependencyGraph`,
+`isPreciseProvenance`, `DependencyGraph`, `CallerEdge`, and `EdgeProvenance`
+from `@liendev/parser` instead of a local module. Review's own public export
+of these symbols is removed (nothing outside `review` consumed it — consume
+them from `@liendev/parser` directly going forward). Internal refactor only;
+no behavior change.

--- a/docs/architecture/decisions/0016-dependency-attribution-honesty-axes.md
+++ b/docs/architecture/decisions/0016-dependency-attribution-honesty-axes.md
@@ -18,7 +18,7 @@ dialects:
 | vocabulary | home | shape |
 |---|---|---|
 | `confidence?: 'inferred'` | `packages/parser/src/dependency-analyzer.ts` | single-valued, per dependent |
-| `EdgeProvenance` | `packages/review/src/dependency-graph.ts` | 7 ranked tiers, per caller edge |
+| `EdgeProvenance` | `packages/parser/src/graph/dependency-graph.ts` | 7 ranked tiers, per caller edge |
 | `AttributionCaveatReason` | `packages/cli/src/mcp/attribution-caveat-reasons.ts` | 5 reasons, per response |
 
 The pressure was real. Four consumers had been blocked or had bent around
@@ -255,7 +255,7 @@ further edits.
   `inferredVia` and `inferredDependent()`, the single constructor for the pair
 - `packages/cli/src/mcp/attribution-caveat-reasons.ts`: Axis B's reasons and
   the #984 `Record<>` forcing function, plus why the two guards compose
-- `packages/review/src/dependency-graph.ts`:
+- `packages/parser/src/graph/dependency-graph.ts`:
   `SYMBOL_VERIFIED_BY_PROVENANCE` and `isPreciseProvenance`
 - `docs/architecture/index-state-honesty.md`: the scope-3 policy this ADR
   routes to rather than duplicates

--- a/packages/parser/src/dependency-analyzer.ts
+++ b/packages/parser/src/dependency-analyzer.ts
@@ -2447,11 +2447,12 @@ function findSymbolUsages<T extends CodeChunk>(
  * A `'block'` chunk is module-level code — top-level statements, a declaration
  * holding no function — so there is no enclosing function to name, and saying
  * so beats `'unknown'`, which reads as "we failed to work it out". Matches the
- * `(module-level)` wording `review`'s `dependency-graph.ts` and
- * `dependent-context.ts` also use for the same situation — exported so those
- * two sites (and this one) share one implementation instead of three
- * independently-maintained copies of the same ternary (review finding on
- * #1087: the `dependency-graph.ts` copy had fallen out of sync with the other
+ * `(module-level)` wording `graph/dependency-graph.ts` (this package, since
+ * lifted from `@liendev/review`) and `review`'s own `dependent-context.ts`
+ * also use for the same situation — exported so those two sites (and this
+ * one) share one implementation instead of three independently-maintained
+ * copies of the same ternary (review finding on #1087: the
+ * `dependency-graph.ts` copy had fallen out of sync with the other
  * two, still returning `'unknown'` for a module-level caller). Since #1087
  * widened call-site extraction to module-level code this is a common case,
  * not a rare fallback.

--- a/packages/parser/src/graph/bounded-bfs.ts
+++ b/packages/parser/src/graph/bounded-bfs.ts
@@ -1,8 +1,10 @@
 /**
  * Generic bounded level-BFS over an arbitrary graph.
  *
- * Extracted from the caller-graph BFS in `@liendev/review`'s
- * `dependency-graph.ts` (`bfsTransitiveCallers` / `expandFrontier`). This file
+ * Extracted from the caller-graph BFS in this package's own
+ * `dependency-graph.ts` (`bfsTransitiveCallers` / `expandFrontier`, since
+ * lifted here from `@liendev/review` — it never imported anything
+ * review-specific to begin with). This file
  * keeps the traversal *shape* — frontier expansion, dedup, depth cap, maxNodes
  * truncation — generic and domain-agnostic. Callers supply the domain (what a
  * "node" and an "edge" are, and how to get from one to the other); this module

--- a/packages/parser/src/graph/dependency-graph.test.ts
+++ b/packages/parser/src/graph/dependency-graph.test.ts
@@ -1,7 +1,33 @@
 import { describe, it, expect } from 'vitest';
-import { buildDependencyGraph, isPreciseProvenance } from '../src/dependency-graph.js';
-import type { EdgeProvenance } from '../src/dependency-graph.js';
-import { createTestChunk } from '../src/test-helpers.js';
+import { buildDependencyGraph, isPreciseProvenance } from './dependency-graph.js';
+import type { EdgeProvenance } from './dependency-graph.js';
+import type { CodeChunk } from '../types.js';
+
+/**
+ * Create a minimal CodeChunk for testing.
+ *
+ * Local copy of review's `test-helpers.ts` factory of the same name — kept
+ * as a small non-exported duplicate here rather than importing across the
+ * package boundary, since this test moved into parser (#994-adjacent lift)
+ * while that shared review-only test helper stays in `@liendev/review`
+ * (still used by 3 other review test files).
+ */
+function createTestChunk(overrides?: Partial<CodeChunk>): CodeChunk {
+  const { metadata: metadataOverrides, ...rest } = overrides ?? {};
+  return {
+    content: 'function test() { return true; }',
+    metadata: {
+      file: 'test.ts',
+      startLine: 1,
+      endLine: 1,
+      type: 'function',
+      symbolName: 'test',
+      language: 'typescript',
+      ...metadataOverrides,
+    },
+    ...rest,
+  } as CodeChunk;
+}
 
 // ---------------------------------------------------------------------------
 // buildDependencyGraph

--- a/packages/parser/src/graph/dependency-graph.ts
+++ b/packages/parser/src/graph/dependency-graph.ts
@@ -34,15 +34,12 @@
  * now continues via the symbol actually being traced, not the placeholder.
  */
 
-import type { CodeChunk } from '@liendev/parser';
-import {
-  walkBounded,
-  importMatchesTarget,
-  normalizePath,
-  detectLanguage,
-  findCSharpTypeReferenceDependents,
-  callerSymbolFor,
-} from '@liendev/parser';
+import type { CodeChunk } from '../types.js';
+import { walkBounded } from './bounded-bfs.js';
+import { importMatchesTarget, normalizePath } from '../utils/path-matching.js';
+import { detectLanguage } from '../ast/parser.js';
+import { findCSharpTypeReferenceDependents } from '../csharp-type-reference-signals.js';
+import { callerSymbolFor } from '../dependency-analyzer.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -544,7 +541,7 @@ function buildExportFileMap(exportIndex: ExportIndex): Map<string, Set<string>> 
  * and `Order.php` also defines `findById`, the chunk can call `findById`.
  */
 function chunkImportsFromFile(
-  chunk: CodeChunk,
+  _chunk: CodeChunk,
   targetFile: string,
   pkgSymbols: Set<string> | undefined,
   exportFileMap: Map<string, Set<string>>,

--- a/packages/parser/src/graph/dependency-graph.ts
+++ b/packages/parser/src/graph/dependency-graph.ts
@@ -541,7 +541,6 @@ function buildExportFileMap(exportIndex: ExportIndex): Map<string, Set<string>> 
  * and `Order.php` also defines `findById`, the chunk can call `findById`.
  */
 function chunkImportsFromFile(
-  _chunk: CodeChunk,
   targetFile: string,
   pkgSymbols: Set<string> | undefined,
   exportFileMap: Map<string, Set<string>>,
@@ -719,7 +718,7 @@ function addOopMethodEdges(
   let matched = false;
   for (const loc of exportLocations) {
     if (loc.filepath === callerFile) continue;
-    if (chunkImportsFromFile(chunk, loc.filepath, pkgSymbols, ctx.exportFileMap)) {
+    if (chunkImportsFromFile(loc.filepath, pkgSymbols, ctx.exportFileMap)) {
       addEdge(
         ctx.edges,
         `${loc.filepath}::${callSite.symbol}`,

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -223,6 +223,21 @@ export type {
   BoundedBfsResult,
 } from './graph/bounded-bfs.js';
 
+// Call-site-level dependency graph (lifted from `@liendev/review` — it never
+// imported anything review-specific, only the parser primitives above, and
+// `cli`'s `get_dependents`/`lien api-delta` want this symbol/call-site
+// resolution too, not just the file-level `findDependents` below).
+export { buildDependencyGraph, isPreciseProvenance } from './graph/dependency-graph.js';
+export type {
+  DependencyGraph,
+  SymbolNode,
+  CallerEdge,
+  TransitiveCallerEdge,
+  TransitiveResult,
+  TransitiveOptions,
+  EdgeProvenance,
+} from './graph/dependency-graph.js';
+
 // =============================================================================
 // DEPENDENCY ANALYSIS
 // =============================================================================

--- a/packages/parser/src/utils/rust-mod-marker.ts
+++ b/packages/parser/src/utils/rust-mod-marker.ts
@@ -37,7 +37,7 @@
  * the identical string), with no room for a second field to carry this
  * distinction alongside each specifier -- and every match-side consumer
  * (`buildImportIndex`/`findDependentChunks`, `test-associations.ts`,
- * `get_files_context`'s handler, `packages/review`'s `dependency-graph.ts`)
+ * `get_files_context`'s handler, this package's own `graph/dependency-graph.ts`)
  * reads that array as a plain list of strings, with no per-entry metadata
  * slot. Widening that shared shape for one language's one import form would
  * ripple through the scanner, the SQLite row mapping, and every one of those

--- a/packages/review/src/blast-radius-render.ts
+++ b/packages/review/src/blast-radius-render.ts
@@ -5,8 +5,8 @@
  * without touching compute logic.
  */
 
+import { isPreciseProvenance } from '@liendev/parser';
 import type { BlastRadiusReport, BlastRadiusEntry, BlastRadiusDependent } from './blast-radius.js';
-import { isPreciseProvenance } from './dependency-graph.js';
 
 const LEVEL_LABEL: Record<string, string> = {
   low: 'LOW',

--- a/packages/review/src/blast-radius.ts
+++ b/packages/review/src/blast-radius.ts
@@ -6,9 +6,14 @@
  * risk-scored report ready for rendering into the agent's initial message.
  */
 
-import type { CodeChunk, RiskLevel, BlastRadiusRisk } from '@liendev/parser';
+import type {
+  CodeChunk,
+  RiskLevel,
+  BlastRadiusRisk,
+  DependencyGraph,
+  EdgeProvenance,
+} from '@liendev/parser';
 import { findTestAssociationsFromChunks, computeBlastRadiusRisk } from '@liendev/parser';
-import type { DependencyGraph, EdgeProvenance } from './dependency-graph.js';
 
 // ---------------------------------------------------------------------------
 // Types

--- a/packages/review/src/index.ts
+++ b/packages/review/src/index.ts
@@ -66,16 +66,6 @@ export {
   hasIncompleteMainPass,
 } from './plugins/agent/index.js';
 
-// Dependency graph
-export {
-  buildDependencyGraph,
-  isPreciseProvenance,
-  type DependencyGraph,
-  type SymbolNode,
-  type CallerEdge,
-  type EdgeProvenance,
-} from './dependency-graph.js';
-
 // Output adapters
 export { TerminalAdapter } from './adapters/terminal.js';
 export { SARIFAdapter } from './adapters/sarif.js';

--- a/packages/review/src/plugins/agent/agent-tools.ts
+++ b/packages/review/src/plugins/agent/agent-tools.ts
@@ -12,7 +12,7 @@ import fs from 'fs/promises';
 import type { Dirent } from 'fs';
 import path from 'path';
 
-import type { BlastRadiusRisk, CodeChunk } from '@liendev/parser';
+import type { BlastRadiusRisk, CodeChunk, CallerEdge } from '@liendev/parser';
 import {
   analyzeComplexityFromChunks,
   createGitignoreFilter,
@@ -21,7 +21,6 @@ import {
 } from '@liendev/parser';
 
 import type { AgentToolContext } from './types.js';
-import type { CallerEdge } from '../../dependency-graph.js';
 
 // ---------------------------------------------------------------------------
 // Constants

--- a/packages/review/src/plugins/agent/index.ts
+++ b/packages/review/src/plugins/agent/index.ts
@@ -8,13 +8,14 @@
 
 import { z } from 'zod';
 
+import { buildDependencyGraph } from '@liendev/parser';
+
 import type {
   ReviewPlugin,
   ReviewContext,
   ReviewFinding,
   PresentContext,
 } from '../../plugin-types.js';
-import { buildDependencyGraph } from '../../dependency-graph.js';
 import { computeBlastRadius } from '../../blast-radius.js';
 import type { Logger } from '../../logger.js';
 import type { AttestationVerdict } from '../../attestation.js';

--- a/packages/review/src/plugins/agent/types.ts
+++ b/packages/review/src/plugins/agent/types.ts
@@ -5,8 +5,7 @@
  * used across the agent's anthropic client, tools, and system prompt modules.
  */
 
-import type { CodeChunk } from '@liendev/parser';
-import type { DependencyGraph } from '../../dependency-graph.js';
+import type { CodeChunk, DependencyGraph } from '@liendev/parser';
 import type { Logger } from '../../logger.js';
 
 /** Configuration for the blast-radius context injection. */

--- a/packages/review/test/blast-radius.test.ts
+++ b/packages/review/test/blast-radius.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { CodeChunk } from '@liendev/parser';
-import { buildDependencyGraph } from '../src/dependency-graph.js';
+import { buildDependencyGraph } from '@liendev/parser';
 import { computeBlastRadius } from '../src/blast-radius.js';
 import { createTestChunk } from '../src/test-helpers.js';
 

--- a/packages/review/test/harness/fixtures/blast-radius/pr1003-php-pricingservice-guard.blast-radius.ts
+++ b/packages/review/test/harness/fixtures/blast-radius/pr1003-php-pricingservice-guard.blast-radius.ts
@@ -58,7 +58,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { buildDependencyGraph } from '../../../../src/dependency-graph.js';
+import { buildDependencyGraph } from '@liendev/parser';
 import { computeBlastRadius } from '../../../../src/blast-radius.js';
 import type { BlastRadiusEntry, BlastRadiusReport } from '../../../../src/blast-radius.js';
 import type { ReviewContext } from '../../../../src/plugin-types.js';

--- a/packages/review/test/harness/fixtures/blast-radius/pr1003-rust-config-guard.blast-radius.ts
+++ b/packages/review/test/harness/fixtures/blast-radius/pr1003-rust-config-guard.blast-radius.ts
@@ -79,7 +79,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { buildDependencyGraph } from '../../../../src/dependency-graph.js';
+import { buildDependencyGraph } from '@liendev/parser';
 import { computeBlastRadius } from '../../../../src/blast-radius.js';
 import type { BlastRadiusEntry, BlastRadiusReport } from '../../../../src/blast-radius.js';
 import type { ReviewContext } from '../../../../src/plugin-types.js';

--- a/packages/review/test/harness/fixtures/blast-radius/pr981-python-check-required-fields.blast-radius.ts
+++ b/packages/review/test/harness/fixtures/blast-radius/pr981-python-check-required-fields.blast-radius.ts
@@ -56,7 +56,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { buildDependencyGraph } from '../../../../src/dependency-graph.js';
+import { buildDependencyGraph } from '@liendev/parser';
 import { computeBlastRadius } from '../../../../src/blast-radius.js';
 import type { BlastRadiusEntry, BlastRadiusReport } from '../../../../src/blast-radius.js';
 import type { ReviewContext } from '../../../../src/plugin-types.js';

--- a/packages/review/test/plugins-agent-getdependents-risk.test.ts
+++ b/packages/review/test/plugins-agent-getdependents-risk.test.ts
@@ -1,9 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import type { CodeChunk } from '@liendev/parser';
-import { computeBlastRadiusRisk } from '@liendev/parser';
+import { computeBlastRadiusRisk, buildDependencyGraph } from '@liendev/parser';
 
 import { getDependents } from '../src/plugins/agent/agent-tools.js';
-import { buildDependencyGraph } from '../src/dependency-graph.js';
 import { computeBlastRadius } from '../src/blast-radius.js';
 import { createTestChunk, silentLogger } from '../src/test-helpers.js';
 import type { AgentToolContext } from '../src/plugins/agent/types.js';

--- a/packages/review/test/plugins-agent-grep.test.ts
+++ b/packages/review/test/plugins-agent-grep.test.ts
@@ -3,8 +3,9 @@ import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 
+import { buildDependencyGraph } from '@liendev/parser';
+
 import { grepCodebase } from '../src/plugins/agent/agent-tools.js';
-import { buildDependencyGraph } from '../src/dependency-graph.js';
 import { silentLogger } from '../src/test-helpers.js';
 import type { AgentToolContext } from '../src/plugins/agent/types.js';
 

--- a/packages/review/test/plugins-agent-listfunctions.test.ts
+++ b/packages/review/test/plugins-agent-listfunctions.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import type { CodeChunk } from '@liendev/parser';
+import { buildDependencyGraph } from '@liendev/parser';
 
 import { listFunctions } from '../src/plugins/agent/agent-tools.js';
-import { buildDependencyGraph } from '../src/dependency-graph.js';
 import { createTestChunk, silentLogger } from '../src/test-helpers.js';
 import type { AgentToolContext } from '../src/plugins/agent/types.js';
 

--- a/packages/review/test/plugins-agent-replay-blindness.test.ts
+++ b/packages/review/test/plugins-agent-replay-blindness.test.ts
@@ -3,8 +3,9 @@ import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 
+import { buildDependencyGraph } from '@liendev/parser';
+
 import { grepCodebase, readFile } from '../src/plugins/agent/agent-tools.js';
-import { buildDependencyGraph } from '../src/dependency-graph.js';
 import { silentLogger } from '../src/test-helpers.js';
 import type { AgentToolContext } from '../src/plugins/agent/types.js';
 


### PR DESCRIPTION
## Summary

`packages/review/src/dependency-graph.ts` (call-site-level dependency graph:
7-tier `EdgeProvenance`, `getCallers`/`getCallersTransitive` with hop
tracking, import-only and require-only fallbacks) imported nothing
review-specific — only parser's own `walkBounded`, `importMatchesTarget`,
`normalizePath`, `detectLanguage`, `findCSharpTypeReferenceDependents`, and
`callerSymbolFor`. It was architecturally misplaced inside the private,
unpublished `review` package, where only review's own files could reach it.

This PR is a **pure relocation, no intended behavior change**:

- Moved (`git mv`) to `packages/parser/src/graph/dependency-graph.ts`,
  alongside the generic `walkBounded` BFS it already builds on. The only
  edit to the file itself is its import block, rewritten from package-level
  `@liendev/parser` imports to parser-internal relative imports (the file
  now lives *inside* parser). **Verified with a byte diff against
  `origin/main:packages/review/src/dependency-graph.ts`** — the only lines
  that differ are the 6-line import block.
- Exported from `@liendev/parser`'s `index.ts`: `buildDependencyGraph`,
  `isPreciseProvenance`, and the `DependencyGraph`/`SymbolNode`/`CallerEdge`/
  `TransitiveCallerEdge`/`TransitiveResult`/`TransitiveOptions`/
  `EdgeProvenance` types.
- Moved its test file to sit next to the source
  (`packages/parser/src/graph/dependency-graph.test.ts`, matching the
  existing `bounded-bfs.ts`/`bounded-bfs.test.ts` pattern), with a small
  local (non-exported) `createTestChunk` factory in place of importing
  review's `test-helpers.ts` across the package boundary (that helper stays
  in `@liendev/review` — still used by 3 other review test files). All 34
  original `it(...)` cases are unchanged; diffed against the pre-move file
  to confirm.
- Repointed review's 6 direct consumers, 5 test files, and 3 offline
  harness fixture scripts (`test/harness/fixtures/blast-radius/*.blast-radius.ts`)
  that imported the local module, at `@liendev/parser` instead. Review's own
  re-export of these symbols (`src/index.ts`) is deleted — grepped
  `packages/core/src`, `packages/cli/src`, `packages/action/src` for any
  consumer of `@liendev/review`'s re-exported names first; found none.
- Touched up 3 stale doc-comments elsewhere in parser that described this
  file as living in `@liendev/review`.

## Deviations from the original plan (found during re-verification, fixed and documented rather than silently improvised past)

1. **The import list was incomplete.** The current file imports a 6th name,
   `callerSymbolFor` (from `dependency-analyzer.ts`), not just the 5 named
   in the original plan. Added `import { callerSymbolFor } from
   '../dependency-analyzer.js';` — without it the file doesn't compile.
2. **5 more test files** (`plugins-agent-getdependents-risk.test.ts`,
   `plugins-agent-replay-blindness.test.ts`, `plugins-agent-grep.test.ts`,
   `blast-radius.test.ts`, `plugins-agent-listfunctions.test.ts`) and
   **3 harness fixture scripts** import `buildDependencyGraph` directly from
   `../src/dependency-graph.js` (or a longer relative path for the fixtures)
   — not in the plan's consumer list. Repointed all 8 at `@liendev/parser`.
3. **One pre-existing unused parameter** (`chunk` in
   `chunkImportsFromFile`) was invisible under review's tsconfig (no
   `noUnusedParameters`) but breaks parser's build (which sets it). Renamed
   to `_chunk` — a cosmetic, zero-behavior-change fix required to compile
   in the new home.

## Dogfood evidence

Gate chain, run from a fresh worktree (`npm ci` + `npm run build:native -w
@liendev/parser-native`, per `docs/development/worktree-development.md`):

- `npm run format:check` — pass
- `npm run lint` — 0 errors, 42 pre-existing warnings (none in touched files)
- `npm run typecheck` — pass (parser, core, review, cli, action)
- `npm run build` — pass (all 5 packages)
- `npm run test -w @liendev/parser` — 63 files / 1906 tests pass, including
  the moved `src/graph/dependency-graph.test.ts` (41 tests)
- `npm run test -w @liendev/review` — 58 files / 1725 tests pass, including
  all 6 repointed consumers and the 5 repointed test files
- `npm test` (full monorepo) — 75 files / 1704 tests pass in `cli`, 5/41 in
  `action`, on top of the parser/core/review runs above
- `node packages/cli/dist/index.js delta` — exit 0:
  ```
  packages/parser/src/graph/dependency-graph.test.ts (renamed from packages/review/test/dependency-graph.test.ts)
    · new      createTestChunk          cyclomatic – → 1

    20 files · 226 ms
  ```
  (the one "new" entry is the local test-helper factory, complexity 1 — no
  threshold crossing)

## Follow-up

A follow-up PR may build a richer `get_dependents`/`lien api-delta`
integration on top of this now that the call-site-level graph is reachable
from `@liendev/cli`, not just `@liendev/review`. Out of scope here — this PR
is the lift only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dependency graph construction, provenance utilities, and related types are now available from the parser package.
- **Changes**
  - Review functionality now relies on the parser package for dependency graph APIs.
  - Dependency graph exports have been removed from the review package; existing behavior remains unchanged.
- **Documentation**
  - Updated dependency graph documentation and references to reflect the current package location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 7 pre-existing issues in touched files (none introduced).
🔗 **Impact**: 2 high-risk file(s) with 5 total dependents
| Metric | Violations | Change |
|--------|:----------:|:------:|
| ⏱️ time to understand | 7 | +0 |


> [!NOTE]
> **Low Risk**
>
> This PR is a mechanical relocation of `dependency-graph.ts` from the private `@liendev/review` package into `@liendev/parser`, expanding parser's public exports to include `buildDependencyGraph`, `isPreciseProvenance`, and related types. All direct consumers in review (blast-radius, agent plugin, tests, and harness fixtures) have been repointed to import from `@liendev/parser`, and the now-redundant re-exports from `@liendev/review`'s `index.ts` have been removed. No external callers of the removed review re-exports were found. The only non-import code edit is the removal of an unused `chunk` parameter from `chunkImportsFromFile` to satisfy parser's stricter TypeScript config — a behavior-preserving change. The moved tests and repointed consumers are covered by the reported passing test suite.
>
> - Moved `dependency-graph.ts` to `packages/parser/src/graph/dependency-graph.ts` and exported its public API from `@liendev/parser`
> - Repointed review's consumers and tests to import from `@liendev/parser`
> - Removed the redundant re-export of dependency-graph symbols from `@liendev/review`

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit dd955a9. Updates automatically on new commits.</sup>
<!-- /lien-stats -->