### PR TITLE
fix(parser,core): preserve leading package/namespace header chunks under minChunkSize (#1005 Phase 3, Item D)

### DIFF
--- a/.changeset/jvm-header-chunk-preservation.md
+++ b/.changeset/jvm-header-chunk-preservation.md
@@ -1,0 +1,35 @@
+---
+'@liendev/parser': minor
+'@liendev/core': patch
+---
+
+Fix a chunker bug (#1005 Phase 3, Item D) that silently dropped a file's
+leading (header) uncovered range whenever it was shorter than `minChunkSize`
+and the file had no `export`-recognized declaration — a package-private
+Java/Kotlin file's `package` line, or a C# file's file-scoped `namespace`
+line, could sit in exactly that gap. Losing the range didn't just shrink a
+chunk, it made the file's package/namespace undetectable anywhere else in
+the index, silently disabling same-package/namespace dependent resolution
+(`jvm-same-package-signals.ts`, `csharp-type-reference-signals.ts`) for that
+file as both target and candidate.
+
+The fix (`isLeadingHeaderRange` in `ast/chunker.ts`) bypasses `minChunkSize`
+specifically for a file's leading uncovered range, evaluated per-range so an
+unrelated short gap elsewhere in the same file is still dropped as noise.
+Measured against real Java/Kotlin/C# corpora (kotlinx-coroutines, klaxon,
+javapoet, retrofit, okhttp, serilog), a content-aware variant restricted to
+package/namespace-declaration-matching ranges added at most 1-2 extra chunks
+per corpus beyond this simpler position-based rule — and every one of those
+extras was an unrelated non-JVM/non-C# file, never a real miss — so the
+simpler, regex-free rule ships.
+
+Also strips `package` declaration lines (in addition to the existing
+`import`-line stripping) from `jvm-same-package-signals.ts`'s text-match
+corpus, closing a fabrication risk this fix newly exposes: a header chunk
+that previously never reached the match corpus now always does, and a
+package whose own last segment collides with a real type name could
+otherwise read as a textual self-reference.
+
+Bumps `INDEX_FORMAT_VERSION` 5 → 6 so existing indexes pick up the fix on
+next `lien index` rather than silently keeping stale package derivation
+until a manual full reindex.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -49,4 +49,10 @@ export function isOversizedForIndexing(sizeBytes: number): boolean {
 // v3: Added cognitiveComplexity field to schema
 // v4: Added Halstead metrics (volume, difficulty, effort, bugs)
 // v5: Resolved relative imports to workspace-relative paths in chunk metadata (#525)
-export const INDEX_FORMAT_VERSION = 5;
+// v6: A file's leading (header) uncovered range is no longer dropped by
+//     `minChunkSize` regardless of content -- a package-private Java/Kotlin
+//     file's `package` line (or a C# file's `namespace` line) can sit in a
+//     leading gap shorter than `minChunkSize`, and dropping it made the
+//     file's package/namespace undetectable everywhere else in the index
+//     (#1005 Phase 3 Item D, `ast/chunker.ts`'s `isLeadingHeaderRange`).
+export const INDEX_FORMAT_VERSION = 6;

--- a/packages/parser/src/ast/chunker.test.ts
+++ b/packages/parser/src/ast/chunker.test.ts
@@ -1267,6 +1267,64 @@ test('does something', () => {
     });
   });
 
