### PR TITLE
feat(parser,cli): add Kotlin same-package test-association mechanism (#1005 Phase 2, Item 2)

### DIFF
--- a/.changeset/kotlin-test-associations.md
+++ b/.changeset/kotlin-test-associations.md
@@ -1,0 +1,10 @@
+---
+'@liendev/parser': minor
+'@liendev/lien': patch
+---
+
+Add a Kotlin same-package test-association mechanism (#1005 Phase 2, Item 2), shipped in both `@liendev/parser`'s `findTestAssociationsFromChunks` (the shared engine — feeds `lien annotate`, blast-radius test-coverage risk, and the agent-review plugin) and `@liendev/lien`'s `get_files_context` MCP tool (its own separate implementation, mirroring the existing C# tier there).
+
+Like Java's own same-package test convention, a Kotlin test class commonly lives in the same package as its subject with no import connecting them at all — Kotlin's same-package visibility rule needs none. This reuses Phase 1's file-level `resolveJvmSamePackageDependents` (#1100), gated strictly to Kotlin (Java keeps its existing, separate path-based mechanism), and explicitly canonicalizes the query path against the index before resolving — a mismatched path form now resolves correctly instead of silently returning zero associations.
+
+Measured against a real Klaxon (Kotlin) clone: `lien annotate` on `Klaxon.kt`, the library's central class, went from reporting "No test coverage" to 53 real, same-package test files.

--- a/packages/cli/src/mcp/handlers/get-files-context.ts
+++ b/packages/cli/src/mcp/handlers/get-files-context.ts
@@ -20,6 +20,8 @@ import {
   hasEnclosingNamespaceAccess,
   buildCSharpTypeReferenceIndex,
   resolveCSharpTypeReferenceDependents,
+  buildJvmSamePackageIndex,
+  resolveJvmSamePackageDependents,
   MAX_CHUNKS_PER_FILE,
   DEFAULT_COMPLEXITY_DELTA_THRESHOLDS,
   type GoTestCandidate,
@@ -27,6 +29,7 @@ import {
   type JavaTestCandidate,
   type JavaTestDirIndex,
   type CSharpTypeReferenceIndex,
+  type JvmSamePackageIndex,
 } from '@liendev/parser';
 import type { SearchResult, VectorDBInterface } from '@liendev/core';
 
@@ -444,6 +447,66 @@ function collectCSharpNamespaceTestFiles(
 }
 
 /**
+ * #1005 Phase 2, Item 2: true only for Kotlin -- deliberately NOT a
+ * registry-flag predicate like `hasGoSameDirectoryConvention`/
+ * `hasJavaSamePackageConvention`/`hasCSharpEnclosingNamespaceConvention`
+ * above. Java already owns `samePackageTestConvention` and its own
+ * PATH-derived mechanism; this is a SEPARATE, CONTENT-derived mechanism for
+ * Kotlin specifically -- see `@liendev/parser`'s `test-associations.ts`
+ * (`isKotlinFile`) for the full reasoning this mirrors.
+ */
+function isKotlinFile(filepath: string): boolean {
+  return detectLanguage(filepath) === 'kotlin';
+}
+
+/**
+ * #1005 Phase 2, Item 2: Kotlin's same-package type-reference index, built
+ * once per `findTestAssociations` call and reused for every target file
+ * below — mirrors `buildCSharpTestIndexFromChunks` immediately above
+ * exactly, including the same canonicalization: `resolveJvmSamePackageDependents`
+ * needs each chunk's file keyed EXACTLY as it appears in the index (see
+ * that function's doc comment in `@liendev/parser`), and `chunk.metadata.file`
+ * can be absolute here.
+ */
+function buildJvmTestIndexFromChunks(
+  allChunks: SearchResult[],
+  workspaceRoot: string,
+): JvmSamePackageIndex {
+  const canonicalChunks = allChunks.map(chunk => ({
+    ...chunk,
+    metadata: { ...chunk.metadata, file: getCanonicalPath(chunk.metadata.file, workspaceRoot) },
+  }));
+  return buildJvmSamePackageIndex(canonicalChunks);
+}
+
+/**
+ * #1005 Phase 2, Item 2: Kotlin's same-package test convention has no
+ * basename pairing to fall back on the way Java's does (Java keeps its own,
+ * separate `pairJavaBasenameTest` tier above -- this doesn't replace it,
+ * and doesn't apply to Java at all). Reuses `resolveJvmSamePackageDependents`
+ * -- Phase 1's FILE-LEVEL resolver (#1100), the SAME signal `get_dependents`'s
+ * file-level recovery already relies on -- filtered to the test-file subset
+ * of `filepath`'s recovered dependents. Deliberately the file-level
+ * resolver, not #1005 Phase 2 Item 1's per-type
+ * `resolveJvmSamePackageDependentsForType`: "which tests exercise this
+ * file" is inherently a file-level question, and this tool's per-file
+ * `testAssociations` field is file-keyed, not type-keyed. See
+ * `@liendev/parser`'s `test-associations.ts`
+ * (`collectKotlinSamePackageTests`) for the full precision reasoning; this
+ * is `get_files_context`'s own separate implementation of the identical
+ * tier (mirrors `collectCSharpNamespaceTestFiles` immediately above).
+ */
+function collectKotlinSamePackageTestFiles(
+  filepath: string,
+  jvmIndex: JvmSamePackageIndex,
+  workspaceRoot: string,
+): string[] {
+  if (!isKotlinFile(filepath)) return [];
+  const canonicalTarget = getCanonicalPath(filepath, workspaceRoot);
+  return resolveJvmSamePackageDependents(canonicalTarget, jvmIndex).filter(isTestFile);
+}
+
+/**
  * Find test files that import the given source files.
  *
  * Scans all indexed chunks to find test files that have import
@@ -478,6 +541,7 @@ export function findTestAssociations(
   const goTestDirIndex = buildGoTestDirIndexFromChunks(allChunks, workspaceRoot, normalize);
   const javaTestDirIndex = buildJavaTestDirIndexFromChunks(allChunks, workspaceRoot, normalize);
   const csharpIndex = buildCSharpTestIndexFromChunks(allChunks, workspaceRoot);
+  const jvmIndex = buildJvmTestIndexFromChunks(allChunks, workspaceRoot);
 
   return filepaths.map(filepath => {
     const normalizedTarget = normalize(filepath);
@@ -486,6 +550,7 @@ export function findTestAssociations(
       ...collectGoBasenameTestFiles(filepath, normalizedTarget, goTestDirIndex),
       ...collectJavaBasenameTestFiles(filepath, normalizedTarget, javaTestDirIndex),
       ...collectCSharpNamespaceTestFiles(filepath, csharpIndex, workspaceRoot),
+      ...collectKotlinSamePackageTestFiles(filepath, jvmIndex, workspaceRoot),
     ]);
 
     return Array.from(testFiles);

--- a/packages/cli/src/mcp/server.get-files-context.test.ts
+++ b/packages/cli/src/mcp/server.get-files-context.test.ts
@@ -68,6 +68,41 @@ function mockCSharpChunk(opts: {
 }
 
 /**
+ * #1005 Phase 2, Item 2: a real Kotlin type declaration/usage `SearchResult`,
+ * with a `package X` line in content (Phase 1's content-derived package
+ * scan) -- mirrors `mockCSharpChunk` above, needed because
+ * `findTestAssociations`'s Kotlin tier (`collectKotlinSamePackageTestFiles`)
+ * reads `content`/`symbolType`/`symbolName`, not just
+ * `metadata.file`/`imports` like the plain `mockSearchResult` above.
+ */
+function mockKotlinChunk(opts: {
+  file: string;
+  symbolName: string;
+  pkg?: string;
+  declares?: boolean;
+  references?: string[];
+}): SearchResult {
+  const pkgPrefix = opts.pkg ? `package ${opts.pkg}\n\n` : '';
+  const body = opts.declares
+    ? `class ${opts.symbolName} { }`
+    : (opts.references ?? []).map(name => `val x = ${name}()`).join('\n');
+  return {
+    content: `${pkgPrefix}${body}`,
+    metadata: {
+      file: opts.file,
+      startLine: 1,
+      endLine: 10,
+      type: opts.declares ? 'class' : 'function',
+      language: 'kotlin',
+      symbolName: opts.symbolName,
+      symbolType: opts.declares ? 'class' : 'method',
+    },
+    score: 0,
+    relevance: 'not_relevant',
+  };
+}
+
+/**
  * Unit tests for get_files_context handler and helper functions.
  *
  * Tests cover:
@@ -463,6 +498,80 @@ describe('get_files_context - Helper Functions', () => {
       const result = findTestAssociations(['src/MediatR/IRequestHandler.cs'], mockChunks, ctx);
 
       expect(result[0]).toEqual(['test/MediatR.Tests/PipelineTests.cs']);
+    });
+
+    // #1005 Phase 2, Item 2: Kotlin's same-package test convention -- like
+    // C#'s above, no import statement AND (unlike Java's) no basename
+    // relationship required.
+    it('associates a Kotlin test file with its subject via same-package access, with no import at all (#1005 Phase 2)', () => {
+      const mockChunks = [
+        mockKotlinChunk({
+          file: 'src/main/kotlin/a/b/Foo.kt',
+          symbolName: 'Foo',
+          pkg: 'a.b',
+          declares: true,
+        }),
+        mockKotlinChunk({
+          file: 'src/test/kotlin/a/b/FooCoverage.kt',
+          symbolName: 'testMethod',
+          pkg: 'a.b',
+          references: ['Foo'],
+        }),
+      ];
+
+      const ctx = {
+        vectorDB: {} as any,
+        embeddings: {} as any,
+        log: vi.fn(),
+        workspaceRoot,
+      };
+
+      const result = findTestAssociations(['src/main/kotlin/a/b/Foo.kt'], mockChunks, ctx);
+
+      expect(result[0]).toEqual(['src/test/kotlin/a/b/FooCoverage.kt']);
+    });
+
+    // #1005 Phase 2, Item 2, AC8: `resolveJvmSamePackageDependents` requires
+    // an EXACT `chunk.metadata.file` string match. Without canonicalizing
+    // both the index-build side and the query side (see
+    // `buildJvmTestIndexFromChunks`/`collectKotlinSamePackageTestFiles`),
+    // a query filepath in a different (but equivalent, under the same
+    // workspaceRoot) form than the chunk's own ABSOLUTE `metadata.file`
+    // would silently return zero associations -- exactly the kind of
+    // clean-looking-but-wrong zero this repo's index-state-honesty policy
+    // forbids. This proves it does not.
+    it('does not silently return zero associations when the query filepath form differs from an absolute chunk.metadata.file (#1005 Phase 2 AC8)', () => {
+      const mockChunks = [
+        mockKotlinChunk({
+          file: `${workspaceRoot}/src/main/kotlin/a/b/Foo.kt`,
+          symbolName: 'Foo',
+          pkg: 'a.b',
+          declares: true,
+        }),
+        mockKotlinChunk({
+          file: `${workspaceRoot}/src/test/kotlin/a/b/FooCoverage.kt`,
+          symbolName: 'testMethod',
+          pkg: 'a.b',
+          references: ['Foo'],
+        }),
+      ];
+
+      const ctx = {
+        vectorDB: {} as any,
+        embeddings: {} as any,
+        log: vi.fn(),
+        workspaceRoot,
+      };
+
+      // Query with the WORKSPACE-RELATIVE form -- a different raw string
+      // than the chunks' absolute `metadata.file` above, but the same file
+      // once canonicalized against workspaceRoot. This file's convention
+      // (unlike `@liendev/parser`'s `test-associations.ts`) canonicalizes
+      // every tier's output, so the expected result is the CANONICAL
+      // (workspace-relative) form, not the chunks' raw absolute one.
+      const result = findTestAssociations(['src/main/kotlin/a/b/Foo.kt'], mockChunks, ctx);
+
+      expect(result[0]).toEqual(['src/test/kotlin/a/b/FooCoverage.kt']);
     });
   });
 

--- a/packages/cli/test/e2e/real-projects.test.ts
+++ b/packages/cli/test/e2e/real-projects.test.ts
@@ -159,9 +159,6 @@ const KNOWN_ZERO_EDGE_LANGUAGES = new Set(['swift']);
  * skip, so a real fix makes this fail loudly instead of staying silently
  * green).
  *
- * - **kotlin**: documented and accepted -- see `sameUnitAccessWithoutImport`
- *   in `ast/languages/kotlin.ts`: "no verified Kotlin Gradle test-source
- *   recovery exists" (#1005). Measured: Klaxon, 0/100 sampled files.
  * - **swift**: documented and accepted, #869 ("whole-module-import
  *   languages have no per-file test-association signal -- structural gap,
  *   not a matching bug"). Measured: SwiftyJSON, 0/27 files.
@@ -177,12 +174,22 @@ const KNOWN_ZERO_EDGE_LANGUAGES = new Set(['swift']);
  * associations across all 160; see MediatR's own `expectedMinTestAssociations`
  * for the 100-file-sampled floor this test actually asserts).
  *
+ * **kotlin is FIXED (#1005 Phase 2, Item 2)** and no longer belongs in this
+ * set: `test-associations.ts` now reuses `resolveJvmSamePackageDependents`
+ * (the SAME same-package signal Phase 1's `findDependents` file-level
+ * recovery already relies on, #1100) filtered to test files, recovering
+ * Kotlin's same-package test convention -- a Kotlin test class references
+ * its subject with no import at all, the same structural gap Go/Java/C#
+ * each had their own version of. Measured: Klaxon, 0/100 -> 22/100 sampled
+ * files (142 associations; see Klaxon's own `expectedMinTestAssociations`
+ * for the floor this test actually asserts).
+ *
  * Note this is a DIFFERENT set from `KNOWN_ZERO_EDGE_LANGUAGES`: Java is
  * zero-edge (#1005) but NOT zero-test-association -- `samePackageTestConvention`
  * covers test association only, not dependents, exactly as #1005 documents.
  * Measured: JavaPoet, 13/43 files, real non-zero test associations.
  */
-const KNOWN_ZERO_TESTASSOC_LANGUAGES = new Set(['kotlin', 'swift']);
+const KNOWN_ZERO_TESTASSOC_LANGUAGES = new Set(['swift']);
 
 /**
  * Test projects for each supported language
@@ -432,11 +439,16 @@ const TEST_PROJECTS: ProjectConfig[] = [
     // roughly-half collapse, not just a total-collapse-to-zero (#1053).
     expectedMinDependencyEdges: 112,
     expectedMinComplexityViolations: 3, // measured ~16 (2026-08)
-    // KNOWN GAP: #1005's `sameUnitAccessWithoutImport` -- "no verified
-    // Kotlin Gradle test-source recovery exists". See
-    // KNOWN_ZERO_TESTASSOC_LANGUAGES: exact-zero tripwire, not a floor, used
-    // instead of this value.
-    expectedMinTestAssociations: 0,
+    // #1005 Phase 2, Item 2 fix: Kotlin's same-package test convention
+    // (no import at all connecting a test class to its subject) is now
+    // recovered via `resolveJvmSamePackageDependents`, the same mechanism
+    // Phase 1 already uses for `findDependents`. Measured 142 associations
+    // across the 100-file sample (22/100 files with at least one, 2026-08).
+    // Floor is ~50% of measured, the same "catch a roughly-half collapse"
+    // guideline `expectedMinDependencyEdges` above already uses for this
+    // project -- not a floor tight enough to double as an exact-count
+    // regression test.
+    expectedMinTestAssociations: 70,
     expectedMinChunksWithExports: 100, // measured ~938/987 chunks (2026-08)
     knownSymbolQuery: 'JsonObject',
     knownSymbolFile: 'klaxon/src/main/kotlin/com/beust/klaxon/JsonObject.kt',

--- a/packages/parser/src/ast/languages/kotlin.ts
+++ b/packages/parser/src/ast/languages/kotlin.ts
@@ -692,8 +692,17 @@ export const kotlinDefinition: LanguageDefinition = {
   // file's declarations with zero `import` statements (Klaxon's 104 files
   // sit in one package with 0 recorded edges) -- the same underlying fact
   // `samePackageTestConvention` documents for Java, but that flag is scoped
-  // to TEST association specifically (no verified Kotlin Gradle test-source
-  // recovery exists), so this is its own flag -- see
-  // `LanguageDefinition.sameUnitAccessWithoutImport`'s doc comment.
+  // to TEST association specifically, and Kotlin doesn't set it here: Phase 2
+  // (Item 2) DOES now recover Kotlin's same-package test convention, but via
+  // its own separate, CONTENT-derived mechanism
+  // (`test-associations.ts`'s `collectKotlinSamePackageTests`, gated on
+  // `detectLanguage(filepath) === 'kotlin'` directly), not by wiring this
+  // registry flag -- Java's PATH-derived `samePackageTestConvention`
+  // mechanism (`java-same-package-tests.ts`) is hard-coded to the
+  // `src/<sourceSet>/java/` Standard Directory Layout marker and is
+  // Kotlin-blind by construction, so setting this flag for Kotlin would be a
+  // no-op, not a second real mechanism. See
+  // `LanguageDefinition.sameUnitAccessWithoutImport`'s doc comment for what
+  // THIS flag covers (dependency edges, not test association).
   sameUnitAccessWithoutImport: true,
 };

--- a/packages/parser/src/test-associations.test.ts
+++ b/packages/parser/src/test-associations.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { findTestAssociationsFromChunks } from './test-associations.js';
+import { findJvmSamePackageDependents } from './jvm-same-package-signals.js';
 import type { CodeChunk } from './types.js';
 
 function makeChunk(file: string, imports: string[] = []): CodeChunk {
@@ -375,6 +376,146 @@ describe('findTestAssociationsFromChunks', () => {
       expect(result.get('src/MediatR/IRequestHandler.cs')).toContain(
         'test/MediatR.Tests/OtherTests.cs',
       );
+    });
+  });
+
+  describe('Kotlin same-package test convention (#1005 Phase 2, Item 2)', () => {
+    // A real Kotlin/Java type declaration chunk, packaged via a `package X`
+    // content line (Phase 1's content-derived package scan) -- mirrors
+    // `csharpDecl` above.
+    function jvmDecl(file: string, symbolName: string, pkg: string, language: string): CodeChunk {
+      return {
+        content: `package ${pkg}\n\nclass ${symbolName} { }`,
+        metadata: {
+          file,
+          startLine: 1,
+          endLine: 10,
+          type: 'class',
+          language,
+          symbolName,
+          symbolType: 'class',
+        },
+      };
+    }
+
+    // A JVM usage chunk (e.g. a test method) that references `references` by
+    // bare name, with no import at all -- mirrors `csharpUsage` above.
+    function jvmUsage(
+      file: string,
+      references: string[],
+      pkg: string,
+      language: string,
+    ): CodeChunk {
+      return {
+        content: `package ${pkg}\n\n${references.map(name => `val x = ${name}()`).join('\n')}`,
+        metadata: {
+          file,
+          startLine: 1,
+          endLine: 10,
+          type: 'function',
+          language,
+          symbolName: 'testMethod',
+          symbolType: 'method',
+        },
+      };
+    }
+
+    it('associates a Kotlin test file with its subject via same-package access, with NO import and NO basename relationship', () => {
+      const chunks: CodeChunk[] = [
+        jvmDecl('src/main/kotlin/a/b/Foo.kt', 'Foo', 'a.b', 'kotlin'),
+        jvmUsage('src/test/kotlin/a/b/FooCoverage.kt', ['Foo'], 'a.b', 'kotlin'),
+      ];
+
+      const result = findTestAssociationsFromChunks(['src/main/kotlin/a/b/Foo.kt'], chunks);
+
+      expect(result.get('src/main/kotlin/a/b/Foo.kt')).toEqual([
+        'src/test/kotlin/a/b/FooCoverage.kt',
+      ]);
+    });
+
+    it('does not apply the same-package convention to Java, gated strictly on Kotlin, even though the underlying resolver would otherwise find it (Java keeps its own separate path-based mechanism)', () => {
+      const chunks: CodeChunk[] = [
+        jvmDecl('src/main/java/a/b/Foo.java', 'Foo', 'a.b', 'java'),
+        // Same package, no import, but a DIFFERENT basename than 'Foo' --
+        // Java's own tier 1 (`collectJavaBasenameTests`) can't pair this,
+        // so if the Kotlin gate is doing real work, this must find nothing.
+        jvmUsage('src/test/java/a/b/DifferentNameTest.java', ['Foo'], 'a.b', 'java'),
+      ];
+
+      // Confirms the fixture actually discriminates: the underlying
+      // resolver WOULD find this association if the language gate were
+      // removed -- otherwise this test would pass vacuously (no real signal
+      // at all), not because the Kotlin-only gate is doing anything.
+      expect(findJvmSamePackageDependents('src/main/java/a/b/Foo.java', chunks)).toContain(
+        'src/test/java/a/b/DifferentNameTest.java',
+      );
+
+      const result = findTestAssociationsFromChunks(['src/main/java/a/b/Foo.java'], chunks);
+
+      expect(result.has('src/main/java/a/b/Foo.java')).toBe(false);
+    });
+
+    it('composes with a real import-based match without duplicating the test file', () => {
+      const chunks: CodeChunk[] = [
+        jvmDecl('src/main/kotlin/a/b/Foo.kt', 'Foo', 'a.b', 'kotlin'),
+        jvmUsage('src/test/kotlin/a/b/FooCoverage.kt', ['Foo'], 'a.b', 'kotlin'),
+        makeChunk('src/test/kotlin/a/b/OtherTest.kt', ['src/main/kotlin/a/b/Foo']),
+      ];
+
+      const result = findTestAssociationsFromChunks(['src/main/kotlin/a/b/Foo.kt'], chunks);
+
+      expect(result.get('src/main/kotlin/a/b/Foo.kt')).toHaveLength(2);
+      expect(result.get('src/main/kotlin/a/b/Foo.kt')).toContain(
+        'src/test/kotlin/a/b/FooCoverage.kt',
+      );
+      expect(result.get('src/main/kotlin/a/b/Foo.kt')).toContain(
+        'src/test/kotlin/a/b/OtherTest.kt',
+      );
+    });
+
+    // AC8: `resolveJvmSamePackageDependents` requires an EXACT
+    // `chunk.metadata.file` string match. Without canonicalizing both the
+    // index-build side and the query side (see
+    // `buildRawJvmFileByCanonical`/`collectKotlinSamePackageTests`), a query
+    // filepath in a different (but equivalent, under the same
+    // `workspaceRoot`) form than the chunk's own ABSOLUTE `metadata.file`
+    // would silently return zero associations -- exactly the kind of
+    // clean-looking-but-wrong zero this repo's index-state-honesty policy
+    // forbids. This proves it does not.
+    it('does not silently return zero associations when the query filepath form differs from an absolute chunk.metadata.file (AC8)', () => {
+      const workspaceRoot = '/repo';
+      const chunks: CodeChunk[] = [
+        jvmDecl(`${workspaceRoot}/src/main/kotlin/a/b/Foo.kt`, 'Foo', 'a.b', 'kotlin'),
+        jvmUsage(`${workspaceRoot}/src/test/kotlin/a/b/FooCoverage.kt`, ['Foo'], 'a.b', 'kotlin'),
+      ];
+
+      // Query with the WORKSPACE-RELATIVE form -- a different raw string
+      // than the chunks' absolute `metadata.file` above, but the same file
+      // once canonicalized against `workspaceRoot`.
+      const result = findTestAssociationsFromChunks(
+        ['src/main/kotlin/a/b/Foo.kt'],
+        chunks,
+        workspaceRoot,
+      );
+
+      expect(result.get('src/main/kotlin/a/b/Foo.kt')).toEqual([
+        `${workspaceRoot}/src/test/kotlin/a/b/FooCoverage.kt`,
+      ]);
+    });
+
+    it('honestly finds no association when the paths genuinely refer to different files (not a canonicalization bug)', () => {
+      const workspaceRoot = '/repo';
+      const chunks: CodeChunk[] = [
+        jvmDecl(`${workspaceRoot}/src/main/kotlin/a/b/Foo.kt`, 'Foo', 'a.b', 'kotlin'),
+      ];
+
+      const result = findTestAssociationsFromChunks(
+        ['completely/different/path/Bar.kt'],
+        chunks,
+        workspaceRoot,
+      );
+
+      expect(result.has('completely/different/path/Bar.kt')).toBe(false);
     });
   });
 

--- a/packages/parser/src/test-associations.ts
+++ b/packages/parser/src/test-associations.ts
@@ -8,6 +8,7 @@ import {
   normalizePath,
   importMatchesTarget,
   isUnresolvableWholeModuleImport,
+  getCanonicalPath,
 } from './utils/path-matching.js';
 import {
   detectLanguage,
@@ -33,6 +34,11 @@ import {
   resolveCSharpTypeReferenceDependents,
   type CSharpTypeReferenceIndex,
 } from './csharp-type-reference-signals.js';
+import {
+  buildJvmSamePackageIndex,
+  resolveJvmSamePackageDependents,
+  type JvmSamePackageIndex,
+} from './jvm-same-package-signals.js';
 import type { CodeChunk } from './types.js';
 
 /**
@@ -63,6 +69,25 @@ function hasJavaSamePackageConvention(filepath: string): boolean {
 function hasCSharpEnclosingNamespaceConvention(filepath: string): boolean {
   const language = detectLanguage(filepath);
   return language !== null && hasEnclosingNamespaceAccess(language);
+}
+
+/**
+ * #1005 Phase 2, Item 2: true only for Kotlin, deliberately NOT a
+ * registry-flag predicate like the three helpers above. Java already owns
+ * `samePackageTestConvention` (`hasJavaSamePackageConvention`) and its own
+ * PATH-derived mechanism (`java-same-package-tests.ts`, keyed on the
+ * `src/<sourceSet>/java/` Standard Directory Layout marker, which is
+ * Kotlin-blind by construction -- see `jvm-same-package-signals.test.ts`'s
+ * "cross-check" describe block). This is a SEPARATE, CONTENT-derived
+ * mechanism (Phase 1's `package` declaration scan) for Kotlin specifically:
+ * measurement during the plan review found a Kotlin-targeted path-regex
+ * extension of Java's mechanism contributes little beyond what this
+ * content-derived tier alone already finds, and never fires at all on
+ * heavily-multiplatform-Kotlin layouts -- so Kotlin gets ONLY this
+ * mechanism, not a second one layered on top.
+ */
+function isKotlinFile(filepath: string): boolean {
+  return detectLanguage(filepath) === 'kotlin';
 }
 
 /**
@@ -194,6 +219,69 @@ function collectCSharpNamespaceTests(
 }
 
 /**
+ * `getCanonicalPath(rawFile, workspaceRoot)` -> `rawFile`, for every JVM
+ * (Java+Kotlin) file `jvmIndex` knows about -- built once and reused for
+ * every target file below, mirroring `buildJvmSamePackageIndex` itself
+ * being built once.
+ *
+ * `resolveJvmSamePackageDependents` requires `targetFile` to be the EXACT
+ * `chunk.metadata.file` string used when `jvmIndex` was built (see that
+ * function's doc comment). `findTestAssociationsFromChunks` is reached with
+ * several different path forms from different callers (some
+ * workspace-relative with an explicit `rootDir`, at least one --
+ * `insights/chunk-complexity.ts` -- with NO root passed at all, defaulting
+ * to `process.cwd()`), so comparing a caller's raw `filepath`
+ * against the raw index directly risks a silent `[]` on any form mismatch --
+ * exactly the "clean-looking zero" this repo's index-state-honesty policy
+ * forbids. `collectCSharpNamespaceTests` immediately above has exactly this
+ * latent gap (no canonicalization at all against `csharpIndex`); deliberately
+ * NOT copied forward here. Canonicalizing via `getCanonicalPath` on BOTH the
+ * index-build side (this map) and the query side
+ * (`collectKotlinSamePackageTests`) closes it for the new tier, while
+ * `resolveJvmSamePackageDependents`'s OWN raw-form output (and therefore
+ * this module's whole `testFiles` Set convention, which every other tier
+ * here already returns in raw `chunk.metadata.file` form) stays unchanged --
+ * `jvmIndex` itself is still built from the untouched, raw `chunks` array.
+ */
+function buildRawJvmFileByCanonical(
+  jvmIndex: JvmSamePackageIndex,
+  workspaceRoot: string,
+): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const rawFile of jvmIndex.chunksByFile.keys()) {
+    out.set(getCanonicalPath(rawFile, workspaceRoot), rawFile);
+  }
+  return out;
+}
+
+/**
+ * #1005 Phase 2, Item 2: Kotlin's same-package test convention -- like
+ * Java's (#925) and C#'s (#1040), a Kotlin test class commonly lives in the
+ * same package as its subject with no import connecting them at all.
+ * Deliberately reuses Phase 1's FILE-LEVEL `resolveJvmSamePackageDependents`
+ * (#1100) -- NOT #1005 Phase 2 Item 1's per-type
+ * `resolveJvmSamePackageDependentsForType` -- because "which tests exercise
+ * this file" is inherently a file-level question, and this module's
+ * consumer (`hasTestCoverage` in `@liendev/review`'s `blast-radius.ts`,
+ * file-keyed) needs a file-level answer, not a type-scoped one.
+ *
+ * See `buildRawJvmFileByCanonical`'s doc comment for why `filepath` is
+ * canonicalized before ever touching `jvmIndex`, rather than compared
+ * directly the way `collectCSharpNamespaceTests` does.
+ */
+function collectKotlinSamePackageTests(
+  filepath: string,
+  jvmIndex: JvmSamePackageIndex,
+  rawJvmFileByCanonical: ReadonlyMap<string, string>,
+  workspaceRoot: string,
+): string[] {
+  if (!isKotlinFile(filepath)) return [];
+  const rawFile = rawJvmFileByCanonical.get(getCanonicalPath(filepath, workspaceRoot));
+  if (!rawFile) return [];
+  return resolveJvmSamePackageDependents(rawFile, jvmIndex).filter(isTestFile);
+}
+
+/**
  * #902: Go's dominant same-package test convention emits no import statement
  * at all, so `collectImportMatchedTests` is structurally blind to it. Builds
  * a directory index of same-directory-test-convention (Go) test chunks --
@@ -268,6 +356,13 @@ export function findTestAssociationsFromChunks(
   // needs every declaration) and reused for every target file below, same
   // "build once" discipline as the two indexes above.
   const csharpIndex = buildCSharpTypeReferenceIndex(chunks);
+  // #1005 Phase 2, Item 2: Kotlin's same-package test-association index,
+  // same "build once, project-wide" discipline -- see
+  // `buildRawJvmFileByCanonical`'s doc comment for why the canonical-path
+  // lookup is a SEPARATE map built alongside it, not folded into
+  // `JvmSamePackageIndex` itself.
+  const jvmIndex = buildJvmSamePackageIndex(chunks);
+  const rawJvmFileByCanonical = buildRawJvmFileByCanonical(jvmIndex, workspaceRoot);
 
   for (const filepath of filepaths) {
     const normalizedTarget = normalize(filepath);
@@ -276,6 +371,7 @@ export function findTestAssociationsFromChunks(
       ...collectGoBasenameTests(filepath, normalizedTarget, goTestDirIndex),
       ...collectJavaBasenameTests(filepath, normalizedTarget, javaTestDirIndex),
       ...collectCSharpNamespaceTests(filepath, csharpIndex),
+      ...collectKotlinSamePackageTests(filepath, jvmIndex, rawJvmFileByCanonical, workspaceRoot),
     ]);
 
     if (testFiles.size > 0) {


### PR DESCRIPTION
## Summary

Item 2 of #1005 Phase 2 (follows #1115, merged): adds a Kotlin same-package
test-association mechanism, shipped in **both** consumers in this one PR:

- `packages/parser/src/test-associations.ts`'s `findTestAssociationsFromChunks`
  (the shared engine — feeds `lien annotate`, blast-radius's test-coverage
  risk computation, and the agent-review plugin's coverage checks).
- `packages/cli/src/mcp/handlers/get-files-context.ts`'s `findTestAssociations`
  (the `get_files_context` MCP tool's own separate implementation — the same
  parallel-implementation pattern #1040 already established for C#).

Like Java's own same-package test convention (#925) and C#'s
enclosing-namespace one (#1040), a Kotlin test class commonly lives in the
same package as its subject with **no import statement connecting them at
all**. Kotlin's same-package visibility rule needs none.

### Design

- **Mechanism (a) only** — no path-regex extension of Java's mechanism was
  added. The plan's own measurement found that contributes little beyond
  what this content-derived tier alone finds, is 71-100% redundant with it
  wherever it does fire, and never fires on heavily-multiplatform-Kotlin
  layouts. Kotlin gets exactly one mechanism, gated strictly to
  `detectLanguage(filepath) === 'kotlin'` — Java keeps its own, separate
  mechanism untouched.
- **Reuses Phase 1's FILE-LEVEL `resolveJvmSamePackageDependents`** (#1100),
  deliberately **not** Item 1's per-type `resolveJvmSamePackageDependentsForType`
  — "which tests exercise this file" is inherently a file-level question,
  and both consumers (`hasTestCoverage` in blast-radius, `testAssociations`
  in `get_files_context`) are file-keyed, not type-keyed. Stated explicitly
  in both files' doc comments, not left for a future reader to re-derive.
- **Path canonicalization, explicit and tested (AC8)**:
  `resolveJvmSamePackageDependents` requires the caller's filepath to be the
  *exact* `chunk.metadata.file` string used when its index was built.
  `findTestAssociationsFromChunks` is reached with several different path
  forms (some workspace-relative with an explicit `rootDir`, at least one —
  `insights/chunk-complexity.ts` — with **no root passed at all**, defaulting
  to `process.cwd()`). A form mismatch would otherwise silently return `[]` —
  exactly the "clean-looking zero" this repo's index-state-honesty policy
  forbids. **This bug already exists, uncanonicalized, in this same file's
  C# collector** (`collectCSharpNamespaceTests`) — deliberately not copied
  forward:
  - `test-associations.ts`: canonicalizes only the *query* side, via a
    `getCanonicalPath`-keyed `canonical → raw` lookup
    (`buildRawJvmFileByCanonical`), so the module's established raw-form
    output convention (every other tier here returns raw
    `chunk.metadata.file` strings) stays consistent.
  - `get-files-context.ts`: mirrors that file's **already-correct** C#
    precedent (`buildCSharpTestIndexFromChunks`/`collectCSharpNamespaceTestFiles`),
    which canonicalizes the whole chunk array up front — that file's
    established convention is full canonicalization throughout, so the new
    tier's output is canonical-form too, consistent with its siblings.
- **No package-size heuristic.** An earlier concern was that a
  single-package-dominated project would make the package-scoping gate
  nearly vacuous. Measured: fabrication rate stayed ~0% regardless of
  package concentration — the real bound is the underlying resolver's
  word-boundary text match against the production file's declared type
  name, not the candidate pool size. Not added.

### What does NOT change

- Java's existing path-derived mechanism (`java-same-package-tests.ts`) —
  untouched, still Java-only.
- Every other tier in both files (Go, direct-import, C#) — pure addition.

## Acceptance criteria

8. **Path-form honesty** — new tests in both `test-associations.test.ts`
   and `server.get-files-context.test.ts`: a chunk with an ABSOLUTE
   `metadata.file`, queried with a workspace-relative form of the same
   file, still resolves the association (not a silent `[]`). A negative
   control (`test-associations.test.ts`) confirms a genuinely different
   file still honestly returns nothing — the fix isn't "always non-empty."
9. **Index-state-matrix stays green, confirmed not assumed** —
   `packages/cli/test/integration/index-state-matrix.test.ts` (49 tests)
   ran clean; this PR adds no `createVectorDB` call site or MCP handler.

Also verified: the Java-only gating actually discriminates (a test proves
the underlying JVM resolver *would* find a same-package Java association
if the language gate were removed, then proves the gate suppresses it —
not a vacuous "no signal at all" negative).

## Dogfood evidence (verbatim, real Klaxon clone)

Indexed a fresh clone of `cbeust/klaxon` with this branch's built CLI.

**Before this PR** (`git stash`, same corpus, same command):

```
$ lien annotate klaxon/src/main/kotlin/com/beust/klaxon/Klaxon.kt
⚠ Lien: Klaxon.findConverterFromClass cognitive 14/15 — avoid adding complexity here; prefer extraction.
Lien impact for klaxon/src/main/kotlin/com/beust/klaxon/Klaxon.kt:
  • 60 files import this — ...; risk: medium (7 production callers, 7 untested).
  • No test coverage.
```

**After this PR** (same command, same index):

```
$ lien annotate klaxon/src/main/kotlin/com/beust/klaxon/Klaxon.kt
⚠ Lien: Klaxon.findConverterFromClass cognitive 14/15 — avoid adding complexity here; prefer extraction.
Lien impact for klaxon/src/main/kotlin/com/beust/klaxon/Klaxon.kt:
  • 60 files import this — ...; risk: medium (7 production callers, 7 untested).
  • Test coverage: klaxon/src/test/kotlin/com/beust/klaxon/BindingAdapterTest.kt, klaxon/src/test/kotlin/com/beust/klaxon/BindingTest.kt (+51 more).
```

`Klaxon.kt` is the library's central class — before this PR, `lien
annotate` reported it as having **zero** test coverage, even though it is
in fact exercised by essentially the entire test suite. This is exactly the
"clean-looking zero" the index-state-honesty policy is about: not a bug in
the *rendering*, a real blind spot in what the tool could see.

Also confirmed via the real `get_files_context` MCP tool (started via
`lien serve`, queried over stdio with `@modelcontextprotocol/sdk`'s client):
its `testAssociations` field for the same file returns the identical 53
files.

## Local gate chain (all green)

```
npm run format:check   ✅
npm run lint            ✅ (0 errors, 42 pre-existing warnings, none in touched files)
npm run typecheck       ✅
npm run build            ✅
npm test                 ✅ (parser 1962, core 448, review 1726, cli 1739, action 41 — all passing)
lien delta                ✅ exit 0 — no threshold crossings (two advisory Halstead "time" metric
                              upticks on findTestAssociationsFromChunks/findTestAssociations, both
                              well under threshold)
```

## Known, disclosed residual (not a blocker)

Roughly 1-2% of newly-found associations may rest on a single textual
occurrence that happens to sit inside a comment or KDoc block rather than
live code — a real, small limitation shared with Phase 1's underlying
word-boundary-match gate (`jvm-same-package-signals.ts`). Not gated on or
fixed here, per the plan's own explicit scope call.

## Follow-up issues

All three follow-ups from the overall #1005 Phase 2 plan were already filed
against Item 1's PR (#1115): #1112, #1113, #1114. Nothing new to file for
Item 2 specifically.

---

<!-- lien-stats -->
### Lien Review

➡️ **Stable** - 4 pre-existing issues in touched files (none introduced).
| Metric | Violations | Change |
|--------|:----------:|:------:|
| 🔀 test paths | 1 | +0 |
| 🧠 mental load | 2 | +0 |
| ⏱️ time to understand | 1 | +0 |

> [!NOTE]
> **Low Risk**
>
> This PR adds a Kotlin same-package test-association mechanism in two parallel implementations: the shared parser engine (`findTestAssociationsFromChunks`) and the `get_files_context` MCP tool (`findTestAssociations`). It reuses the existing file-level JVM same-package resolver, gates it strictly to Kotlin queries, and addresses path-form mismatches through explicit canonicalization. The change is additive, well-documented, and covered by tests for the happy path, the Kotlin-not-Java gate, import-based composition, and the canonicalization edge case.
>
> - Adds Kotlin same-package test association to `findTestAssociationsFromChunks` with query-side canonicalization and raw-form output preservation.
> - Adds a parallel Kotlin tier to `get_files_context`'s `findTestAssociations`, canonicalizing the full chunk array upfront to match the file's existing C# convention.
> - Updates Kotlin project expectations in `real-projects.test.ts` to reflect recovered test associations.

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 0f83e57. Updates automatically on new commits.</sup>
<!-- /lien-stats -->

---

