### PR TITLE
feat(parser): resolve Java/Kotlin same-package callers in the call graph (#1005 Phase 2, Item 1)

### DIFF
--- a/.changeset/jvm-call-graph-tier.md
+++ b/.changeset/jvm-call-graph-tier.md
@@ -1,0 +1,27 @@
+---
+'@liendev/parser': minor
+---
+
+Add a Java/Kotlin same-package resolution tier to `buildDependencyGraph`'s
+call-graph (`getCallers`/`getCallersTransitive`), closing the #1005 Phase 2
+gap between Phase 1's file-level `findDependents` recovery (#1100) and the
+symbol/call-site-level call graph used by blast-radius and the MCP
+`get_dependents` tool's `importedBy` evidence.
+
+Java and Kotlin's same-package visibility rule lets one top-level type
+reference another in the same package with no import statement at all — the
+call graph previously had no way to see that reference for a declared
+class/interface symbol, only for the exact same-directory heuristic PHP/
+Python/Rust already used (`addSameNamespaceEdges`, unchanged and still firing
+for JVM method/function seeds it structurally can't reach). The new tier is
+per-type-scoped (`resolveJvmSamePackageDependentsForType`, exported from
+`@liendev/parser`) so a multi-type Kotlin file doesn't misattribute a
+sibling declaration's callers, unioned onto the existing result (never
+replacing it), and tagged `namespace-inferred` — never `import-only` — so it
+is correctly excluded from the MCP tool's "verifiably imports" evidence.
+
+Measured against a real OkHttp clone: `getCallers` for `Cache` (Kotlin, same
+package `okhttp3`) went from 16 to 33 edges, with 17 real same-package
+callers (`OkHttpClient`, `Request`, `Response`, `EventListener`, several
+test files, etc.) recovered that were previously invisible to the call
+graph entirely.

--- a/packages/parser/src/graph/dependency-graph.test.ts
+++ b/packages/parser/src/graph/dependency-graph.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   buildDependencyGraph,
   isPreciseProvenance,
@@ -7,6 +7,7 @@ import {
 import type { EdgeProvenance } from './dependency-graph.js';
 import type { CodeChunk } from '../types.js';
 import { findDependents } from '../dependency-analyzer.js';
+import * as jvmSignals from '../jvm-same-package-signals.js';
 
 /**
  * Create a minimal CodeChunk for testing.
@@ -1421,6 +1422,479 @@ describe('buildDependencyGraph — barrel transitive-walk regression (post-#1011
 });
 
 // ---------------------------------------------------------------------------
+// JVM same-package call-graph tier (#1005 Phase 2, Item 1) — the type-scoped
+// twin of Phase 1's file-level `findDependents` recovery (#1100), unioned
+// into `getCallers`'s result rather than tried as another early-return
+// branch in `resolveBaseTier`'s chain. See `unionJvmSamePackageTier`'s doc
+// comment in dependency-graph.ts for the full reasoning; the tests below are
+// the acceptance criteria from the design review that preceded this tier.
+// ---------------------------------------------------------------------------
+
+describe('buildDependencyGraph — JVM same-package call-graph tier (#1005 Phase 2)', () => {
+  it('AC1 per-type scoping: a same-package referrer that only textually references ONE of two sibling top-level types is not misattributed to the other', () => {
+    const fooChunk = createTestChunk({
+      content: 'package a.b\n\nclass Foo { }',
+      metadata: {
+        file: 'src/main/kotlin/a/b/FooBar.kt',
+        startLine: 1,
+        endLine: 3,
+        type: 'class',
+        symbolName: 'Foo',
+        symbolType: 'class',
+        language: 'kotlin',
+        exports: ['Foo'],
+      },
+    });
+    const barChunk = createTestChunk({
+      content: 'package a.b\n\nclass Bar { }',
+      metadata: {
+        file: 'src/main/kotlin/a/b/FooBar.kt',
+        startLine: 5,
+        endLine: 7,
+        type: 'class',
+        symbolName: 'Bar',
+        symbolType: 'class',
+        language: 'kotlin',
+        exports: ['Bar'],
+      },
+    });
+    // References ONLY Foo, textually — no import, no call site.
+    const referrerChunk = createTestChunk({
+      content: 'package a.b\n\nfun run() { Foo().doSomething() }',
+      metadata: {
+        file: 'src/main/kotlin/a/b/Ref.kt',
+        startLine: 1,
+        endLine: 3,
+        type: 'function',
+        symbolName: 'run',
+        symbolType: 'function',
+        language: 'kotlin',
+      },
+    });
+
+    const graph = buildDependencyGraph([fooChunk, barChunk, referrerChunk]);
+
+    const barCallers = graph.getCallers('src/main/kotlin/a/b/FooBar.kt', 'Bar');
+    expect(
+      barCallers.find(c => c.caller.filepath === 'src/main/kotlin/a/b/Ref.kt'),
+    ).toBeUndefined();
+
+    const fooCallers = graph.getCallers('src/main/kotlin/a/b/FooBar.kt', 'Foo');
+    const fooRef = fooCallers.find(c => c.caller.filepath === 'src/main/kotlin/a/b/Ref.kt');
+    expect(fooRef).toBeDefined();
+    expect(fooRef?.provenance).toBe('namespace-inferred');
+  });
+
+  it("AC2 provenance pinned: the NEW tier tags its own contribution namespace-inferred, distinct from a blanket check over a result that also carries the pre-existing directory heuristic's namespace-inferred edge", () => {
+    const targetChunk = createTestChunk({
+      content: 'package a.b;\n\npublic class Target { }',
+      metadata: {
+        file: 'src/main/java/a/b/Target.java',
+        startLine: 1,
+        endLine: 3,
+        type: 'class',
+        symbolName: 'Target',
+        symbolType: 'class',
+        language: 'java',
+        exports: ['Target'],
+      },
+    });
+    // Resolves via the PRE-EXISTING `addSameNamespaceEdges` directory
+    // heuristic: same directory as Target, a real call site literally
+    // naming 'Target', no import.
+    const dirCallerChunk = createTestChunk({
+      content: 'package a.b;\n\nclass DirCaller { void run() { new Target(); } }',
+      metadata: {
+        file: 'src/main/java/a/b/DirCaller.java',
+        startLine: 1,
+        endLine: 3,
+        type: 'class',
+        symbolName: 'DirCaller',
+        symbolType: 'class',
+        language: 'java',
+        callSites: [{ symbol: 'Target', line: 3 }],
+      },
+    });
+    // Resolvable ONLY via the NEW per-type tier: same PACKAGE (content-derived),
+    // a DIFFERENT directory (so the directory heuristic can't explain it), no
+    // import, no call site (so no import-based tier can explain it either).
+    const pkgCallerChunk = createTestChunk({
+      content: 'package a.b;\n\nclass PkgCaller { private Target target; }',
+      metadata: {
+        file: 'src/main/java/a/other/PkgCaller.java',
+        startLine: 1,
+        endLine: 3,
+        type: 'class',
+        symbolName: 'PkgCaller',
+        symbolType: 'class',
+        language: 'java',
+      },
+    });
+
+    const graph = buildDependencyGraph([targetChunk, dirCallerChunk, pkgCallerChunk]);
+    const callers = graph.getCallers('src/main/java/a/b/Target.java', 'Target');
+
+    expect(callers).toHaveLength(2);
+
+    const dirEdge = callers.find(c => c.caller.filepath === 'src/main/java/a/b/DirCaller.java');
+    expect(dirEdge?.provenance).toBe('namespace-inferred'); // the OLD heuristic's contribution
+
+    // The assertion that actually matters: the NEW tier's OWN edge, isolated
+    // from the pre-existing heuristic's edge above (which also happens to be
+    // 'namespace-inferred' — a blanket "every edge is namespace-inferred"
+    // check would pass even if the new tier tagged its edge wrong, as long
+    // as it tagged it SOMETHING that happened to coincide; this checks the
+    // specific edge that can only have come from the new tier).
+    const pkgEdge = callers.find(c => c.caller.filepath === 'src/main/java/a/other/PkgCaller.java');
+    expect(pkgEdge).toBeDefined();
+    expect(pkgEdge?.provenance).toBe('namespace-inferred');
+    expect(isImportOnlyEvidenceTier(pkgEdge!.provenance)).toBe(false);
+  });
+
+  it('AC3 no method/function-seed regression: a same-directory call site to a plain METHOD (not a type reference) still resolves via the retained directory heuristic, unchanged — the new tier structurally cannot touch it (G5)', () => {
+    const methodChunk = createTestChunk({
+      content: 'package app.services;\n\nclass PaymentService { void charge() { } }',
+      metadata: {
+        file: 'app/services/PaymentService.java',
+        startLine: 1,
+        endLine: 10,
+        type: 'function',
+        symbolName: 'charge',
+        symbolType: 'method',
+        language: 'java',
+        exports: ['PaymentService'],
+      },
+    });
+
+    const callerChunk = createTestChunk({
+      content: 'package app.services;\n\nclass OrderService { void processOrder() { charge(); } }',
+      metadata: {
+        file: 'app/services/OrderService.java',
+        startLine: 1,
+        endLine: 10,
+        type: 'function',
+        symbolName: 'processOrder',
+        symbolType: 'method',
+        language: 'java',
+        callSites: [{ symbol: 'charge', line: 10 }],
+      },
+    });
+
+    const graph = buildDependencyGraph([methodChunk, callerChunk]);
+    const callers = graph.getCallers('app/services/PaymentService.java', 'charge');
+
+    // Exactly what `resolveBaseTier`'s `addSameNamespaceEdges` produced
+    // before this tier existed — no additional edge from the new tier,
+    // because 'charge' is a method, never one of PaymentService.java's
+    // declared top-level class/interface names.
+    expect(callers).toHaveLength(1);
+    expect(callers[0].caller.filepath).toBe('app/services/OrderService.java');
+    expect(callers[0].caller.symbolName).toBe('processOrder');
+    expect(callers[0].provenance).toBe('namespace-inferred');
+  });
+
+  it('AC4 the import-only union point: getCallers unions the new tier even when resolveBaseTier resolved via the import-only fallback specifically (not just the empty-base or direct-edge cases)', () => {
+    // Zero call sites anywhere name 'Target' — every dependent below is
+    // recovered through a non-call-site path.
+    const targetChunk = createTestChunk({
+      content: 'package a.b;\n\npublic class Target { }',
+      metadata: {
+        file: 'src/main/java/a/b/Target.java',
+        startLine: 1,
+        endLine: 3,
+        type: 'class',
+        symbolName: 'Target',
+        symbolType: 'class',
+        language: 'java',
+        exports: ['Target'],
+      },
+    });
+    // Same package, NO import, references Target only via a field
+    // declaration (never a call site) -- resolvable ONLY by the new tier.
+    const samePackageCaller = createTestChunk({
+      content: 'package a.b;\n\nclass SamePackageCaller { private Target target; }',
+      metadata: {
+        file: 'src/main/java/a/b/SamePackageCaller.java',
+        startLine: 1,
+        endLine: 3,
+        type: 'class',
+        symbolName: 'SamePackageCaller',
+        symbolType: 'class',
+        language: 'java',
+      },
+    });
+    // Different package, a VERIFIED import (already resolved to a slash
+    // path — the shape jvm-source-root.ts's #1046 resolution produces, see
+    // path-matching.test.ts's "#1046 Java/Kotlin dotted-FQN specifiers"),
+    // referenced only via a field declaration, never a call site -- resolves
+    // via resolveBaseTier's IMPORT-ONLY fallback specifically.
+    const importVerifiedCaller = createTestChunk({
+      content:
+        'package x.y;\n\nimport a.b.Target;\n\nclass ImportVerifiedCaller { private Target target; }',
+      metadata: {
+        file: 'src/main/java/x/y/ImportVerifiedCaller.java',
+        startLine: 1,
+        endLine: 3,
+        type: 'class',
+        symbolName: 'ImportVerifiedCaller',
+        symbolType: 'class',
+        language: 'java',
+        importedSymbols: { 'src/main/java/a/b/Target': ['Target'] },
+      },
+    });
+
+    const graph = buildDependencyGraph([targetChunk, samePackageCaller, importVerifiedCaller]);
+    const callers = graph.getCallers('src/main/java/a/b/Target.java', 'Target');
+
+    // Confirms the fixture actually exercises resolveBaseTier's import-only
+    // branch (not e.g. a direct call-site edge) -- otherwise this test
+    // wouldn't discriminate the import-only union point from the trivial
+    // empty-base case AC1-AC3 already cover. Reverting the single union
+    // point in `getCallers` back to "only union after direct edges" (an
+    // earlier, rejected multi-union-point draft) makes THIS assertion fail
+    // while AC1/AC2/AC3 above would still pass unchanged.
+    const importOnlyEdge = callers.find(
+      c => c.caller.filepath === 'src/main/java/x/y/ImportVerifiedCaller.java',
+    );
+    expect(importOnlyEdge?.provenance).toBe('import-only');
+
+    const samePackageEdge = callers.find(
+      c => c.caller.filepath === 'src/main/java/a/b/SamePackageCaller.java',
+    );
+    expect(samePackageEdge?.provenance).toBe('namespace-inferred');
+
+    expect(callers).toHaveLength(2);
+  });
+
+  it('AC5 union predicate correctness: two real call sites in one already-resolved caller file are preserved unchanged, and the new tier does not add a duplicate entry for that same file', () => {
+    const targetChunk = createTestChunk({
+      content: 'package a.b;\n\npublic class Target { }',
+      metadata: {
+        file: 'src/main/java/a/b/Target.java',
+        startLine: 1,
+        endLine: 3,
+        type: 'class',
+        symbolName: 'Target',
+        symbolType: 'class',
+        language: 'java',
+        exports: ['Target'],
+      },
+    });
+    // Two DISTINCT call sites in the SAME file, both resolving via the
+    // pre-existing directory heuristic (same directory, no import) -- this
+    // is what a real multi-method caller class looks like in `base`.
+    const callerMethodOne = createTestChunk({
+      content: 'package a.b;\n\nclass Caller { void methodOne() { Target.doSomething(); } }',
+      metadata: {
+        file: 'src/main/java/a/b/Caller.java',
+        startLine: 1,
+        endLine: 3,
+        type: 'function',
+        symbolName: 'methodOne',
+        symbolType: 'method',
+        language: 'java',
+        callSites: [{ symbol: 'Target', line: 3 }],
+      },
+    });
+    const callerMethodTwo = createTestChunk({
+      content: 'package a.b;\n\nclass Caller { void methodTwo() { Target.doSomethingElse(); } }',
+      metadata: {
+        file: 'src/main/java/a/b/Caller.java',
+        startLine: 5,
+        endLine: 7,
+        type: 'function',
+        symbolName: 'methodTwo',
+        symbolType: 'method',
+        language: 'java',
+        callSites: [{ symbol: 'Target', line: 7 }],
+      },
+    });
+
+    const graph = buildDependencyGraph([targetChunk, callerMethodOne, callerMethodTwo]);
+    const callers = graph.getCallers('src/main/java/a/b/Target.java', 'Target');
+
+    // Caller.java is ALSO a valid same-package referrer for the new tier
+    // (same package, textually references 'Target') -- so `jvmExtra` WOULD
+    // resolve it too, if the filter in `unionJvmSamePackageTier` were
+    // missing or wrong. The assertion below is deliberately NOT "no
+    // duplicate filepaths" (two real call sites legitimately sharing one
+    // filepath is normal and expected, both before and after this change) —
+    // it specifically checks that `base`'s two ORIGINAL entries (their real
+    // symbolNames and call-site lines) survive untouched, and that no THIRD,
+    // jvmExtra-shaped entry (which would carry a different, representative-
+    // chunk symbolName/line — see `buildRepresentativeEdge`) was added.
+    expect(callers).toHaveLength(2);
+    expect(callers.every(c => c.caller.filepath === 'src/main/java/a/b/Caller.java')).toBe(true);
+    expect(callers.map(c => c.caller.symbolName).sort()).toEqual(['methodOne', 'methodTwo']);
+    expect(callers.map(c => c.callSiteLine).sort((a, b) => a - b)).toEqual([3, 7]);
+    expect(callers.every(c => c.provenance === 'namespace-inferred')).toBe(true);
+  });
+
+  it('AC6 the inverted-gate divergence is intentional: findDependents (symbol-level) and getCallers legitimately disagree for the identical declared-type symbol', () => {
+    const targetChunk = createTestChunk({
+      content: 'package a.b;\n\npublic class Target { }',
+      metadata: {
+        file: 'src/main/java/a/b/Target.java',
+        startLine: 1,
+        endLine: 3,
+        type: 'class',
+        symbolName: 'Target',
+        symbolType: 'class',
+        language: 'java',
+        exports: ['Target'],
+      },
+    });
+    // A REAL import-verified caller with a real call site.
+    const importCaller = createTestChunk({
+      content:
+        'package x.y;\n\nimport a.b.Target;\n\nclass ImportCaller { void run() { Target.doSomething(); } }',
+      metadata: {
+        file: 'src/main/java/x/y/ImportCaller.java',
+        startLine: 1,
+        endLine: 3,
+        type: 'class',
+        symbolName: 'ImportCaller',
+        symbolType: 'class',
+        language: 'java',
+        importedSymbols: { 'src/main/java/a/b/Target': ['Target'] },
+        callSites: [{ symbol: 'Target', line: 3 }],
+      },
+    });
+    // A same-package caller with NO import, textual reference only.
+    const samePkgCaller = createTestChunk({
+      content: 'package a.b;\n\nclass SamePkgCaller { private Target target; }',
+      metadata: {
+        file: 'src/main/java/a/b/SamePkgCaller.java',
+        startLine: 1,
+        endLine: 3,
+        type: 'class',
+        symbolName: 'SamePkgCaller',
+        symbolType: 'class',
+        language: 'java',
+      },
+    });
+
+    const chunks = [targetChunk, importCaller, samePkgCaller];
+    const graph = buildDependencyGraph(chunks);
+
+    // getCallers (this PR's new tier) finds BOTH: the import-verified caller
+    // via the ordinary chain, AND the same-package caller via the new tier
+    // (fires unconditionally for a JVM type-symbol query, regardless of
+    // whether the base tier already found something).
+    const callers = graph.getCallers('src/main/java/a/b/Target.java', 'Target');
+    expect(callers.map(c => c.caller.filepath).sort()).toEqual([
+      'src/main/java/a/b/SamePkgCaller.java',
+      'src/main/java/x/y/ImportCaller.java',
+    ]);
+
+    // findDependents (Phase 1's file-level JVM recovery, `dependency-analyzer.ts`)
+    // finds ONLY the import-verified caller here — its JVM same-package
+    // recovery (`enrichWithJvmSamePackageDependents`) is gated to fire ONLY
+    // when `symbol` is undefined AND the import graph found LITERALLY ZERO
+    // dependents; neither holds here (a `symbol` was passed, AND the import
+    // graph already found `importCaller`), so it never runs and
+    // `samePkgCaller` is never recovered at the findDependents layer.
+    //
+    // This is a DELIBERATE, disclosed divergence, not a bug: the two
+    // mechanisms' firing conditions are exact inverses of each other by
+    // design (findDependents' recovery only fires on a zero-result miss;
+    // getCallers' new tier fires unconditionally for any JVM type symbol) —
+    // see dependency-analyzer.ts's `enrichWithJvmSamePackageDependents` doc
+    // comment and the "What does NOT change" section of #1005 Phase 2's
+    // design. A future reader must not "fix" this as an inconsistency.
+    const result = findDependents(
+      chunks,
+      'src/main/java/a/b/Target.java',
+      () => {
+        // Intentionally empty -- no log assertions in this test.
+      },
+      '',
+      'Target',
+    );
+    expect(result.dependents.map(d => d.filepath)).toEqual(['src/main/java/x/y/ImportCaller.java']);
+  });
+});
+
+describe('buildDependencyGraph — JVM same-package index built once per build (#1005 Phase 2 §5-f)', () => {
+  it('invokes buildJvmSamePackageIndex at most once across many distinct getCallers queries within one buildDependencyGraph call', () => {
+    const spy = vi.spyOn(jvmSignals, 'buildJvmSamePackageIndex');
+    spy.mockClear();
+
+    const chunks: CodeChunk[] = ['One', 'Two', 'Three'].map(name =>
+      createTestChunk({
+        content: `package a.b;\n\npublic class ${name} { }`,
+        metadata: {
+          file: `src/main/java/a/b/${name}.java`,
+          startLine: 1,
+          endLine: 3,
+          type: 'class',
+          symbolName: name,
+          symbolType: 'class',
+          language: 'java',
+          exports: [name],
+        },
+      }),
+    );
+
+    const graph = buildDependencyGraph(chunks);
+
+    // Never queried before this point -- the index must be built lazily on
+    // the FIRST of these, not eagerly inside buildDependencyGraph itself.
+    expect(spy).not.toHaveBeenCalled();
+
+    graph.getCallers('src/main/java/a/b/One.java', 'One');
+    graph.getCallers('src/main/java/a/b/Two.java', 'Two');
+    graph.getCallers('src/main/java/a/b/Three.java', 'Three');
+    graph.getCallers('src/main/java/a/b/One.java', 'One'); // repeat query
+
+    // Built once, then REUSED for every subsequent query in this same
+    // buildDependencyGraph call -- never rebuilt per filepath, per call, or
+    // even on a repeat query for the same filepath. Mirrors #1101's
+    // RecoveryIndexes discipline for findDependents.
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    spy.mockRestore();
+  });
+
+  it('never builds the JVM index at all for a non-JVM query, even across a build that also contains JVM chunks', () => {
+    const spy = vi.spyOn(jvmSignals, 'buildJvmSamePackageIndex');
+    spy.mockClear();
+
+    const jvmChunk = createTestChunk({
+      content: 'package a.b;\n\npublic class Target { }',
+      metadata: {
+        file: 'src/main/java/a/b/Target.java',
+        startLine: 1,
+        endLine: 3,
+        type: 'class',
+        symbolName: 'Target',
+        symbolType: 'class',
+        language: 'java',
+        exports: ['Target'],
+      },
+    });
+    const tsChunk = createTestChunk({
+      metadata: {
+        file: 'src/utils/validate.ts',
+        startLine: 1,
+        endLine: 5,
+        type: 'function',
+        symbolName: 'validateEmail',
+        symbolType: 'function',
+        language: 'typescript',
+        exports: ['validateEmail'],
+      },
+    });
+
+    const graph = buildDependencyGraph([jvmChunk, tsChunk]);
+    graph.getCallers('src/utils/validate.ts', 'validateEmail');
+
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // isPreciseProvenance — the "verified vs. inferred" boundary consumed by
 // blast-radius-render.ts's Confidence column. `import-only` is precise: the
 // import IS verified for this exact symbol (see resolveOneChunkImports), it
@@ -1470,19 +1944,28 @@ describe('buildDependencyGraph <-> findDependents subset property (#1015 fix dir
     // Intentionally empty.
   }
 
-  // NOTE: `getCallers` returns the FIRST non-empty tier for a given
-  // `file::symbol` key (`callerEdges` -- which is where `import-verified` AND
+  // NOTE: within `resolveBaseTier` (the pre-#1005 chain), `getCallers`
+  // returns the FIRST non-empty tier for a given `file::symbol` key
+  // (`callerEdges` -- which is where `import-verified` AND
   // `symbol-name-match` both land, since both are written during the same
   // build pass -- then `importOnlyEdges`, then the C# fallback, then
   // require-only, last). That means `import-only` and a real call-site edge
-  // for the identical key can never BOTH appear in one `getCallers` result
-  // (`buildImportOnlyEdges` explicitly skips any key already covered by a
-  // real edge -- see its own doc comment), and likewise `require-only` never
-  // appears when a stronger tier already resolved the same key. Each tier is
-  // therefore exercised in its OWN minimal fixture below rather than one
-  // combined scenario -- forcing two tiers into a single `getCallers` call
-  // would just prove which one wins the priority order, not the subset
-  // property this describe block exists to check.
+  // for the identical key can never BOTH appear in one `resolveBaseTier`
+  // result (`buildImportOnlyEdges` explicitly skips any key already covered
+  // by a real edge -- see its own doc comment), and likewise `require-only`
+  // never appears when a stronger tier already resolved the same key. Each
+  // tier is therefore exercised in its OWN minimal fixture below rather than
+  // one combined scenario -- forcing two BASE tiers into a single
+  // `getCallers` call would just prove which one wins the priority order,
+  // not the subset property this describe block exists to check.
+  //
+  // #1005 Phase 2 makes this UNION -- not "first non-empty wins" -- true one
+  // level up: `getCallers` itself unions `resolveBaseTier`'s result with the
+  // JVM same-package tier (`resolveJvmSamePackageTier`), so a `namespace-inferred`
+  // JVM edge and an `import-verified` base edge for the SAME key legitimately
+  // can both appear in one `getCallers` result now -- see the
+  // "buildDependencyGraph — JVM same-package call-graph tier (#1005 Phase 2)"
+  // describe block below for that behavior, which is intentional, not a bug.
 
   it('import-only: the recovered caller file is already present in dependents (PHP PricingService shape)', () => {
     const classChunk = createTestChunk({

--- a/packages/parser/src/graph/dependency-graph.ts
+++ b/packages/parser/src/graph/dependency-graph.ts
@@ -40,6 +40,11 @@ import { importMatchesTarget, normalizePath } from '../utils/path-matching.js';
 import { detectLanguage } from '../ast/parser.js';
 import { findCSharpTypeReferenceDependents } from '../csharp-type-reference-signals.js';
 import { callerSymbolFor } from '../dependency-analyzer.js';
+import {
+  buildJvmSamePackageIndex,
+  resolveJvmSamePackageDependentsForType,
+  type JvmSamePackageIndex,
+} from '../jvm-same-package-signals.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -78,9 +83,15 @@ import { callerSymbolFor } from '../dependency-analyzer.js';
  *   method whose name matches one declared on it; the class import is solid,
  *   the specific method attribution is inferred.
  * - `namespace-inferred`: no import at all — resolved via a same-namespace/
- *   same-directory convention (PHP/Python/Rust) or, for C#, the #930/#971
- *   type-reference-matching fallback (`findCSharpTypeReferenceDependents`).
- *   The weakest tier: a real structural signal, never an import edge.
+ *   same-directory convention (PHP/Python/Rust), for C#, the #930/#971
+ *   type-reference-matching fallback (`findCSharpTypeReferenceDependents`),
+ *   OR, for Java/Kotlin (#1005 Phase 2), the type-scoped same-package
+ *   resolver (`resolveJvmSamePackageDependentsForType`) — a same-package
+ *   reference needs NO import statement at all (JLS §6.5.5.1), so this tier
+ *   is pinned here and never `import-only`: tagging it `import-only` would
+ *   fabricate the exact claim `import-only`/`isImportOnlyEvidenceTier` exist
+ *   to make honestly (see that predicate's doc comment). The weakest tier: a
+ *   real structural signal, never an import edge.
  */
 export type EdgeProvenance =
   | 'same-file'
@@ -294,6 +305,12 @@ function createNormalizer(workspaceRoot: string): (p: string) => string {
  *    for languages (Ruby) whose import statement names a FILE, never a
  *    symbol, so passes 2-4 (all keyed on `importedSymbols`) have nothing to
  *    match on at all — see `buildRawImportsByFile`/`resolveRequireOnlyFallback`.
+ *
+ * `getCallers` itself resolves in two stages (#1005 Phase 2): `resolveBaseTier`
+ * runs the ENTIRE chain above (unchanged), then `resolveJvmSamePackageTier`
+ * (Java/Kotlin only) is UNIONED on top rather than tried as another
+ * early-return branch — see `unionJvmSamePackageTier`'s doc comment for why a
+ * single union point, not one at each intermediate step, is load-bearing.
  */
 export function buildDependencyGraph(chunks: CodeChunk[], workspaceRoot = ''): DependencyGraph {
   const normalize = createNormalizer(workspaceRoot);
@@ -302,36 +319,36 @@ export function buildDependencyGraph(chunks: CodeChunk[], workspaceRoot = ''): D
   const callerEdges = buildCallerEdges(chunks, chunkImportMaps, exportIndex);
   const importOnlyEdges = buildImportOnlyEdges(chunkImportMaps, callerEdges, chunksByFile);
   const rawImportsByFile = buildRawImportsByFile(chunks);
-  const csharpDependentFilesCache = new Map<string, string[] | null>();
-  const requireOnlyCache = new Map<string, string[] | null>();
+  const baseTierCtx: BaseTierContext = {
+    chunks,
+    chunksByFile,
+    callerEdges,
+    importOnlyEdges,
+    rawImportsByFile,
+    normalize,
+    csharpDependentFilesCache: new Map<string, string[] | null>(),
+    requireOnlyCache: new Map<string, string[] | null>(),
+  };
+  // Lazily built at most once per `buildDependencyGraph` call (#1005 Phase 2
+  // §5-f) -- never per-filepath-per-call. Mirrors #1101's
+  // `ctx.recoveryIndexes.jvm ??= buildJvmSamePackageIndex(...)` discipline in
+  // `dependency-analyzer.ts`, just scoped to this one build instead of a
+  // caller-supplied bag: a project-wide index rebuild costs tens of
+  // milliseconds, so paying it once per query here (as the C# fallback's
+  // OLDER per-filepath cache does — see `getCSharpDependentFiles`) would not
+  // scale to a project-wide BFS or blast-radius walk.
+  const jvmTierCache: JvmTierCache = {};
 
   const getCallers = (filepath: string, symbolName: string): CallerEdge[] => {
-    const key = `${filepath}::${symbolName}`;
-    const direct = callerEdges.get(key);
-    if (direct && direct.length > 0) return direct;
-
-    const importOnly = importOnlyEdges.get(key);
-    if (importOnly && importOnly.length > 0) return importOnly;
-
-    const csharpFallback = resolveCSharpFallback(
+    const base = resolveBaseTier(filepath, symbolName, baseTierCtx);
+    const jvmExtra = resolveJvmSamePackageTier(
       filepath,
       symbolName,
       chunks,
       chunksByFile,
-      csharpDependentFilesCache,
+      jvmTierCache,
     );
-    if (csharpFallback && csharpFallback.length > 0) return csharpFallback;
-
-    return (
-      resolveRequireOnlyFallback(
-        filepath,
-        symbolName,
-        rawImportsByFile,
-        chunksByFile,
-        normalize,
-        requireOnlyCache,
-      ) ?? []
-    );
+    return unionJvmSamePackageTier(base, jvmExtra);
   };
 
   return {
@@ -339,6 +356,121 @@ export function buildDependencyGraph(chunks: CodeChunk[], workspaceRoot = ''): D
     getCallersTransitive: (filepath, symbolName, opts = {}) =>
       bfsTransitiveCallers(getCallers, filepath, symbolName, opts),
   };
+}
+
+/** Everything `resolveBaseTier` needs — the pre-#1005 `getCallers` chain, unchanged, just threaded explicitly instead of closed over. */
+interface BaseTierContext {
+  chunks: CodeChunk[];
+  chunksByFile: Map<string, CodeChunk[]>;
+  callerEdges: Map<string, CallerEdge[]>;
+  importOnlyEdges: Map<string, CallerEdge[]>;
+  rawImportsByFile: Map<string, string[]>;
+  normalize: (p: string) => string;
+  csharpDependentFilesCache: Map<string, string[] | null>;
+  requireOnlyCache: Map<string, string[] | null>;
+}
+
+/**
+ * The ENTIRE pre-#1005 `getCallers` resolution chain, verbatim: direct
+ * call-site edges → import-only edges → C# namespace fallback → require-only
+ * fallback, each an early return at the first non-empty tier. Unchanged by
+ * #1005 Phase 2 — the new JVM tier is unioned on top of this function's
+ * result by `getCallers`, never mixed into this chain — see
+ * `unionJvmSamePackageTier`'s doc comment for why.
+ */
+function resolveBaseTier(filepath: string, symbolName: string, ctx: BaseTierContext): CallerEdge[] {
+  const key = `${filepath}::${symbolName}`;
+  const direct = ctx.callerEdges.get(key);
+  if (direct && direct.length > 0) return direct;
+
+  const importOnly = ctx.importOnlyEdges.get(key);
+  if (importOnly && importOnly.length > 0) return importOnly;
+
+  const csharpFallback = resolveCSharpFallback(
+    filepath,
+    symbolName,
+    ctx.chunks,
+    ctx.chunksByFile,
+    ctx.csharpDependentFilesCache,
+  );
+  if (csharpFallback && csharpFallback.length > 0) return csharpFallback;
+
+  return (
+    resolveRequireOnlyFallback(
+      filepath,
+      symbolName,
+      ctx.rawImportsByFile,
+      ctx.chunksByFile,
+      ctx.normalize,
+      ctx.requireOnlyCache,
+    ) ?? []
+  );
+}
+
+/** Holds the lazily-built JVM index for one `buildDependencyGraph` call — see that function's doc comment on why this must be built at most once. */
+interface JvmTierCache {
+  index?: JvmSamePackageIndex;
+}
+
+/**
+ * The new tier (#1005 Phase 2): Java/Kotlin same-package callers of a
+ * declared TYPE symbol, via `resolveJvmSamePackageDependentsForType`
+ * (per-type-scoped — see that function's doc comment for why the file-level
+ * resolver would misattribute callers across sibling declarations in a
+ * multi-type file). `[]` for every non-JVM language, or when `symbolName`
+ * isn't one of `filepath`'s own declared top-level class/interface names (G5
+ * — a method/function seed structurally can't resolve here). Cheap language
+ * check first so a non-JVM corpus never pays the index build at all, not
+ * even once.
+ */
+function resolveJvmSamePackageTier(
+  filepath: string,
+  symbolName: string,
+  chunks: CodeChunk[],
+  chunksByFile: Map<string, CodeChunk[]>,
+  cache: JvmTierCache,
+): CallerEdge[] {
+  const language = detectLanguage(filepath);
+  if (language !== 'java' && language !== 'kotlin') return [];
+
+  cache.index ??= buildJvmSamePackageIndex(chunks);
+  const dependentFiles = resolveJvmSamePackageDependentsForType(filepath, symbolName, cache.index);
+  if (dependentFiles.length === 0) return [];
+
+  return dependentFiles.map(file =>
+    buildRepresentativeEdge(file, chunksByFile, 'namespace-inferred', symbolName),
+  );
+}
+
+/**
+ * ONE union point over the FINAL result of `resolveBaseTier`, not one at each
+ * of its intermediate early-return branches. An earlier draft of this design
+ * unioned the new tier in at three separate points in that chain; that shape
+ * left the import-only union point completely untested, and a variant that
+ * silently dropped just that one point still passed every other check while
+ * losing real edges. Collapsing to one union point makes that defect class
+ * structurally impossible instead of something a test has to catch.
+ *
+ * The dedup predicate is deliberately NOT "unique by filepath" (a single file
+ * legitimately appears more than once in `base` — one entry per real call
+ * site — and collapsing that would destroy real edges) and NOT a plain
+ * concat (every downstream consumer counts EDGES, not distinct files:
+ * `agent-tools.ts` reads `callers.length` directly, and `blast-radius.ts`
+ * dedupes on `` `${filepath}::${symbolName}` ``, under which the same file
+ * could survive as two distinct "dependents" — one via a real call-site
+ * edge, one via `jvmExtra`'s representative-chunk symbolName — inflating
+ * `dependentCount`). The correct predicate: drop any `jvmExtra` entry whose
+ * caller filepath ALREADY appears anywhere in `base`, regardless of that
+ * entry's symbolName; `base` itself is never touched. `jvmExtra` is appended
+ * LAST (not prepended) so a BFS budget (`bounded-bfs.ts`'s `expandFrontier`)
+ * spends on the existing, typically more precise tiers first when `maxNodes`
+ * truncates mid-array.
+ */
+function unionJvmSamePackageTier(base: CallerEdge[], jvmExtra: CallerEdge[]): CallerEdge[] {
+  if (jvmExtra.length === 0) return base;
+
+  const seenFilepaths = new Set(base.map(e => e.caller.filepath));
+  return [...base, ...jvmExtra.filter(e => !seenFilepaths.has(e.caller.filepath))];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/parser/src/jvm-same-package-signals.test.ts
+++ b/packages/parser/src/jvm-same-package-signals.test.ts
@@ -562,4 +562,103 @@ describe('cross-check: content-derived package agrees with path-derived package'
     expect(index.packageByFile.get(file)).toBe('com.beust.klaxon');
     expect(javaPackageRelativePath(file.replace(/\.kt$/, ''))).toBeNull();
   });
+
+  // #1005 Phase 2 AC7: the two tests above only ever assert AGREEMENT on the
+  // subset of files where BOTH notions already derive something -- a weak
+  // canary, since it can't distinguish "the two mechanisms are consistent"
+  // from "we only ever checked the cases where they were never going to
+  // disagree". This test instead classifies a small representative fixture
+  // set into the four possible outcomes and pins the exact COUNT/shape of
+  // each bucket, so a future change that shifts which bucket a file falls
+  // into (e.g. a `derivePackage` regex tweak, or a `javaPackageRelativePath`
+  // layout extension) trips this test instead of passing silently.
+  it('pins the exact shape of the residual set where path-derived and content-derived package notions disagree or one is undefined', () => {
+    function pathDerivedPackage(file: string): string | null {
+      const relative = javaPackageRelativePath(file.replace(/\.(java|kt)$/, ''));
+      if (relative === null) return null;
+      const segments = relative.split('/').slice(0, -1);
+      return segments.length > 0 ? segments.join('.') : null;
+    }
+
+    const cases: Array<{ label: string; file: string; content: string }> = [
+      {
+        // Both derivable, and they agree -- the case the earlier "weak
+        // canary" tests already cover.
+        label: 'agree-both-derivable',
+        file: 'src/main/java/a/b/Foo.java',
+        content: 'package a.b;\n\nclass Foo { }',
+      },
+      {
+        // Content-derivable (a `package` line is present), but NOT under
+        // the Standard Directory Layout `javaPackageRelativePath` requires
+        // -- path-derivation fails.
+        label: 'content-only',
+        file: 'flat/NoSourceRoot.java',
+        content: 'package a.b;\n\nclass NoSourceRoot { }',
+      },
+      {
+        // Under the Standard Directory Layout (path-derivable), but its
+        // chunk content carries no `package` line at all (e.g. a stale
+        // extraction, or Java's legal-but-rare unnamed/default package) --
+        // content-derivation fails (G3).
+        label: 'path-only',
+        file: 'src/main/java/a/b/NoPackageStatement.java',
+        content: 'class NoPackageStatement { }',
+      },
+      {
+        // Neither notion can derive a package at all.
+        label: 'neither-derivable',
+        file: 'NoPackageNoRoot.java',
+        content: 'class NoPackageNoRoot { }',
+      },
+    ];
+
+    const chunks: CodeChunk[] = cases.map(({ file, content }) =>
+      makeChunk({
+        file,
+        content,
+        symbolName: file
+          .split('/')
+          .pop()!
+          .replace(/\.java$/, ''),
+        symbolType: 'class',
+      }),
+    );
+    const index = buildJvmSamePackageIndex(chunks);
+
+    const buckets = { agreeBothDerivable: 0, contentOnly: 0, pathOnly: 0, neitherDerivable: 0 };
+    for (const { label, file } of cases) {
+      const contentDerived = index.packageByFile.get(file);
+      const pathDerived = pathDerivedPackage(file);
+
+      if (contentDerived !== undefined && pathDerived !== null) {
+        expect(contentDerived).toBe(pathDerived); // the "agree" half of this bucket
+        buckets.agreeBothDerivable += 1;
+      } else if (contentDerived !== undefined && pathDerived === null) {
+        buckets.contentOnly += 1;
+      } else if (contentDerived === undefined && pathDerived !== null) {
+        buckets.pathOnly += 1;
+      } else {
+        buckets.neitherDerivable += 1;
+      }
+
+      // Cross-check the fixture is actually shaped the way its label claims.
+      expect(label).toBe(
+        contentDerived !== undefined && pathDerived !== null
+          ? 'agree-both-derivable'
+          : contentDerived !== undefined
+            ? 'content-only'
+            : pathDerived !== null
+              ? 'path-only'
+              : 'neither-derivable',
+      );
+    }
+
+    expect(buckets).toEqual({
+      agreeBothDerivable: 1,
+      contentOnly: 1,
+      pathOnly: 1,
+      neitherDerivable: 1,
+    });
+  });
 });

--- a/packages/parser/src/jvm-same-package-signals.ts
+++ b/packages/parser/src/jvm-same-package-signals.ts
@@ -665,3 +665,44 @@ export function findJvmSamePackageDependents(targetFile: string, chunks: CodeChu
   if (!isJvmLanguage(targetFile)) return [];
   return resolveJvmSamePackageDependents(targetFile, buildJvmSamePackageIndex(chunks));
 }
+
+/**
+ * #1005 Phase 2: the PER-TYPE twin of `resolveJvmSamePackageDependents`, for
+ * `graph/dependency-graph.ts`'s call-graph tier (`getCallers(filepath,
+ * symbolName)` is always scoped to ONE symbol, never "every dependent of this
+ * file"). Wraps the same `collectDependentsForName` the file-level resolver
+ * already unions across all of `targetFile`'s declared types -- this is an
+ * ADDITION, not a modification: the file-level resolver's contract and
+ * callers (`findDependents`'s recovery tier) are untouched.
+ *
+ * Scoping matters: a JVM file can top-level-declare MORE than one
+ * class/interface (idiomatic for sealed hierarchies or grouped data
+ * classes), and the file-level resolver's union means "the set of files that
+ * reference ANY of this file's declared types" -- correct for "who depends
+ * on this FILE", but wrong for "who calls THIS type": a reference to a
+ * sibling type declared in the same file would be misattributed as a
+ * reference to `typeName`. This function applies the exact same G3
+ * (package-derivable) and target-is-test gates the file-level resolver does,
+ * but resolves candidates for `typeName` alone -- returning `[]` immediately
+ * when `typeName` isn't one of `targetFile`'s own TOP-LEVEL declared
+ * class/interface names (G5's type-only restriction still applies; a bare
+ * method/function seed is never resolvable here, by construction).
+ */
+export function resolveJvmSamePackageDependentsForType(
+  targetFile: string,
+  typeName: string,
+  index: JvmSamePackageIndex,
+): string[] {
+  if (!isJvmLanguage(targetFile)) return [];
+
+  const targetPackage = index.packageByFile.get(targetFile);
+  if (targetPackage === undefined) return []; // G3
+
+  const isOwnDeclaredType = index.declarations.some(
+    decl => decl.file === targetFile && decl.typeName === typeName,
+  );
+  if (!isOwnDeclaredType) return [];
+
+  const targetIsTest = index.isTestByFile.get(targetFile) ?? false;
+  return collectDependentsForName(targetFile, targetPackage, targetIsTest, typeName, index).sort();
+}

--- a/packages/review/test/blast-radius.test.ts
+++ b/packages/review/test/blast-radius.test.ts
@@ -214,4 +214,90 @@ describe('computeBlastRadius', () => {
     expect(report.truncated).toBe(true);
     expect(report.entries[0].dependents).toHaveLength(2);
   });
+
+  // #1005 Phase 2, AC10: a disclosed, NOT-fixed-here limitation. The JVM
+  // same-package call-graph tier (dependency-graph.ts's `getCallers`) can
+  // legitimately surface far more same-package callers for a popular
+  // declared type than any TS/JS seed typically has -- a real fan-in
+  // increase, not a bug. Once that fan-in exceeds `computeBlastRadius`'s
+  // DEFAULT maxNodes (30, not overridden below -- the point is that this is
+  // a realistic budget, not an artificially small one), the walk saturates
+  // at hop 1 and NEVER reaches hop 2 for that seed at all, even for a caller
+  // sitting right at hop 1 with its own further caller waiting one hop away.
+  // This test pins that as the CURRENT, EXPECTED behavior (the existing
+  // `maxNodes`/depth policy trading recall for a bounded walk), so a future
+  // change doesn't silently alter this semantics without a test noticing --
+  // see the #1005 Phase 2 PR body for the filed follow-up asking whether
+  // this file's defaults should be revisited now that JVM recall improved.
+  it('AC10 (disclosed limitation, not fixed here): a very-high-fan-in JVM type seed saturates the default maxNodes at hop 1, losing all hop-2 reach for that seed', () => {
+    const target = createTestChunk({
+      content: 'package a.b;\n\npublic class Target { }',
+      metadata: {
+        file: 'src/main/java/a/b/Target.java',
+        startLine: 1,
+        endLine: 3,
+        type: 'class',
+        symbolName: 'Target',
+        symbolType: 'class',
+        language: 'java',
+        exports: ['Target'],
+      },
+    });
+
+    // 35 same-package callers -- more than DEFAULT_MAX_NODES (30) -- each a
+    // real, textual same-package reference with no import at all (the exact
+    // shape the new tier exists to resolve).
+    const sameCallers = Array.from({ length: 35 }, (_, i) =>
+      createTestChunk({
+        content: `package a.b;\n\nclass Caller${i} { void run() { Target.doSomething(); } }`,
+        metadata: {
+          file: `src/main/java/a/b/Caller${i}.java`,
+          startLine: 1,
+          endLine: 3,
+          type: 'class',
+          symbolName: `Caller${i}`,
+          symbolType: 'class',
+          language: 'java',
+        },
+      }),
+    );
+
+    // A real, verified hop-2 caller of Caller0 specifically -- reachable
+    // only if the BFS gets past hop 1 for that particular node, which the
+    // default budget (saturated by the other 34 same-package siblings at
+    // hop 1) never lets it do.
+    const hop2Caller = createTestChunk({
+      content:
+        'package x.y;\n\nimport a.b.Caller0;\n\nclass Consumer { void run() { Caller0.run(); } }',
+      metadata: {
+        file: 'src/main/java/x/y/Consumer.java',
+        startLine: 1,
+        endLine: 3,
+        type: 'class',
+        symbolName: 'Consumer',
+        symbolType: 'class',
+        language: 'java',
+        importedSymbols: { 'src/main/java/a/b/Caller0': ['Caller0'] },
+        callSites: [{ symbol: 'run', line: 3 }],
+      },
+    });
+
+    const repoChunks = [target, ...sameCallers, hop2Caller];
+    const graph = buildDependencyGraph(repoChunks);
+
+    // Confirm the fan-in is real before blaming the budget for anything.
+    expect(graph.getCallers('src/main/java/a/b/Target.java', 'Target')).toHaveLength(35);
+
+    const report = computeBlastRadius([target], graph, repoChunks); // default maxNodes (30)
+
+    expect(report.entries).toHaveLength(1);
+    const entry = report.entries[0];
+    expect(entry.truncated).toBe(true);
+    expect(entry.dependents).toHaveLength(30);
+    // Zero hop-2 reach: truncation halts the walk before ANY hop-1 node is
+    // expanded to hop 2, regardless of which 30 of the 35 hop-1 callers
+    // survived the budget.
+    expect(entry.dependents.every(d => d.hops === 1)).toBe(true);
+    expect(entry.dependents.find(d => d.filepath.includes('Consumer'))).toBeUndefined();
+  });
 });

--- a/packages/review/test/blast-radius.test.ts
+++ b/packages/review/test/blast-radius.test.ts
@@ -246,7 +246,13 @@ describe('computeBlastRadius', () => {
 
     // 35 same-package callers -- more than DEFAULT_MAX_NODES (30) -- each a
     // real, textual same-package reference with no import at all (the exact
-    // shape the new tier exists to resolve).
+    // shape the new tier exists to resolve). `exports` is set on each so
+    // `Caller0` specifically is a real, resolvable target for the hop-2
+    // fixture below (review finding on this PR: without it, `Caller0` was
+    // never in `exportIndex` at all, so the "positive control" import-only
+    // edge from Consumer could never resolve -- the zero-hop-2-reach
+    // assertion was passing for the wrong reason, an unreachable fixture
+    // rather than a genuine budget effect).
     const sameCallers = Array.from({ length: 35 }, (_, i) =>
       createTestChunk({
         content: `package a.b;\n\nclass Caller${i} { void run() { Target.doSomething(); } }`,
@@ -258,6 +264,7 @@ describe('computeBlastRadius', () => {
           symbolName: `Caller${i}`,
           symbolType: 'class',
           language: 'java',
+          exports: [`Caller${i}`],
         },
       }),
     );
@@ -299,5 +306,18 @@ describe('computeBlastRadius', () => {
     // survived the budget.
     expect(entry.dependents.every(d => d.hops === 1)).toBe(true);
     expect(entry.dependents.find(d => d.filepath.includes('Consumer'))).toBeUndefined();
+
+    // Positive control (review finding on this PR): the assertion above is
+    // only meaningful if Consumer is genuinely reachable at hop 2 when the
+    // budget doesn't truncate -- otherwise it would pass for the wrong
+    // reason (an unreachable fixture, not a budget effect). With a budget
+    // large enough for the whole hop-1 frontier, the walk does expand
+    // Caller0 and finds Consumer at hop 2 via the import-only tier (Consumer
+    // verifiably imports Caller0 via the extension-less resolved-form key;
+    // its own callSite names 'run', which resolves nothing on its own, so
+    // this path is real, not a call-site coincidence).
+    const generous = computeBlastRadius([target], graph, repoChunks, { maxNodes: 200 });
+    const consumer = generous.entries[0].dependents.find(d => d.filepath.includes('Consumer'));
+    expect(consumer?.hops).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

Item 1 of #1005 Phase 2: adds a Java/Kotlin same-package resolution tier to
the call-graph (`packages/parser/src/graph/dependency-graph.ts`'s
`getCallers`/`getCallersTransitive`), closing the gap between Phase 1's
file-level `findDependents` recovery (#1100, merged) and the
symbol/call-site-level graph that `blast-radius.ts`, the agent-review
plugin's `dependentCount`, and the MCP `get_dependents` tool's `importedBy`
evidence field all actually consume.

- **New export**: `resolveJvmSamePackageDependentsForType(targetFile,
  typeName, index)` in `jvm-same-package-signals.ts` — a per-TYPE wrapper
  around the same internal resolution the existing file-level
  `resolveJvmSamePackageDependents` already unions across every declared
  type. Pure addition; the file-level resolver (Phase 1's `findDependents`
  consumer) is untouched.
- **`getCallers` restructured to one union point**: `resolveBaseTier` (the
  entire pre-#1005 chain: direct call-site edges → import-only → C#
  fallback → require-only, verbatim) is unioned with
  `resolveJvmSamePackageTier`'s result, rather than the new tier being
  spliced into multiple early-return branches. This makes it structurally
  impossible for the union to silently skip one intermediate tier (the
  import-only case specifically — see AC4 below).
- **Provenance pinned to `namespace-inferred`, never `import-only`**: a
  same-package reference has no import statement, so tagging it
  `import-only` would fabricate exactly the "verifiably imports" claim
  `get-dependents.ts`'s `importedBy` field exists to make honestly.
  `isImportOnlyEvidenceTier('namespace-inferred')` already returns `false`,
  so this is correctly excluded from that field with no further changes
  needed there.
- **`addSameNamespaceEdges` (the pre-existing same-directory heuristic) is
  untouched** and still fires for Java/Kotlin: it's call-site-level and
  covers method/function seeds the new, type-only tier structurally cannot
  reach (G5 excludes non-type symbols) — this is a deliberate reversal of an
  earlier draft that would have removed it for JVM.
- **JVM index built lazily, at most once per `buildDependencyGraph` call**
  (mirrors #1111's `RecoveryIndexes` discipline), never per-filepath/per-query.
- Updated `EdgeProvenance`'s doc comment and the now-intentionally-stale
  "two tiers can never both appear" test comment in
  `dependency-graph.test.ts` to describe the new union behavior.

### What does NOT change

- Phase 1's six gates in `jvm-same-package-signals.ts`.
- `findDependents`'s existing JVM recovery tier
  (`enrichWithJvmSamePackageDependents`) — still fires only when `symbol` is
  undefined AND the import graph found zero dependents. This tier's
  precondition is exactly inverted (fires for any JVM type-symbol query,
  unconditionally) — the two mechanisms will legitimately disagree for the
  same file (AC6 below), which is intentional, not a bug.
- Scope stays Phase 2 only: no Kotlin `typealias`, Java annotations, or
  Kotlin top-level `fun`/`val` targets. `typealias` deferral has a real cost
  worth naming: `actual typealias` declarations are exactly what creates
  package-local-uniqueness ambiguity for the corresponding `expect` type on
  multiplatform Kotlin projects.

## Acceptance criteria (§6 of the plan)

All ten verified with real tests (not just read-through), in
`packages/parser/src/graph/dependency-graph.test.ts` unless noted:

1. **Per-type scoping** — a Kotlin file with sibling top-level `Foo`/`Bar`;
   a referrer that only references `Foo` shows up for `getCallers(file,
   'Foo')`, not `getCallers(file, 'Bar')`. ✅
2. **Provenance pinned, isolated from the pre-existing heuristic** — a
   fixture where BOTH the old directory heuristic and the new tier
   contribute `namespace-inferred` edges to the same result; asserts the
   NEW tier's specific edge is tagged correctly, not a blanket check over
   the whole array. ✅
3. **No method/function-seed regression** — a Java same-directory call site
   to a plain method returns exactly what it did before (via the retained
   heuristic); the new tier contributes nothing (G5). ✅
4. **The import-only union point** — a 3-file `src/main/java/...` fixture:
   zero call sites anywhere, one same-package field-reference caller (no
   import) and one different-package field-reference caller with a
   resolved import. `getCallers` returns BOTH. This is the specific
   fixture shape a previous draft's own verification missed; my
   single-union-point structure makes it pass by construction (mentally
   verified: an "only union after direct edges" variant would drop the
   same-package caller here, while AC1–3 above would still pass). ✅
5. **Union predicate correctness** — two real call sites in one caller file
   (already in `base`), and the new tier also resolves that same file:
   result keeps `base`'s two original entries (exact symbolNames/lines)
   unchanged, no third entry added. ✅
6. **Inverted-gate divergence, pinned as intentional** — a file with both a
   real import-verified dependent and a same-package dependent:
   `getCallers` finds both, `findDependents` (symbol-level) finds only the
   import-verified one, with an inline comment explaining the exactly-
   inverted firing conditions. ✅
7. **Java package-derivation residual, shape not just agreement** — added
   to `jvm-same-package-signals.test.ts`: classifies a small fixture set
   into all 4 buckets (agree-both-derivable / content-only / path-only /
   neither-derivable) and pins the exact count of each, closing Phase 1's
   deferred question with more than a weak "they agree where both exist"
   canary. ✅
8. **Item 2 scope** (path-form honesty) — N/A for this PR, will ship with
   Item 2.
9. **Index-state-matrix stays green, confirmed not assumed** —
   `packages/cli/test/integration/index-state-matrix.test.ts` (49 tests)
   ran clean; this PR adds no `createVectorDB` call site or MCP handler.
   ✅
10. **BFS budget disclosure, not a fix** — new test in
    `packages/review/test/blast-radius.test.ts`: a 35-caller same-package
    seed saturates the DEFAULT `maxNodes` (30, not overridden) at hop 1,
    `truncated: true`, zero hop-2 reach, pinned as current/expected
    behavior. Reproduced live against the real OkHttp dogfood run below.
    Follow-up issue filed (see below) asking whether `blast-radius.ts`'s
    defaults should be revisited now that JVM recall has improved — a
    policy question for that file's owners, not solved here. ✅

## Dogfood evidence (verbatim, real OkHttp clone)

Indexed a fresh clone of `square/okhttp` (682 files / 9,033 chunks) with
this branch's built CLI, then called the real, shipped
`@liendev/parser` `buildDependencyGraph`/`getCallers`/`getCallersTransitive`
against the real scanned chunks (via a throwaway script — production
functions, not a spike).

**Before this PR** (`git stash`, same corpus, same query):

```
getCallers(okhttp/src/commonJvmAndroid/kotlin/okhttp3/Cache.kt, Cache) -> 16 edges
  [oop-method-import] x6  (test files constructing Cache via helpers)
  [symbol-name-match] x10 (cross-module test/sample files)

getCallersTransitive(depth=2) -> 19 edges, truncated=false, visitedSymbols=17
```

**After this PR:**

```
getCallers(okhttp/src/commonJvmAndroid/kotlin/okhttp3/Cache.kt, Cache) -> 33 edges
  ...same 16 edges as before, plus 17 NEW [namespace-inferred] edges:
  okhttp/src/commonJvmAndroid/kotlin/okhttp3/CacheControl.kt :: CacheControl
  okhttp/src/commonJvmAndroid/kotlin/okhttp3/DnsCache.kt :: DnsCache
  okhttp/src/commonJvmAndroid/kotlin/okhttp3/EventListener.kt :: EventListener
  okhttp/src/commonJvmAndroid/kotlin/okhttp3/Interceptor.kt :: (module-level)
  okhttp/src/commonJvmAndroid/kotlin/okhttp3/OkHttpClient.kt :: OkHttpClient
  okhttp/src/commonJvmAndroid/kotlin/okhttp3/Request.kt :: Request
  okhttp/src/commonJvmAndroid/kotlin/okhttp3/Response.kt :: Response
  okhttp/src/jvmTest/kotlin/okhttp3/CacheControlJvmTest.kt :: CacheControlJvmTest
  okhttp/src/jvmTest/kotlin/okhttp3/CacheCorruptionTest.kt :: CacheCorruptionTest
  okhttp/src/jvmTest/kotlin/okhttp3/CallTest.kt :: CallTest
  okhttp/src/jvmTest/kotlin/okhttp3/HeadersJvmTest.kt :: HeadersJvmTest
  okhttp/src/jvmTest/kotlin/okhttp3/InterceptorOverridesTest.kt :: InterceptorOverridesTest
  okhttp/src/jvmTest/kotlin/okhttp3/KotlinDeprecationErrorTest.kt :: KotlinDeprecationErrorTest
  okhttp/src/jvmTest/kotlin/okhttp3/KotlinSourceModernTest.kt :: KotlinSourceModernTest
  okhttp/src/jvmTest/kotlin/okhttp3/RequestCommonTest.kt :: RequestCommonTest
  okhttp/src/jvmTest/kotlin/okhttp3/RequestTest.kt :: RequestTest
  okhttp/src/jvmTest/kotlin/okhttp3/TrailersTest.kt :: TrailersTest

getCallersTransitive(depth=2) -> 30 edges, truncated=true, visitedSymbols=1
```

These 17 recovered files reference `Cache` (or, for the `okhttp3` package,
its sibling declarations) with no import statement at all — exactly
Kotlin's same-package visibility rule, and exactly the case this tier
exists to resolve. The `getCallersTransitive` truncation flip
(`false`→`true`, 19→30 edges) is a live reproduction of AC10's disclosed
BFS-budget effect, not a bug.

## Local gate chain (all green)

```
npm run format:check   ✅
npm run lint            ✅ (0 errors, 42 pre-existing warnings, none in touched files)
npm run typecheck       ✅
npm run build            ✅
npm test                 ✅ (64+40+58+75+5 test files, 1957+448+1726+1737+41 = 5,909 tests; one core
                              GC-lock race test flaked once in a parallel full run, passed clean in
                              isolation and in a second full run — pre-existing flake, unrelated to
                              this change)
lien delta                ✅ exit 0 — buildDependencyGraph's own complexity IMPROVED (6→0) from the
                              extraction; all new functions land well under threshold
```

## Follow-up issues filed

1. #1112 — Whether `findDependents`'s zero-only JVM recovery gate should
   become additive too, now that #1111 removed the "rebuilding per-call is
   expensive" cost argument for doing so.
2. #1113 — Whether `blast-radius.ts`'s `maxNodes`/depth defaults should be
   revisited now that JVM call-graph recall has measurably improved (AC10).
3. #1114 — The Kotlin AST extractor not setting `parentClass` on nested
   classes' own chunks, which currently makes nested classes count as
   top-level declarations in `jvm-same-package-signals.ts`'s index.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Java and Kotlin call-graph results by detecting same-package dependencies.
  - Added more accurate per-type dependency attribution for files containing multiple classes.
  - Preserved dependency provenance and removed duplicate results.

- **Bug Fixes**
  - Prevented unrelated types in the same Kotlin file from being incorrectly attributed.
  - Excluded inferred same-package edges from `importedBy` evidence.
  - Maintained result limits and traversal behavior for high fan-in dependencies.

- **Tests**
  - Added comprehensive coverage for JVM package resolution, scoping, caching, deduplication, and language gating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds a Java/Kotlin same-package resolution tier to the symbol-level call graph in `dependency-graph.ts`. The implementation is additive and well-isolated: a new per-type resolver `resolveJvmSamePackageDependentsForType` is unioned onto the existing base-tier result at a single union point, provenance is correctly pinned to `namespace-inferred` (so it is excluded from `import-only` evidence), and the JVM index is built lazily at most once per `buildDependencyGraph` call. The acceptance-criteria tests cover per-type scoping, the import-only union point, deduplication, the intentional `findDependents` divergence, and the BFS budget effect. No logic errors, breaking changes, or silent misbehaviors were found in the changed code.
>
> - Adds `resolveJvmSamePackageDependentsForType` for per-type JVM same-package caller recovery
> - Restructures `getCallers` to union `resolveBaseTier` with the new JVM tier at a single union point
> - Tags new edges `namespace-inferred` so they are excluded from `import-only` evidence
> - Builds the JVM same-package index lazily and caches it per `buildDependencyGraph` call

> [!WARNING]
> 🟡 **Trust: Degraded — budget-starved**
>
> The review stopped after exhausting its token budget before finishing. Treat the findings above as partial.

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 86d567c. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

<!-- lien:attestation -->
Attested: degraded:budget_starved · 666K/788K tokens
<!-- /lien:attestation -->