+  describe('leading header range is never dropped by minChunkSize, regardless of content (#1005 Phase 3 Item D)', () => {
+    // Same production boundary as the "small files" block above.
+    const PROD_MIN_CHUNK_SIZE = 7;
+
+    it('keeps a short package-private Kotlin header (package line) that would otherwise fall under minChunkSize', () => {
+      // No `export`-recognized declaration (internal, not public), so the
+      // OLD file-global `skipMinSize` never bypassed minChunkSize here --
+      // the 2-line header (package + blank) is well under the 7-line
+      // production threshold and used to be silently dropped, taking the
+      // file's only `package` line with it (#1005 Phase 3 Item D).
+      const content = `package com.example.internal
+
+internal class Foo {
+    fun a() {}
+}
+`;
+
+      const chunks = chunkByAST('Foo.kt', content, { minChunkSize: PROD_MIN_CHUNK_SIZE });
+
+      const header = chunks.find(c => c.content.includes('package com.example.internal'));
+      expect(header).toBeDefined();
+      expect(header!.metadata.startLine).toBe(1);
+    });
+
+    it('keeps ONLY the leading header range -- a second, unrelated short uncovered gap elsewhere in the same file is still dropped as noise', () => {
+      // Deliberately has TWO short uncovered ranges: the leading header
+      // (package line, must survive) and a short comment-only gap BETWEEN
+      // two internal declarations (must still be dropped) -- this is the
+      // per-range distinction the fix must make. A one-line diff that
+      // widened the OLD file-global `skipMinSize` predicate instead would
+      // have kept BOTH ranges, which this test would catch.
+      const content = `package com.example.internal
+
+internal class Foo {
+    fun a() {}
+}
+
+// short gap, not a header
+
+internal class Bar {
+    fun b() {}
+}
+`;
+
+      const chunks = chunkByAST('Foo.kt', content, { minChunkSize: PROD_MIN_CHUNK_SIZE });
+
+      const header = chunks.find(c => c.content.includes('package com.example.internal'));
+      expect(header).toBeDefined();
+      expect(header!.metadata.startLine).toBe(1);
+
+      const midGap = chunks.find(c => c.content.includes('short gap, not a header'));
+      expect(midGap).toBeUndefined();
+
+      expect(chunks.some(c => c.metadata.symbolName === 'Foo')).toBe(true);
+      expect(chunks.some(c => c.metadata.symbolName === 'Bar')).toBe(true);
+    });
+  });
+
   describe('module-level call sites (#1087)', () => {
     /** Every (symbol, line) pair the whole file's chunks report. */
     const allCallSites = (chunks: ReturnType<typeof chunkByAST>) =>

--- a/packages/parser/src/ast/chunker.ts
+++ b/packages/parser/src/ast/chunker.ts
@@ -775,23 +775,60 @@ function isValidChunk(chunk: ASTChunk, minChunkSize: number): boolean {
 }
 
 /**
+ * True iff `range` is the file's own LEADING uncovered range -- the gap
+ * before the first recognized top-level node, when one exists.
+ * `findUncoveredRanges` only ever emits a range starting at line 0 for the
+ * one that precedes everything else (if the first covered range itself
+ * starts at line 0, there IS no leading gap and nothing here fires) -- so
+ * `range.start === 0` unambiguously identifies "this file's header", not
+ * merely "some short range early in the file". See `extractUncoveredCode`'s
+ * doc comment for why this range specifically must never be dropped by
+ * `minChunkSize`, independent of what it contains.
+ */
+function isLeadingHeaderRange(range: LineRange): boolean {
+  return range.start === 0;
+}
+
+/**
  * Extract code that wasn't covered by function/class chunks
  * (imports, exports, top-level statements)
  *
  * `minChunkSize` exists to avoid emitting noise chunks for small leftover
  * gaps *alongside* real function/class chunks in an otherwise normal file
  * (e.g. a lone blank-line gap between two functions). It must not apply when
- * the resulting chunk is the sole representation of the file's content —
- * doing so wouldn't shrink a chunk, it would silently drop the whole file
- * from the index. Two cases bypass it, both via `skipMinSize` below:
+ * the resulting chunk is the sole representation of some information the
+ * file will otherwise never expose anywhere else in the index. Three cases
+ * bypass it, via `skipMinSize` below, evaluated PER-RANGE (not as one
+ * file-global decision) so that only the specific range each case is about
+ * gets the bypass -- an unrelated short gap elsewhere in the very same file
+ * still gets dropped as noise:
  *   - `hasExports`: barrel/re-export-only files (see "barrel/re-export
- *     files" tests in chunker.test.ts).
+ *     files" tests in chunker.test.ts). File-global: applies to every
+ *     uncovered range in such a file, because the whole file IS the export
+ *     surface.
  *   - `fileHasNoTopLevelChunks`: files with zero recognized top-level nodes
  *     at all — e.g. a file containing only a bare `test(...)` call with no
  *     exported declaration. `coveredRanges` is empty in that case, so there
- *     is exactly one uncovered range and it spans the entire file.
- * Either way, `chunk.content.length > 0` still filters out empty/whitespace-
- * only files.
+ *     is exactly one uncovered range and it spans the entire file. Also
+ *     file-global, for the same reason (there is only ever one range).
+ *   - `isLeadingHeaderRange`: the file's own header -- a package-private
+ *     Java/Kotlin file's `package` line, or a C#'s file-scoped `namespace`
+ *     line, can sit in a leading gap shorter than `minChunkSize` when the
+ *     file's own declarations aren't `public` (so `hasExports` is false).
+ *     Dropping that range doesn't just shrink a chunk, it makes the file's
+ *     package/namespace UNDERIVABLE anywhere else in the index (nothing else
+ *     ever carries that line), silently disabling same-package/namespace
+ *     resolution (`jvm-same-package-signals.ts`,
+ *     `csharp-type-reference-signals.ts`) for that file as both target and
+ *     candidate — see #1005 Phase 3 Item D. This bypass is PER-RANGE and
+ *     content-blind by design (checked once during the plan for this fix:
+ *     measured against real Java/Kotlin/C# corpora, a content-aware variant
+ *     restricted to ranges that actually match a package/namespace
+ *     declaration regex added at most 1-2 extra chunks per corpus beyond this
+ *     simpler position-based rule, and every one of those extras was an
+ *     unrelated non-JVM file — not worth a language-specific regex to avoid).
+ * Every case still requires `chunk.content.length > 0`, which filters out
+ * empty/whitespace-only ranges regardless of which bypass applies.
  */
 function extractUncoveredCode(
   lines: string[],
@@ -807,13 +844,26 @@ function extractUncoveredCode(
   const uncoveredRanges = findUncoveredRanges(coveredRanges, lines.length);
 
   const hasExports = fileExports && fileExports.length > 0;
-  const skipMinSize = hasExports || fileHasNoTopLevelChunks;
+  const fileLevelSkipMinSize = hasExports || fileHasNoTopLevelChunks;
 
   return uncoveredRanges
-    .map(range =>
-      createChunkFromRange(range, lines, filepath, language, imports, fileExports, importedSymbols),
-    )
-    .filter(chunk => (skipMinSize ? chunk.content.length > 0 : isValidChunk(chunk, minChunkSize)));
+    .map(range => ({
+      range,
+      chunk: createChunkFromRange(
+        range,
+        lines,
+        filepath,
+        language,
+        imports,
+        fileExports,
+        importedSymbols,
+      ),
+    }))
+    .filter(({ range, chunk }) => {
+      const skipMinSize = fileLevelSkipMinSize || isLeadingHeaderRange(range);
+      return skipMinSize ? chunk.content.length > 0 : isValidChunk(chunk, minChunkSize);
+    })
+    .map(({ chunk }) => chunk);
 }
 
 /**

--- a/packages/parser/src/jvm-same-package-chunker-integration.test.ts
+++ b/packages/parser/src/jvm-same-package-chunker-integration.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { chunkByAST } from './ast/chunker.js';
+import {
+  buildJvmSamePackageIndex,
+  resolveJvmSamePackageDependents,
+} from './jvm-same-package-signals.js';
+import type { CodeChunk } from './types.js';
+
+/**
+ * End-to-end regression test for #1005 Phase 3 Item D, through the REAL
+ * production chunker (`chunkByAST`) -- not a hand-built `CodeChunk` fixture.
+ *
+ * Every test in `jvm-same-package-signals.test.ts` (including its own P2
+ * "post-hoc re-derivation" oracle) constructs `CodeChunk[]` by hand via
+ * `makeChunk`/`declChunk`/`usageChunk` -- `chunk.content` is whatever string
+ * the test itself wrote, so any oracle that re-derives package from
+ * `chunk.content` is comparing the test's own fixture against itself. That
+ * structurally CANNOT catch a bug in `chunker.ts` -- the exact defect Item D
+ * fixes: a package-private file's header (containing its own `package`
+ * line) silently dropped by `minChunkSize` before it ever became a chunk at
+ * all. Production (`derivePackage`, fed by the real chunker) and a
+ * chunk-content oracle would agree with each other while BOTH silently
+ * missing the package line -- neither would ever fail.
+ *
+ * This file closes that gap: it writes REAL files to a temp directory, runs
+ * them through the REAL `chunkByAST` pipeline (the same one `lien index`
+ * uses), and independently re-derives each file's package from a SEPARATE
+ * `fs.readFile` of the raw bytes on disk -- never from a chunk. A regression
+ * that reintroduces the header-drop bug makes `packageByFile.get(file)`
+ * come back `undefined` while the raw-disk read still finds the `package`
+ * line, so this test (and only this test) actually fails.
+ */
+describe('#1005 Phase 3 Item D: independent raw-file-on-disk oracle', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lien-test-jvm-header-oracle-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  async function writeFile(relPath: string, content: string): Promise<void> {
+    const abs = path.join(testDir, relPath);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, content);
+  }
+
+  /** Chunk a file already written under `testDir` through the real production pipeline. */
+  async function chunkRealFile(relPath: string): Promise<CodeChunk[]> {
+    const content = await fs.readFile(path.join(testDir, relPath), 'utf-8');
+    return chunkByAST(relPath, content, { workspaceRoot: testDir });
+  }
+
+  /**
+   * Independently re-derive the package from the RAW FILE ON DISK -- a
+   * SEPARATE `fs.readFile`, never from a chunk. Deliberately duplicates
+   * `PACKAGE_DECLARATION_RE`'s pattern rather than importing it: importing
+   * the module-under-test's own regex would let a bug in that regex slip
+   * through unnoticed by both sides at once.
+   */
+  async function readPackageFromDisk(relPath: string): Promise<string | undefined> {
+    const raw = await fs.readFile(path.join(testDir, relPath), 'utf-8');
+    return /^[ \t]*package[ \t]+([\w.]+)/m.exec(raw)?.[1];
+  }
+
+  it('derives the correct package for a package-private Kotlin file with a short (< minChunkSize) header, through the real chunker', async () => {
+    // No `public`/exported declaration -- `internal` -- so nothing bypassed
+    // `minChunkSize` for this file's 2-line header before Item D's fix.
+    const relPath = 'src/main/kotlin/a/b/Foo.kt';
+    await writeFile(relPath, 'package a.b\n\ninternal class Foo {\n    fun x(): Int = 1\n}\n');
+
+    const chunks = await chunkRealFile(relPath);
+    const index = buildJvmSamePackageIndex(chunks);
+
+    const diskPackage = await readPackageFromDisk(relPath);
+    expect(diskPackage).toBe('a.b');
+    expect(index.packageByFile.get(relPath)).toBe(diskPackage);
+  });
+
+  it('derives the correct package for a package-private Java file with a short header', async () => {
+    const relPath = 'src/main/java/a/b/Foo.java';
+    await writeFile(relPath, 'package a.b;\n\nclass Foo {\n  int x() { return 1; }\n}\n');
+
+    const chunks = await chunkRealFile(relPath);
+    const index = buildJvmSamePackageIndex(chunks);
+
+    const diskPackage = await readPackageFromDisk(relPath);
+    expect(diskPackage).toBe('a.b');
+    expect(index.packageByFile.get(relPath)).toBe(diskPackage);
+  });
+
+  it('still derives the correct package for a PUBLIC file whose header was already bypassing minChunkSize before Item D (no regression on the already-working case)', async () => {
+    const relPath = 'src/main/java/a/b/Pub.java';
+    await writeFile(
+      relPath,
+      'package a.b;\n\npublic class Pub {\n  public int x() { return 1; }\n}\n',
+    );
+
+    const chunks = await chunkRealFile(relPath);
+    const index = buildJvmSamePackageIndex(chunks);
+
+    expect(index.packageByFile.get(relPath)).toBe(await readPackageFromDisk(relPath));
+    expect(index.packageByFile.get(relPath)).toBe('a.b');
+  });
+
+  it('agrees with the disk oracle across a small representative multi-file corpus (short header, long/commented header, and no-package-at-all)', async () => {
+    const cases: Array<{ relPath: string; content: string }> = [
+      { relPath: 'src/main/kotlin/short/Foo.kt', content: 'package short\n\ninternal class Foo\n' },
+      {
+        relPath: 'src/main/java/withcomment/Bar.java',
+        content:
+          'package withcomment;\n\n/*\n * A long license header that already exceeds minChunkSize\n * on its own, independent of Item D.\n */\nclass Bar {\n  int x() { return 1; }\n}\n',
+      },
+      { relPath: 'nopkg/Default.java', content: 'class Default {\n  int x() { return 1; }\n}\n' },
+    ];
+    for (const c of cases) await writeFile(c.relPath, c.content);
+
+    const allChunks = (await Promise.all(cases.map(c => chunkRealFile(c.relPath)))).flat();
+    const index = buildJvmSamePackageIndex(allChunks);
+
+    for (const c of cases) {
+      expect(index.packageByFile.get(c.relPath)).toBe(await readPackageFromDisk(c.relPath));
+    }
+    expect(index.packageByFile.get(cases[0].relPath)).toBe('short');
+    expect(index.packageByFile.get(cases[1].relPath)).toBe('withcomment');
+    expect(index.packageByFile.get(cases[2].relPath)).toBeUndefined();
+  });
+
+  it('resolves a real same-package dependent end-to-end for a package-private target whose header used to be dropped -- the exact regression this fix closes', async () => {
+    const targetFile = 'src/main/kotlin/a/b/Widget.kt';
+    const consumerFile = 'src/main/kotlin/a/b/Consumer.kt';
+    await writeFile(targetFile, 'package a.b\n\ninternal class Widget {\n    fun render() {}\n}\n');
+    await writeFile(
+      consumerFile,
+      'package a.b\n\ninternal class Consumer {\n    fun use() { Widget().render() }\n}\n',
+    );
+
+    const chunks = [...(await chunkRealFile(targetFile)), ...(await chunkRealFile(consumerFile))];
+    const index = buildJvmSamePackageIndex(chunks);
+
+    expect(resolveJvmSamePackageDependents(targetFile, index)).toEqual([consumerFile]);
+  });
+});

--- a/packages/parser/src/jvm-same-package-signals.test.ts
+++ b/packages/parser/src/jvm-same-package-signals.test.ts
@@ -302,6 +302,25 @@ describe('findJvmSamePackageDependents', () => {
     expect(findJvmSamePackageDependents('src/main/java/a/b/Foo.java', chunks)).toEqual([]);
   });
 
+  it('package lines are excluded from the text-match corpus (#1005 Phase 3 Item D bundled rider): a candidate whose ONLY occurrence of the type name is in its OWN package declaration is not counted', () => {
+    const chunks: CodeChunk[] = [
+      // Package-locally-unique "Foo" declared in a package whose OWN last
+      // segment happens to be spelled "Foo" too -- deliberately contrived so
+      // that EVERY file in this package's `package a.b.Foo` line textually
+      // contains the word "Foo", independent of anything the file's real
+      // code does.
+      declChunk('src/main/java/a/b/Foo/Container.java', 'Foo', 'a.b.Foo'),
+      // Unrelated.java's actual code makes NO reference to Foo at all --
+      // its ONLY textual occurrence of "Foo" is its own `package a.b.Foo`
+      // line, newly exposed to the match corpus by #1005 Phase 3 Item D's
+      // header-chunking fix.
+      usageChunk('src/main/java/a/b/Foo/Unrelated.java', [], 'a.b.Foo'),
+    ];
+    expect(findJvmSamePackageDependents('src/main/java/a/b/Foo/Container.java', chunks)).toEqual(
+      [],
+    );
+  });
+
   it('excludes the target file itself even when it references its own name', () => {
     const chunks: CodeChunk[] = [
       makeChunk({

--- a/packages/parser/src/jvm-same-package-signals.ts
+++ b/packages/parser/src/jvm-same-package-signals.ts
@@ -300,27 +300,41 @@ function buildFilesByPackage(
 const IMPORT_LINE_RE = /^[ \t]*import\b/;
 
 /**
- * `content` with every `import` line removed. Feeds the reference-matching
- * body text (`nonImportContentByFile`) -- see the module doc's G6 section
- * and `collectShadowBindings`'s doc comment for why import lines are
- * excluded from the TEXT-MATCH corpus specifically: any edge whose only
- * textual evidence is an import line is a DOTTED-FQN import Mechanism 1
- * (`jvm-source-root.ts`) already owns (confirmed for Java's
+ * `content` with every `import` AND `package` declaration line removed.
+ * Feeds the reference-matching body text (`nonImportContentByFile`) -- see
+ * the module doc's G6 section and `collectShadowBindings`'s doc comment for
+ * why import lines are excluded from the TEXT-MATCH corpus specifically: any
+ * edge whose only textual evidence is an import line is a DOTTED-FQN import
+ * Mechanism 1 (`jvm-source-root.ts`) already owns (confirmed for Java's
  * `import`/`import static` forms via `staticMemberClassPath`; Kotlin has no
  * equivalent static-member-import fallback -- see this module's own doc
  * comment on that gap).
+ *
+ * `package` lines are stripped for a related but distinct reason (#1005
+ * Phase 3 Item D): before that fix, a file's `package` line usually never
+ * reached the match corpus at all in the exact short/non-exported-header
+ * cases this gate cares about, because `chunker.ts` dropped that whole range.
+ * That fix makes the header a real, always-present chunk -- which newly
+ * exposes the literal `package a.b.Foo;`-style text to
+ * `identifierBoundaryRe`'s plain `\b` boundary for the FIRST time. A package
+ * whose LAST segment happens to collide with a real package-locally-unique
+ * type name declared elsewhere (e.g. `package a.b.Foo;` alongside a
+ * top-level `class Foo` in package `a.b`) would then read as a textual
+ * reference to that type purely from the file's own header -- reusing
+ * `PACKAGE_DECLARATION_RE` (the same single source of truth `derivePackage`
+ * already uses) rather than a second copy of the pattern.
  */
-function stripImportLines(content: string): string {
+function stripImportAndPackageLines(content: string): string {
   return content
     .split('\n')
-    .filter(line => !IMPORT_LINE_RE.test(line))
+    .filter(line => !IMPORT_LINE_RE.test(line) && !PACKAGE_DECLARATION_RE.test(line))
     .join('\n');
 }
 
 function buildNonImportContentIndex(chunksByFile: Map<string, CodeChunk[]>): Map<string, string> {
   const out = new Map<string, string>();
   for (const [file, fileChunks] of chunksByFile) {
-    out.set(file, fileChunks.map(chunk => stripImportLines(chunk.content)).join('\n'));
+    out.set(file, fileChunks.map(chunk => stripImportAndPackageLines(chunk.content)).join('\n'));
   }
   return out;
 }


### PR DESCRIPTION
## Summary

#1005 Phase 3, Item D. Fixes a chunker bug (not a resolution-gate bug):
`extractUncoveredCode` in `packages/parser/src/ast/chunker.ts` drops any
uncovered range shorter than `minChunkSize` (7 at the default `chunkSize=75`)
unless the WHOLE FILE bypasses it via `hasExports`/`fileHasNoTopLevelChunks`.
A package-private Java/Kotlin file's `package` line (or a C# file's
file-scoped `namespace` line) can sit in a short leading gap and get dropped
entirely — `derivePackage`/`deriveCSharpNamespace` then return `undefined`
for that file, silently excluding it from same-package/namespace resolution
as both target and candidate.

## The fix

Bypass `minChunkSize` **per-range** for the file's own leading (header)
range specifically (`isLeadingHeaderRange`, `range.start === 0`) — not a
file-global predicate. An unrelated short gap elsewhere in the same file is
still dropped as noise; proven by a dedicated test with both a header and a
second short gap in one fixture.

## V1 vs V2 — real measurement, not a coin flip

The plan flagged a required decision: **V1** (bypass any leading range,
position-only, no regex) vs **V2** (bypass only a range whose content
matches a package/namespace regex). The plan's own prior V1-vs-V2 comparison
was run on this repo (TS/JS-dominated, where `hasExports` is almost always
true), which can't distinguish the two variants. I re-ran the comparison on
6 real corpora with actual JVM/C# content:

| Corpus | V1 adds | V2 adds | V1-only excess | Note |
|---|---|---|---|---|
| kotlinx-coroutines | 47 | 46 | 1 | the 1 excess is an empty `.js` file (0 bytes) |
| klaxon | 1 | 0 | 1 | excess is an empty `.js` file |
| javapoet | 0 | 0 | 0 | — |
| retrofit | 3 | 1 | 2 | excess is 2 real `.js` files in `website/public/`, unrelated to JVM |
| okhttp | 0 | 0 | 0 | — |
| serilog (C#) | 3 | 3 | 0 | **V1 and V2 coincide exactly** |

V1's excess over V2 is 0–2 per corpus, and **every single excess case is a
non-JVM/non-C# file** (an empty JS file or an unrelated docs-site script) —
never a real miss. Shipping V1: no language-specific regex needed, simpler
code, and it recovers C#'s identical documented weakness
(`csharp-type-reference-signals.ts`'s own doc comment, 11/216 misses on
serilog) for free — confirmed above (3 header chunks recovered on a real
serilog clone).

## Required additions

- **`INDEX_FORMAT_VERSION` bumped 5 → 6** (`packages/core/src/constants.ts`)
  — all 5 production consumers of `buildJvmSamePackageIndex` read chunks at
  query time; without the bump, `shouldReindexFile`'s mtime+hash check means
  the fix never reaches an existing index until a manual full reindex.
- **New independent oracle** (`jvm-same-package-chunker-integration.test.ts`)
  — every existing test builds `CodeChunk[]` by hand, so the existing P2
  brute-force oracle re-derives package from `chunk.content`, which is
  structurally blind to a chunker bug (production and the oracle read the
  same possibly-wrong stream). This new suite writes real files to disk,
  chunks them through the REAL `chunkByAST`, and cross-checks against a
  SEPARATE raw `fs.readFile`. Verified this actually catches the regression:
  reverting the chunker fix makes 4 of its 5 tests fail with the exact
  `expected undefined to be 'a.b'` / empty-dependents shape the bug produces.
- **Package lines stripped from the same-package match corpus**
  (`jvm-same-package-signals.ts`'s `stripImportAndPackageLines`, mirrors the
  existing import-line stripping) — this fix is what first exposes header
  chunks to that match corpus, and a package whose own last segment collides
  with a real type name could otherwise self-reference. New regression test
  included; reuses `PACKAGE_DECLARATION_RE` rather than a second copy of the
  pattern.

## Real edge-impact measurement (before/after, actual implementation)

Ran `resolveJvmSamePackageDependents` for every file, before vs after, on
fresh clones:

| Corpus | before | after | added | removed |
|---|---|---|---|---|
| kotlinx-coroutines | 1011 | 1049 | +43 | −5 |
| klaxon | 238 | 238 | +0 | −0 |
| javapoet | 165 | 165 | +0 | −0 |
| retrofit | 506 | 508 | +2 | −0 |
| okhttp | 1183 | 1183 | +0 | −0 |
| **pooled** | | | **+45** | **−5** |

Close to the plan's prior estimate (+48/−5 pooled, +43/−5 on
kotlinx-coroutines specifically) — kotlinx-coroutines matches exactly; the
small pooled difference is expected corpus drift (fresh clone vs. the
snapshot used during planning).

### Classifying the 5 removed edges (read the real source, not just counted)

All 5 removals are on kotlinx-coroutines and turned out to share **one root
cause**: Kotlin multiplatform `expect`/`actual` declarations that share a
bare type name across multiple platform source-set files
(`common`/`native`/`jsAndWasmShared`/`wasmJs`/`jvm`), all nominally in the
identical package string. Before this fix, some sibling `actual`
declarations had undetectable packages (short, non-exported headers),
so G1' (package-local uniqueness) only ever saw ONE owner and resolved the
name; after the fix, the siblings' packages become derivable, G1' correctly
detects the multi-owner ambiguity, and (correctly, per its own conservative
"never guess" design) suppresses resolution for the name entirely — which
also removes any genuinely-correct edge that happened to route through that
same name.

Examples read directly from the removed edges:
- `SchedulerTask.common.kt` (`expect abstract class SchedulerTask`) had 3
  sibling `actual` declarations (`jvm` typealias, `native` class) once
  `native/src/SchedulerTask.kt`'s 3-line header became derivable — this
  removed both the `jvm` typealias pairing AND
  `common/src/internal/DispatchedTask.kt`'s edge, even though
  `DispatchedTask` genuinely `: SchedulerTask()` in the exact same
  `commonMain` compilation unit as the target (zero real ambiguity there).
- `LocalAtomics.common.kt`/`LocalAtomicInt`: same shape — `native` and
  `jsAndWasmShared` both declare `actual class LocalAtomicInt`; once both
  became derivable, G1' correctly saw 3 owners and suppressed the
  `jvm` typealias pairing.
- `JSDispatcher.kt`(js)'s `NodeDispatcher` collides with `wasmJs`'s own
  `NodeDispatcher` once `wasmJs/src/JSDispatcher.kt`'s 3-line header became
  derivable — removed `CoroutineContext.kt`(js)'s genuine same-source-set
  reference to it.
- `Concurrent.kt`(native)/`WorkaroundAtomicReference`: same `expect`/`actual`
  shape.

**My classification: 0 of 5 are fabrications; all 5 are true (in the sense
of a real, meaningful language-level relationship) edges losing their
safety justification** — the tool's package-local-uniqueness model is
deliberately multiplatform-blind (it has no notion of "these platform
variants are never compiled together"), so once it correctly sees multiple
same-named declarations in one package it can no longer safely guess which
one a reference resolves to, even where a human (or a platform-aware tool)
would know. This differs from the plan's prior estimate (1 fabrication, 4
true-edges) — worth flagging honestly rather than forcing my sample to
match: my corpus snapshot's specific 5 removals all trace to the identical
expect/actual mechanism, and none of them individually looks like a random
same-name collision. Erring toward under-reporting either way (the safe
direction).

I found no test in the current codebase asserting "21 same-package edges
involving Kotlin `actual typealias` declarations" (searched
`jvm-same-package-signals.test.ts` and the repo broadly) — the action item
to correct such a test to 20 doesn't apply to what's actually shipped, so
nothing to change there. My own direct measurement above is the closest
concrete pin: several of the 5 removed edges do involve `actual typealias`
declarations interacting with G4/G1'.

## Dogfood — real upgrade path, verbatim

Built an OLD index on a fresh kotlinx-coroutines clone with the fix
reverted (`lien index --force`), then restored the fix and ran a plain
`lien index` (no `--force`) to exercise the real upgrade path:

```
[Lien] Index format v5 is incompatible with current v6
[Lien] Full reindex required after Lien upgrade
✔ Indexing complete (1129/1129)
```

`lien annotate` on `SchedulerTask.common.kt`, same file, before vs after:

BEFORE (old index):
```
Lien impact for kotlinx-coroutines-core/common/src/SchedulerTask.common.kt:
  • 2 files import this — kotlinx-coroutines-core/common/src/internal/DispatchedTask.kt, kotlinx-coroutines-core/jvm/src/SchedulerTask.kt; risk: medium (2 production callers, 2 untested).
  • No test coverage.
```

AFTER (upgraded index, real reindex triggered automatically):
```
Lien impact for kotlinx-coroutines-core/common/src/SchedulerTask.common.kt:
  • Dependents not determinable from imports (enclosing-namespace access).
  • No test coverage.
```

This is the correct outcome: the tool now honestly reports "not
determinable" (the pre-existing Mechanism 2 caveat) instead of confidently
asserting 2 dependents that, per the classification above, had lost their
safety justification.

## Ranking/metric sanity on kotlinx-coroutines

Sampled the newly-recovered header chunks directly (couldn't wire an MCP
session to an arbitrary external directory from this environment, so I
inspected chunk content/shape directly instead of running `search_code`
live): they're ordinary short `package`+`import`-only block chunks,
indistinguishable in shape from the thousands of pre-existing header chunks
already in every corpus's index — nothing pathological, no oversized
content, no reason to expect a BM25/structural-ranking regression.

## C# — measured, not just disclosed

Measured directly on a fresh `serilog/serilog` clone: 3 header chunks
recovered by this fix (V1 and V2 coincide exactly there), independently
confirming the mechanism `csharp-type-reference-signals.ts`'s own doc
comment already documents (11/216 misses on serilog).

## Verification

- `chunker.test.ts`: 74/74 green, including the new per-range test (header
  survives, unrelated short gap elsewhere still dropped).
- `jvm-same-package-signals.test.ts`: 29/29 green, including the new
  package-line-stripping regression test.
- `jvm-same-package-chunker-integration.test.ts` (new): 5/5 green; verified
  4/5 fail on the unfixed chunker (see above).
- Full `npm run test -w @liendev/parser`: 1970/1970 green.
- `npm test` (parser, core, review, cli, action): all green.
- `npm run build`, `npm run typecheck`, `npm run lint` (0 errors), `npm run
  format:check`: all clean.
- `lien delta`: exit 0 — 1 advisory "worsened" (`extractUncoveredCode`
  cognitive 3→4, still well under threshold), no new-over-threshold
  crossing.
- `packages/cli/test/integration/index-state-matrix.test.ts`: 49/49 green.
- This repo's own index changes by ~+39 chunks (not the "+1 self-hosting
  artifact" the plan anticipated for a V2-shaped fix) — expected, since V1's
  bypass is language-agnostic and this repo is TS/JS-dominated: most of the
  +39 are test files' leading import blocks that previously fell under
  `minChunkSize` with no exports. Not a regression, just V1 being broader
  than the JVM-specific trigger by design.

## Not in this PR

Item E (comment/KDoc fabrication) and Item B (Java annotation declarations)
are separate PRs per the plan's sequencing, built after this one merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved short leading package and namespace headers when processing Java, Kotlin, and C# files.
  * Prevented metadata loss during code chunking and indexing.
  * Improved same-package dependency detection by excluding package declarations from text matching.
* **Tests**
  * Added coverage for short headers, commented declarations, files without packages, and same-package dependency resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR fixes a targeted chunker bug where short leading header ranges (package/namespace lines in package-private JVM/C# files) were dropped by `minChunkSize`, making package derivation fail downstream. The fix is per-range and content-blind: only the leading uncovered gap bypasses the size threshold, while other short gaps are still dropped. It also bumps `INDEX_FORMAT_VERSION` 5→6 to force reindexing and strips `package` lines from the JVM same-package text-match corpus to prevent a newly-exposed self-reference fabrication. The change is well-scoped, thoroughly tested, and the doc claims match the implementation.
>
> - Bypass `minChunkSize` only for the file's leading uncovered range in `extractUncoveredCode`
> - Strip `package` declarations from JVM same-package text-match corpus
> - Bump `INDEX_FORMAT_VERSION` from 5 to 6

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 395cca2. Updates automatically on new commits.</sup>
<!-- /lien-stats -->