### PR TITLE
perf(parser,cli): reuse recovery-tier indexes across a findDependents batch

### DIFF
--- a/packages/cli/src/cli/annotate-cmd.ts
+++ b/packages/cli/src/cli/annotate-cmd.ts
@@ -436,6 +436,14 @@ async function computeAnnotationData(
   const log = () => undefined;
   // includeAllChunks=true: annotator needs the chunks for test-association
   // and complexity lookups. The default (false) keeps the MCP path cheap.
+  //
+  // No `recoveryIndexes` bag (#1101): `lien annotate <file>` takes exactly
+  // ONE file per process invocation (`.command('annotate <file>')` in
+  // `cli/index.ts`) and this is the only `findDependents` call in that
+  // invocation -- there is no loop here for a shared bag to amortize across,
+  // unlike `api-delta-cmd.ts`'s `enrichDeltas`. A fresh, call-scoped bag
+  // (built internally by `findDependents` when this param is omitted) is
+  // exactly as cheap as a shared one would be for a batch of one.
   const result = await findDependents(
     vectorDB,
     filepath,

--- a/packages/cli/src/cli/api-delta-cmd.ts
+++ b/packages/cli/src/cli/api-delta-cmd.ts
@@ -8,7 +8,11 @@
 
 import chalk from 'chalk';
 import { createVectorDB } from '@liendev/core';
-import { computeBlastRadiusRisk, type FileContentChange } from '@liendev/parser';
+import {
+  computeBlastRadiusRisk,
+  type FileContentChange,
+  type RecoveryIndexes,
+} from '@liendev/parser';
 import { getRepoRoot, collectFileChanges, collectFileChange } from './delta-git.js';
 import {
   findDependents,
@@ -142,10 +146,21 @@ async function enrichOneChange(
   filepath: string,
   change: ExportedSymbolChange,
   indexVersion: number,
+  recoveryIndexes: RecoveryIndexes,
 ): Promise<EnrichedExportedSymbolChange> {
   try {
     const log = (): void => undefined;
-    const analysis = await findDependents(vectorDB, filepath, log, change.symbolName, indexVersion);
+    const analysis = await findDependents(
+      vectorDB,
+      filepath,
+      log,
+      change.symbolName,
+      indexVersion,
+      1,
+      500,
+      false,
+      recoveryIndexes,
+    );
     const docRefs = await resolveDocRefs(vectorDB, change);
     // Same composition/priority rules `get_dependents` uses for its own
     // `attributionCaveat` -- both surfaces call `findDependents` and get
@@ -205,11 +220,34 @@ async function enrichDeltas(
     // Captured once so every symbol in this run shares the scan cache inside
     // findDependents — only the first symbol in the batch pays the scanAll.
     const indexVersion = vectorDB.getCurrentVersion();
+    // #1101: one recovery-index bag for the WHOLE batch, threaded into every
+    // findDependents call below. Each of the three non-import recovery tiers
+    // (C# type-reference, Go root-package, JVM same-package) would then be
+    // built at most once for this entire `lien api-delta` invocation, however
+    // many zero-dependent C#/Go/Java/Kotlin symbols the diff touches, instead
+    // of once per symbol.
+    //
+    // Measured honesty note (dogfooded against a real OkHttp diff touching 3
+    // zero-import-dependent Kotlin symbols, see the PR for the full numbers):
+    // `enrichOneChange` below always calls `findDependents` with
+    // `change.symbolName` set, and all three `enrichWith*Dependents` recovery
+    // tiers (`dependency-analyzer.ts`) unconditionally skip whenever `symbol`
+    // is truthy -- that gate predates this PR and isn't relaxed here. So
+    // today this bag never actually gets populated from THIS call site (a
+    // real before/after run showed byte-identical output and no wall-clock
+    // change). It's still threaded through because it's the shape #1101
+    // asks for, costs nothing, and is exactly correct if a future change ever
+    // extends recovery to symbol-scoped queries -- the actually-measurable
+    // win today is any FILE-LEVEL (symbol-omitted) caller looping
+    // `findDependents`, which this repo doesn't have one of yet.
+    const recoveryIndexes: RecoveryIndexes = {};
 
     const results: EnrichedSignatureDelta[] = [];
     for (const delta of deltas) {
       const changes = await Promise.all(
-        delta.changes.map(c => enrichOneChange(vectorDB, delta.filepath, c, indexVersion)),
+        delta.changes.map(c =>
+          enrichOneChange(vectorDB, delta.filepath, c, indexVersion, recoveryIndexes),
+        ),
       );
       results.push({ filepath: delta.filepath, changes });
     }

--- a/packages/cli/src/mcp/handlers/dependency-analyzer.ts
+++ b/packages/cli/src/mcp/handlers/dependency-analyzer.ts
@@ -4,6 +4,7 @@ import {
   buildDependencyGraph,
   type FindDependentsResult,
   type DependencyGraph,
+  type RecoveryIndexes,
 } from '@liendev/parser';
 
 export type { ComplexityMetrics, DependentInfo, SymbolUsage } from '@liendev/parser';
@@ -125,6 +126,20 @@ export async function getOrBuildDependencyGraph(
  * result). This wrapper's only jobs are: fetch (and cache) the chunk set
  * from the vectorDB via `getOrScanChunks`, and hand it to the parser's
  * pure, chunk-based engine.
+ *
+ * `recoveryIndexes` (#1101) is a pure pass-through -- this wrapper does no
+ * caching of its own, it just forwards whatever it's given (or `undefined`)
+ * to the parser-level call. A caller looping this function over many
+ * FILE-LEVEL (no `symbol`) targets within one process invocation should
+ * construct one `{}` bag and pass the same object on every call -- see the
+ * parser-level `findDependents`'s own doc comment for why the "FILE-LEVEL"
+ * qualifier matters (the three recovery tiers unconditionally skip whenever
+ * `symbol` is set, so `lien api-delta`'s `enrichDeltas` -- which always
+ * passes `change.symbolName` -- still threads this bag through per #1101's
+ * asked-for shape, but measured against a real corpus it doesn't currently
+ * change that command's output or wall-clock time). Every other caller (the
+ * MCP `get_dependents` handler,
+ * `lien annotate`) omits it and gets today's per-call-fresh behavior.
  */
 export async function findDependents(
   vectorDB: VectorDBInterface,
@@ -141,6 +156,7 @@ export async function findDependents(
    * Default `false` keeps memory cost down for the common MCP path.
    */
   includeAllChunks: boolean = false,
+  recoveryIndexes?: RecoveryIndexes,
 ): Promise<DependencyAnalysisResult> {
   const chunks = await getOrScanChunks(vectorDB, log, indexVersion);
   const workspaceRoot = process.cwd().replace(/\\/g, '/');
@@ -153,5 +169,6 @@ export async function findDependents(
     depth,
     maxNodes,
     includeAllChunks,
+    recoveryIndexes,
   );
 }

--- a/packages/parser/src/dependency-analyzer.test.ts
+++ b/packages/parser/src/dependency-analyzer.test.ts
@@ -17,6 +17,7 @@ import { clearGoModuleCache } from './go-module.js';
 import { clearRustCrateMapCache } from './rust-crate-map.js';
 import { clearRustCrateExportCache } from './rust-crate-exports.js';
 import type { CodeChunk, ChunkMetadata } from './types.js';
+import type { RecoveryIndexes } from './dependent-count-index.js';
 
 describe('analyzeDependencies', () => {
   const workspaceRoot = '/test/workspace';
@@ -1267,6 +1268,110 @@ describe('findDependents (Go root-package export-lookup recovery, #1039)', () =>
       expect(d.confidence).toBeUndefined();
       expect(d.inferredVia).toBeUndefined();
     }
+  });
+
+  it('reuses a caller-supplied recoveryIndexes bag across multiple findDependents calls in one batch (#1101)', () => {
+    // The exact shape `lien api-delta`'s `enrichDeltas` needs: one bag built
+    // before the loop, threaded into every `findDependents` call inside it.
+    // Asserting object identity (not just "same answer") is the point --
+    // the fix is specifically that `buildGoRootPackageIndex` runs at most
+    // ONCE for the whole batch, not once per call.
+    const chunks: CodeChunk[] = [
+      createGoChunk('context.go', { exports: ['RouteContext', 'NewRouteContext'] }),
+      createGoChunk('middleware/clean_path.go', {
+        imports: [MODULE_PREFIX],
+        callSites: ['RouteContext'],
+      }),
+    ];
+    const recoveryIndexes: RecoveryIndexes = {};
+
+    const first = findDependents(
+      chunks,
+      'context.go',
+      noopLog,
+      workspaceRoot,
+      undefined,
+      1,
+      500,
+      false,
+      recoveryIndexes,
+    );
+    expect(first.dependents.map(d => d.filepath)).toEqual(['middleware/clean_path.go']);
+    const builtIndex = recoveryIndexes.go;
+    expect(builtIndex).toBeDefined();
+
+    const second = findDependents(
+      chunks,
+      'context.go',
+      noopLog,
+      workspaceRoot,
+      undefined,
+      1,
+      500,
+      false,
+      recoveryIndexes,
+    );
+    // Same object reference reused -- proof the second call never rebuilt it.
+    expect(recoveryIndexes.go).toBe(builtIndex);
+    expect(second.dependents.map(d => d.filepath)).toEqual(['middleware/clean_path.go']);
+  });
+
+  it('produces identical results whether or not a recoveryIndexes bag is threaded through (batching only caches, never changes the answer)', () => {
+    const chunks: CodeChunk[] = [
+      createGoChunk('context.go', { exports: ['RouteContext', 'NewRouteContext'] }),
+      createGoChunk('middleware/clean_path.go', {
+        imports: [MODULE_PREFIX],
+        callSites: ['RouteContext'],
+      }),
+      createGoChunk('middleware/get_head.go', {
+        imports: [MODULE_PREFIX],
+        callSites: ['RouteContext', 'NewRouteContext'],
+      }),
+    ];
+
+    const withoutBag = findDependents(chunks, 'context.go', noopLog, workspaceRoot);
+    const sharedBag: RecoveryIndexes = {};
+    const withBag = findDependents(
+      chunks,
+      'context.go',
+      noopLog,
+      workspaceRoot,
+      undefined,
+      1,
+      500,
+      false,
+      sharedBag,
+    );
+
+    expect(withBag.dependents).toEqual(withoutBag.dependents);
+    expect(withBag.dependentAttributionPartial).toBe(withoutBag.dependentAttributionPartial);
+  });
+
+  it('never builds the Go root-package index for a non-root-level Go file, even when a shared recoveryIndexes bag is supplied (preserves the single-shot short-circuit)', () => {
+    // `enrichWithGoRootPackageDependents` must check `isRootLevelGoFile`
+    // BEFORE touching `ctx.recoveryIndexes.go` -- otherwise a single MCP
+    // query for a zero-dependent, non-root-level Go file would start paying
+    // the corpus-wide index build it never paid before #1101.
+    const chunks: CodeChunk[] = [
+      createGoChunk('sub/helper.go', { exports: ['Helper'] }),
+      createGoChunk('sub/unrelated.go', {}),
+    ];
+    const recoveryIndexes: RecoveryIndexes = {};
+
+    const result = findDependents(
+      chunks,
+      'sub/helper.go',
+      noopLog,
+      workspaceRoot,
+      undefined,
+      1,
+      500,
+      false,
+      recoveryIndexes,
+    );
+
+    expect(result.dependents).toEqual([]);
+    expect(recoveryIndexes.go).toBeUndefined();
   });
 
   it('does NOT fabricate a false hub: two unrelated root files get disjoint dependents (the #1056 failure shape, checked explicitly)', () => {

--- a/packages/parser/src/dependency-analyzer.ts
+++ b/packages/parser/src/dependency-analyzer.ts
@@ -15,9 +15,20 @@ import {
   hasDependentAttributionBlindSpot,
 } from './ast/languages/registry.js';
 import { findChunkLineIndex } from './chunk-line-lookup.js';
-import { findCSharpTypeReferenceDependents } from './csharp-type-reference-signals.js';
-import { findGoRootPackageDependents } from './go-root-package-signals.js';
-import { findJvmSamePackageDependents } from './jvm-same-package-signals.js';
+import {
+  buildCSharpTypeReferenceIndex,
+  resolveCSharpTypeReferenceDependents,
+} from './csharp-type-reference-signals.js';
+import {
+  buildGoRootPackageIndex,
+  resolveGoRootPackageDependents,
+  isRootLevelGoFile,
+} from './go-root-package-signals.js';
+import {
+  buildJvmSamePackageIndex,
+  resolveJvmSamePackageDependents,
+} from './jvm-same-package-signals.js';
+import type { RecoveryIndexes } from './dependent-count-index.js';
 import type { InferredDependentMechanism } from './inferred-dependent-mechanisms.js';
 
 /**
@@ -1490,6 +1501,12 @@ function mergeChunksByFile<T extends CodeChunk>(
 /**
  * Shared context for a single `findDependents` call. These values always
  * travel together, so grouping them removes parameter noise from helpers.
+ *
+ * `recoveryIndexes` (#1101) is always populated by `findDependents` itself --
+ * either the caller-supplied batch-scoped bag, or a fresh `{}` scoped to just
+ * this one call -- so every one of the three `enrichWith*Dependents` helpers
+ * below can unconditionally read/write through it (`ctx.recoveryIndexes.jvm
+ * ??= buildJvmSamePackageIndex(...)`) with no extra undefined-check.
  */
 interface ScanContext<T extends CodeChunk> {
   importIndex: Map<string, ImportIndexEntry<T>[]>;
@@ -1497,6 +1514,7 @@ interface ScanContext<T extends CodeChunk> {
   normalizePathCached: (p: string) => string;
   log: (message: string, level?: 'warning') => void;
   workspaceRoot: string;
+  recoveryIndexes: RecoveryIndexes;
 }
 
 /**
@@ -1655,6 +1673,29 @@ function resolveDependents<T extends CodeChunk>(args: {
  * read from `process.cwd()` internally -- same reasoning as
  * `analyzeDependencies` above: keeps this function pure and independently
  * testable, with no hidden environment read.
+ *
+ * `recoveryIndexes` (#1101) is an optional, caller-threaded bag for the three
+ * non-import recovery tiers' project-wide indexes (C# type-reference, Go
+ * root-package, JVM same-package -- see the `enrichWith*Dependents`
+ * functions below). Omit it (the default) for a one-off call -- this
+ * function builds and discards a fresh, empty bag internally, identical to
+ * today's behavior for every existing caller. A caller that invokes this
+ * function in a loop over many FILE-LEVEL targets (no `symbol`) within ONE
+ * outer batch should construct ONE `{}` bag before the loop and pass the
+ * SAME object into every call -- each of the three tiers is then built at
+ * most once per batch and reused for the rest of it, mirroring
+ * `dependent-count-index.ts`'s own `RecoveryIndexes` batching discipline.
+ * Note the "FILE-LEVEL" qualifier is load-bearing: all three
+ * `enrichWith*Dependents` functions unconditionally no-op whenever `symbol`
+ * is set (see their shared `if (symbol || ...)` guard), so a caller that
+ * always queries with a `symbol` (`lien api-delta`'s `enrichDeltas`, which
+ * always passes `change.symbolName`) never reaches this tier at all,
+ * batched or not -- threading the bag through such a caller is still
+ * correct and harmless, just not currently observable as a speedup there
+ * (measured; see #1101's PR for the real before/after). Never a
+ * module-level cache keyed by workspace root: see `jvm-source-root.ts`'s own
+ * doc comment for why that goes stale under a long-running `lien serve` --
+ * this bag must stay scoped to one batch/call.
  */
 export function findDependents<T extends CodeChunk>(
   chunks: Iterable<T>,
@@ -1671,6 +1712,7 @@ export function findDependents<T extends CodeChunk>(
    * Default `false` keeps memory cost down for the common MCP path.
    */
   includeAllChunks: boolean = false,
+  recoveryIndexes?: RecoveryIndexes,
 ): FindDependentsResult<T> {
   const normalizePathCached = createPathNormalizer(workspaceRoot);
   const normalizedTarget = normalizePathCached(filepath);
@@ -1682,6 +1724,7 @@ export function findDependents<T extends CodeChunk>(
     normalizePathCached,
     log,
     workspaceRoot,
+    recoveryIndexes: recoveryIndexes ?? {},
   };
 
   const { targetIndexed, chunksByFile, reExporterPaths } = seedIfTargetIndexed(
@@ -1828,8 +1871,20 @@ function enrichWithCSharpTypeReferenceDependents<T extends CodeChunk>(
   const targetRawFile = targetChunks[0]?.metadata.file;
   if (!targetRawFile) return undefined;
 
+  // Build once per batch (#1101): a caller looping `findDependents` over many
+  // targets in one outer batch (`lien api-delta`'s `enrichDeltas`) threads
+  // the same `ctx.recoveryIndexes` bag through every call, so this only pays
+  // the project-wide index build for the FIRST zero-dependent C# target it
+  // reaches -- every subsequent one in the same batch reuses it. A one-off
+  // caller (the common `get_dependents` MCP path) gets a fresh, empty bag
+  // from `findDependents` itself, so this still builds exactly once per call,
+  // identical to before.
   const allChunks = Array.from(ctx.allChunksByFile.values()).flat();
-  const inferredFiles = findCSharpTypeReferenceDependents(targetRawFile, allChunks);
+  ctx.recoveryIndexes.csharp ??= buildCSharpTypeReferenceIndex(allChunks);
+  const inferredFiles = resolveCSharpTypeReferenceDependents(
+    targetRawFile,
+    ctx.recoveryIndexes.csharp,
+  );
   if (inferredFiles.length === 0) return undefined;
 
   for (const rawFile of inferredFiles) {
@@ -1860,9 +1915,10 @@ function enrichWithCSharpTypeReferenceDependents<T extends CodeChunk>(
  * Mirrors `enrichWithCSharpTypeReferenceDependents` immediately above in
  * every structural respect: file-level only (no `symbol`), only attempted
  * when the import graph found LITERALLY ZERO dependents, only for a
- * root-level Go file (`findGoRootPackageDependents` itself also checks this,
- * but checking here too avoids the corpus-wide index rebuild for every
- * non-Go or non-root query), and recovered entries are tagged
+ * root-level Go file (checked explicitly below via `isRootLevelGoFile`,
+ * mirroring `findGoRootPackageDependents`'s own guard -- kept here too so a
+ * non-root-level Go query never triggers `buildGoRootPackageIndex`'s
+ * corpus-wide scan, #1101), and recovered entries are tagged
  * `confidence: 'inferred'` -- not joined against `chunksByFile` for
  * complexity-metrics purposes, same reasoning as the C# recovery.
  */
@@ -1879,10 +1935,13 @@ function enrichWithGoRootPackageDependents<T extends CodeChunk>(
 
   const targetChunks = ctx.allChunksByFile.get(normalizedTarget) ?? [];
   const targetRawFile = targetChunks[0]?.metadata.file;
-  if (!targetRawFile) return undefined;
+  if (!targetRawFile || !isRootLevelGoFile(targetRawFile)) return undefined;
 
+  // Build once per batch (#1101) -- see the C# recovery's identical comment
+  // immediately above for the full reasoning.
   const allChunks = Array.from(ctx.allChunksByFile.values()).flat();
-  const inferredFiles = findGoRootPackageDependents(targetRawFile, allChunks, ctx.workspaceRoot);
+  ctx.recoveryIndexes.go ??= buildGoRootPackageIndex(allChunks, ctx.workspaceRoot);
+  const inferredFiles = resolveGoRootPackageDependents(targetRawFile, ctx.recoveryIndexes.go);
   if (inferredFiles.length === 0) return undefined;
 
   for (const rawFile of inferredFiles) {
@@ -1930,8 +1989,13 @@ function enrichWithJvmSamePackageDependents<T extends CodeChunk>(
   const targetRawFile = targetChunks[0]?.metadata.file;
   if (!targetRawFile) return undefined;
 
+  // Build once per batch (#1101) -- see the C# recovery's identical comment
+  // near the top of this file for the full reasoning. This is the tier the
+  // issue's own measurement targeted: ~37-40ms per rebuild on OkHttp
+  // (682 files / 9033 chunks).
   const allChunks = Array.from(ctx.allChunksByFile.values()).flat();
-  const inferredFiles = findJvmSamePackageDependents(targetRawFile, allChunks);
+  ctx.recoveryIndexes.jvm ??= buildJvmSamePackageIndex(allChunks);
+  const inferredFiles = resolveJvmSamePackageDependents(targetRawFile, ctx.recoveryIndexes.jvm);
   if (inferredFiles.length === 0) return undefined;
 
   for (const rawFile of inferredFiles) {

--- a/packages/parser/src/dependent-count-index.ts
+++ b/packages/parser/src/dependent-count-index.ts
@@ -333,8 +333,17 @@ function buildReverseEdges(
  * Lazily-built project-wide indexes for the three non-import recovery tiers.
  * Built on first use, so a corpus with no zero-dependent C#/Go/JVM file pays
  * nothing for any of them.
+ *
+ * Exported so `dependency-analyzer.ts`'s `findDependents` can thread the
+ * exact same bag shape through its own `ScanContext` (#1101) -- this is the
+ * one shared home for "which of the three recovery indexes has been built
+ * so far in the current batch", rather than two structurally-identical
+ * interfaces declared separately. The two call sites' caching logic stays
+ * separate (`recoverDependentsForFile` below vs. the three
+ * `enrichWith*Dependents` functions) since their call shapes genuinely
+ * differ; only the bag's TYPE is shared.
  */
-interface RecoveryIndexes {
+export interface RecoveryIndexes {
   csharp?: ReturnType<typeof buildCSharpTypeReferenceIndex>;
   go?: ReturnType<typeof buildGoRootPackageIndex>;
   jvm?: ReturnType<typeof buildJvmSamePackageIndex>;

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -229,6 +229,12 @@ export {
   computeDependentCountsFromChunks,
   computeDependentCountsBruteForce,
 } from './dependent-count-index.js';
+// `RecoveryIndexes` is the shared batch-scoped bag for the C#/Go/JVM
+// recovery-tier indexes -- shared with `dependency-analyzer.ts`'s
+// `findDependents` (#1101) so a caller looping `findDependents` over many
+// FILE-LEVEL (no `symbol`) targets in one process invocation can build each
+// language's index once and reuse it, instead of paying a rebuild per call.
+export type { RecoveryIndexes } from './dependent-count-index.js';
 
 // =============================================================================
 // GRAPH TRAVERSAL (generic bounded BFS — domain graphs build on this)


### PR DESCRIPTION
## What changed

`findDependents`'s three non-import recovery tiers — C# type-reference, Go root-package, and JVM same-package (`enrichWithCSharpTypeReferenceDependents`/`enrichWithGoRootPackageDependents`/`enrichWithJvmSamePackageDependents` in `packages/parser/src/dependency-analyzer.ts`) — each rebuilt their project-wide index from scratch on every call, via their fused build+resolve convenience wrappers (`findCSharpTypeReferenceDependents`/`findGoRootPackageDependents`/`findJvmSamePackageDependents`).

- Added an optional, caller-threaded `recoveryIndexes?: RecoveryIndexes` parameter to parser-level `findDependents`, and a `ScanContext.recoveryIndexes` field it's populated into (caller-supplied bag, or a fresh `{}` per call when omitted).
- `RecoveryIndexes` (previously module-private in `dependent-count-index.ts`, which already used this exact shape for a different batch codepath) is now exported and reused — one shared type, no near-duplicate interface.
- All three `enrichWith*Dependents` functions now read/write through `ctx.recoveryIndexes.<lang> ??= build<Lang>Index(...)` and call the matching `resolve<Lang>Dependents` directly, instead of the fused wrapper.
- Go's recovery additionally gained an explicit `isRootLevelGoFile` check *before* touching the cache (mirroring `findGoRootPackageDependents`'s own guard) — needed to preserve today's "non-root-level Go file never pays the index build" short-circuit; without it, a single-shot query for a non-root Go file would start paying a corpus-wide scan it never paid before.
- Threaded the parameter through the CLI-level wrapper (`packages/cli/src/mcp/handlers/dependency-analyzer.ts`, pure pass-through) and into `api-delta-cmd.ts`'s `enrichDeltas`, which now builds one bag before its loop and passes it to every `enrichOneChange` → `findDependents` call in that batch.
- `annotate-cmd.ts` left unchanged (with an inline comment explaining why — see below). `get-dependents.ts` unchanged, compiles as-is (additive param).
- Added 4 new unit tests to `dependency-analyzer.test.ts`: object-identity proof that a shared bag is reused (not rebuilt) across calls, an equivalence test (bag vs. no bag produces identical results), and a regression test for the Go short-circuit.

Everything is purely additive — every existing caller that omits the new parameter gets a fresh, empty bag per call, byte-identical to today's behavior.

## Dogfood evidence (measured against a real OkHttp clone, 682 files / 9033 chunks)

**The mechanism works exactly as designed.** Direct microbenchmark: N=196 zero-import-graph-dependent Kotlin/Java files that the JVM same-package tier actually recovers, looped through `findDependents` file-level (no `symbol`):

```
WITHOUT shared recoveryIndexes bag: 29938.3ms for 196 calls (152.75ms/call avg)
WITH shared recoveryIndexes bag:    22456.3ms for 196 calls (114.57ms/call avg)
recoveryIndexes.jvm built exactly once, reused for all 196 calls (object identity confirms no rebuild): true
```

7.48s saved across 195 avoided rebuilds ≈ **38.4ms per avoided rebuild** — matches this issue's own baseline measurement (37-40ms) almost exactly. Isolated `buildJvmSamePackageIndex(chunks)` alone on the same corpus: **38.10ms/call** avg over 10 runs.

A smaller N=20 run: 3047.0ms → 2314.5ms (732.5ms saved / 19 avoided rebuilds ≈ 38.6ms each).

**Important correction to this issue's own framing, found while dogfooding `lien api-delta` itself** (not just the underlying mechanism): `enrichDeltas`'s `enrichOneChange` always calls `findDependents` with `change.symbolName` set (a real, non-empty string for any actual signature change), and all three `enrichWith*Dependents` functions unconditionally no-op whenever `symbol` is truthy (`if (symbol || dependents.length !== 0 || !targetIndexed) return undefined;` — predates this PR, not touched here). So **`lien api-delta` never actually reaches these recovery tiers today, batched or not** — confirmed two ways:

1. A direct probe: `findDependents(chunks, targetFile, log, root, 'Foo')` (symbol set) on a fixture where the file-level call recovers a real same-package dependent returns `dependents: []` — no `confidence`/`inferredVia` — while the file-level call (no symbol) correctly recovers it.
2. A real end-to-end run: changed 3 exported Kotlin symbols across 3 zero-import-dependent files in the OkHttp clone (`UppercaseResponseInterceptor.intercept`, `UppercaseRequestInterceptor.intercept`, `TestUtil.headerEntries`), ran `lien api-delta --format json` before and after this fix:
   - Before: `0.67s`, `0.69s`, `0.67s` (3 runs)
   - After: `0.67s`, `0.68s` (2 runs)
   - `diff` of the two JSON outputs: **byte-identical**. Both show `dependentCount: 0` with the pre-existing `dependent-attribution-incomplete` caveat (a different, index-build-free signal) — never a recovered/inferred dependent.

So the bag threaded into `api-delta-cmd.ts` is correctly wired per this issue's asked-for shape and is harmless/forward-compatible (e.g. if a future change ever extends recovery to symbol-scoped queries), but it doesn't change `lien api-delta`'s behavior or wall-clock time today. This is documented inline at both the parser-level `findDependents` doc comment and at the `enrichDeltas` call site so a future reader doesn't have to re-derive it. The actually-measurable win today is any FILE-LEVEL (symbol-omitted) caller looping `findDependents` over many targets in one batch — which the microbenchmark above demonstrates directly, but which no *existing* command in this repo currently does (the two current file-level callers, `get_dependents` MCP and `lien annotate`, are both genuinely one-shot per process/request).

## annotate-cmd.ts decision

Checked the loop structure: `lien annotate <file>` (`.command('annotate <file>')` in `cli/index.ts`) takes exactly one file per process invocation, and `computeAnnotationData` makes exactly one `findDependents` call (file-level, no `symbol`) per invocation. There's no loop for a shared bag to amortize across — a fresh, call-scoped bag is exactly as cheap as a shared one for a batch of one. Left as-is with an inline comment explaining this.

## Verification

- Full local gate chain: `npm run format:check && npm run lint && npm run typecheck && npm run build && npm test && lien delta` — all green (0 lint errors, 0 typecheck errors, 1948 parser tests / 1737 cli+core tests / 2173 review tests / 41 action tests all passing, `lien delta` exit 0 with only pre-existing-threshold "worsened" advisories, no new crossings).
- Confirmed via the real OkHttp run above: identical `dependentCount`/`riskLevel`/`attributionCaveat`/everything for `lien api-delta`, byte-for-byte.
- Confirmed `lien annotate` still correctly recovers a same-package JVM dependent (unchanged, single-shot path): `Lien impact for .../UppercaseResponseInterceptor.kt: • 1 file imports this — .../DuplexTest.kt; risk: medium`.
- `get_dependents` MCP handler untouched beyond the additive, unused parameter — full CLI test suite (including `get-dependents.test.ts`) passes unchanged.

Closes #1101


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved dependency analysis for batch operations by reusing recovery indexes, reducing repeated processing across related files.
  * Preserved existing dependency results and recovery behavior.

* **Bug Fixes**
  * Improved Go dependency recovery by validating root-level targets before building indexes.
  * Added coverage to verify consistent results with and without index reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds an optional, caller-threaded `RecoveryIndexes` bag to `findDependents` so that C# type-reference, Go root-package, and JVM same-package recovery-tier indexes can be built once and reused across a batch of file-level dependent queries. The change is purely additive: existing callers omitting the parameter get a fresh empty bag per call, preserving byte-identical behavior. The Go tier correctly preserves its pre-existing `isRootLevelGoFile` short-circuit before touching the cache, and the new tests verify bag reuse, equivalence, and that short-circuit. The CLI wrapper passes the parameter through transparently, and `api-delta-cmd.ts` builds one batch-scoped bag as intended.
>
> - Exported and reused `RecoveryIndexes` from `dependent-count-index.ts` across `dependency-analyzer.ts`
> - Three recovery tiers now cache indexes via `ctx.recoveryIndexes.<lang> ??= build<Lang>Index(...)` and call the matching resolver directly
> - Go recovery explicitly guards with `isRootLevelGoFile` before cache/index build to preserve the non-root short-circuit
> - CLI `dependency-analyzer.ts` wrapper and `api-delta-cmd.ts` thread the bag through; `annotate-cmd.ts` intentionally left unchanged for its one-shot use case

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 1de6cba. Updates automatically on new commits.</sup>
<!-- /lien-stats -->