### PR TITLE
fix(parser): strip comments from the JVM same-package text-match corpus (#1005 Phase 3, Item E)

### DIFF
--- a/.changeset/jvm-comment-fabrication.md
+++ b/.changeset/jvm-comment-fabrication.md
@@ -1,0 +1,17 @@
+---
+'@liendev/parser': patch
+---
+
+Fix a precision gap in the Java/Kotlin same-package dependent resolver
+(#1005 Phase 3, Item E): a same-package file whose ONLY textual reference to
+a target type sat inside a Javadoc/KDoc comment (not real code) was counted
+as a genuine dependent. `jvm-same-package-signals.ts`'s text-match corpus now
+strips Javadoc/KDoc and block comments, plus whole comment-only lines, in
+addition to the existing `import`/`package` line stripping — closing a gap
+larger than Item D's entire measured gain (2.4%–19.6% of currently-shipped
+same-package edges across 7 real corpora rested solely on a comment-only
+match). Deliberately does not also strip a trailing same-line comment after
+real code — measured to recover only 0-2 additional edges per corpus against
+100+ comment-only-line fabrications already caught, not worth the added risk
+of a bare `//` inside a string literal truncating a real code line. Query-time
+only; no `INDEX_FORMAT_VERSION` bump needed.

--- a/packages/parser/src/jvm-same-package-signals.test.ts
+++ b/packages/parser/src/jvm-same-package-signals.test.ts
@@ -321,6 +321,81 @@ describe('findJvmSamePackageDependents', () => {
     );
   });
 
+  it('#1005 Phase 3 Item E: a candidate whose ONLY occurrence of the type name is inside a Javadoc/KDoc comment is not counted', () => {
+    const chunks: CodeChunk[] = [
+      declChunk('src/main/java/a/b/Foo.java', 'Foo', 'a.b'),
+      makeChunk({
+        file: 'src/main/java/a/b/Bar.java',
+        content:
+          'package a.b\n\n/**\n * See {@link Foo} for details.\n */\nclass Bar { void method() {} }',
+        symbolName: 'Bar',
+        symbolType: 'class',
+      }),
+    ];
+    expect(findJvmSamePackageDependents('src/main/java/a/b/Foo.java', chunks)).toEqual([]);
+  });
+
+  it('#1005 Phase 3 Item E: a candidate whose ONLY occurrence of the type name is inside a whole-line `//` comment is not counted', () => {
+    const chunks: CodeChunk[] = [
+      declChunk('src/main/java/a/b/Foo.java', 'Foo', 'a.b'),
+      makeChunk({
+        file: 'src/main/kotlin/a/b/Bar.kt',
+        content:
+          'package a.b\n\n// TODO: migrate this to use Foo once it stabilizes\nclass Bar { fun method() {} }',
+        symbolName: 'Bar',
+        symbolType: 'class',
+      }),
+    ];
+    expect(findJvmSamePackageDependents('src/main/java/a/b/Foo.java', chunks)).toEqual([]);
+  });
+
+  it('#1005 Phase 3 Item E: a multi-line block comment is fully removed without bleeding into the real code that follows it', () => {
+    const chunks: CodeChunk[] = [
+      declChunk('src/main/java/a/b/Foo.java', 'Foo', 'a.b'),
+      makeChunk({
+        file: 'src/main/java/a/b/Bar.java',
+        content:
+          'package a.b\n\n/*\n * Multi-line block comment mentioning Foo,\n * spanning several lines.\n */\nclass Bar { void method() {} }',
+        symbolName: 'Bar',
+        symbolType: 'class',
+      }),
+    ];
+    // The ONLY mention of "Foo" is inside the block comment -- must not resolve.
+    expect(findJvmSamePackageDependents('src/main/java/a/b/Foo.java', chunks)).toEqual([]);
+  });
+
+  it('#1005 Phase 3 Item E: a REAL code reference still resolves even when a nearby comment ALSO mentions the same name (comment-stripping must not eat adjacent real code)', () => {
+    const chunks: CodeChunk[] = [
+      declChunk('src/main/java/a/b/Foo.java', 'Foo', 'a.b'),
+      makeChunk({
+        file: 'src/main/java/a/b/Bar.java',
+        content:
+          'package a.b\n\n/**\n * Uses {@link Foo} internally.\n */\nclass Bar { void method() { Foo.doSomething(); } }',
+        symbolName: 'Bar',
+        symbolType: 'class',
+      }),
+    ];
+    expect(findJvmSamePackageDependents('src/main/java/a/b/Foo.java', chunks)).toEqual([
+      'src/main/java/a/b/Bar.java',
+    ]);
+  });
+
+  it('#1005 Phase 3 Item E: a REAL code reference before a TRAILING same-line comment still resolves (stripping never eats the code portion of a line, only whole comment-only lines/blocks)', () => {
+    const chunks: CodeChunk[] = [
+      declChunk('src/main/java/a/b/Foo.java', 'Foo', 'a.b'),
+      makeChunk({
+        file: 'src/main/java/a/b/Bar.java',
+        content:
+          'package a.b\n\nclass Bar { void method() { Foo.doSomething(); // legacy, TODO remove\n } }',
+        symbolName: 'Bar',
+        symbolType: 'class',
+      }),
+    ];
+    expect(findJvmSamePackageDependents('src/main/java/a/b/Foo.java', chunks)).toEqual([
+      'src/main/java/a/b/Bar.java',
+    ]);
+  });
+
   it('excludes the target file itself even when it references its own name', () => {
     const chunks: CodeChunk[] = [
       makeChunk({

--- a/packages/parser/src/jvm-same-package-signals.ts
+++ b/packages/parser/src/jvm-same-package-signals.ts
@@ -300,12 +300,36 @@ function buildFilesByPackage(
 const IMPORT_LINE_RE = /^[ \t]*import\b/;
 
 /**
- * `content` with every `import` AND `package` declaration line removed.
- * Feeds the reference-matching body text (`nonImportContentByFile`) -- see
- * the module doc's G6 section and `collectShadowBindings`'s doc comment for
- * why import lines are excluded from the TEXT-MATCH corpus specifically: any
- * edge whose only textual evidence is an import line is a DOTTED-FQN import
- * Mechanism 1 (`jvm-source-root.ts`) already owns (confirmed for Java's
+ * Matches an entire Javadoc/KDoc or block comment (`/** ... *\/` or
+ * `/* ... *\/`), possibly spanning multiple lines -- `/**` is still just
+ * `/*` as far as this pattern cares, so no special case is needed for
+ * Javadoc/KDoc specifically. Non-greedy (`[\s\S]*?`) so two SEPARATE block
+ * comments on the same file don't collapse into one match spanning the real
+ * code between them.
+ *
+ * A `/*`-shaped sequence inside a STRING LITERAL (vanishingly rare in real
+ * Java/Kotlin source) would be misread as a real comment opener -- an
+ * accepted, fail-safe-direction limitation shared by any regex-based
+ * comment stripper: it can only over-strip (suppress a genuine match),
+ * never fabricate one.
+ */
+const BLOCK_COMMENT_RE = /\/\*[\s\S]*?\*\//g;
+
+/**
+ * A line whose ENTIRE trimmed text is a `//` line comment. Deliberately
+ * does NOT match a line with a TRAILING comment after real code (`foo(); //
+ * note`) -- see `stripCommentsImportsAndPackageLines`'s doc comment for why.
+ */
+const COMMENT_ONLY_LINE_RE = /^[ \t]*\/\//;
+
+/**
+ * `content` with every Javadoc/KDoc comment, `import` line, and `package`
+ * line removed. Feeds the reference-matching body text
+ * (`nonImportContentByFile`) -- see the module doc's G6 section and
+ * `collectShadowBindings`'s doc comment for why import lines are excluded
+ * from the TEXT-MATCH corpus specifically: any edge whose only textual
+ * evidence is an import line is a DOTTED-FQN import Mechanism 1
+ * (`jvm-source-root.ts`) already owns (confirmed for Java's
  * `import`/`import static` forms via `staticMemberClassPath`; Kotlin has no
  * equivalent static-member-import fallback -- see this module's own doc
  * comment on that gap).
@@ -323,18 +347,44 @@ const IMPORT_LINE_RE = /^[ \t]*import\b/;
  * reference to that type purely from the file's own header -- reusing
  * `PACKAGE_DECLARATION_RE` (the same single source of truth `derivePackage`
  * already uses) rather than a second copy of the pattern.
+ *
+ * Comments are stripped for a THIRD, PRE-EXISTING reason (#1005 Phase 3
+ * Item E, independent of Item D): a same-package file whose ONLY textual
+ * reference to a target type sits inside a Javadoc/KDoc comment (not real
+ * code) was counted as a genuine dependent by the already-shipped Phase 1
+ * resolver (#1100). Measured across 6 real Java/Kotlin corpora: 2.4%-19.6%
+ * of the resolver's currently-shipped edges rest SOLELY on a comment-only
+ * match (see the PR body for the exact per-corpus numbers) -- larger than
+ * Item D's entire measured gain.
+ *
+ * Deliberately stops at whole COMMENT-ONLY lines and full block comments,
+ * and does NOT also strip a trailing `// comment` that follows real code on
+ * the same line: measured (same 6 corpora) that recovering trailing
+ * same-line comments on top of this gains only 0-2 ADDITIONAL edges per
+ * corpus, against 100+ comment-only-line fabrications this already catches
+ * -- not worth the extra risk of a bare `//` inside a string literal (e.g. a
+ * URL) truncating a real code line if stripped blindly.
  */
-function stripImportAndPackageLines(content: string): string {
-  return content
+function stripCommentsImportsAndPackageLines(content: string): string {
+  const withoutBlockComments = content.replace(BLOCK_COMMENT_RE, '');
+  return withoutBlockComments
     .split('\n')
-    .filter(line => !IMPORT_LINE_RE.test(line) && !PACKAGE_DECLARATION_RE.test(line))
+    .filter(
+      line =>
+        !IMPORT_LINE_RE.test(line) &&
+        !PACKAGE_DECLARATION_RE.test(line) &&
+        !COMMENT_ONLY_LINE_RE.test(line),
+    )
     .join('\n');
 }
 
 function buildNonImportContentIndex(chunksByFile: Map<string, CodeChunk[]>): Map<string, string> {
   const out = new Map<string, string>();
   for (const [file, fileChunks] of chunksByFile) {
-    out.set(file, fileChunks.map(chunk => stripImportAndPackageLines(chunk.content)).join('\n'));
+    out.set(
+      file,
+      fileChunks.map(chunk => stripCommentsImportsAndPackageLines(chunk.content)).join('\n'),
+    );
   }
   return out;
 }
@@ -428,7 +478,7 @@ export interface JvmSamePackageIndex {
   pkgLocalOwners: Map<string, Set<string>>;
   /** package -> every JVM file with that derived package (G2 candidate set). */
   filesByPackage: Map<string, string[]>;
-  /** file -> its own content with `import` lines stripped (the G6/text-match corpus). */
+  /** file -> its own content with `import`/`package` lines and comments stripped (the G6/text-match corpus). */
   nonImportContentByFile: Map<string, string>;
   /** file -> its own single-type/single-static import bindings (G6). */
   shadowBindingsByFile: Map<string, Map<string, string>>;


### PR DESCRIPTION
## Summary

#1005 Phase 3, Item E. A separate, pre-existing precision gap in the
already-shipped Phase 1 same-package resolver (#1100) — unrelated to Item
D's chunker fix (#1118, already merged). `stripImportLines` strips `import`
lines from `nonImportContentByFile` but never comments, so a same-package
file whose ONLY textual reference to a target type is inside a Javadoc/KDoc
comment (not real code) was counted as a genuine dependent.

## Fix

`jvm-same-package-signals.ts`'s match corpus now strips, in addition to the
existing `import`/`package` line stripping (Item D's bundled rider):
- Full Javadoc/KDoc and block comments (`/** ... */`, `/* ... */`),
  non-greedy so two separate block comments don't collapse into one match
  spanning real code between them.
- Whole comment-only lines (`//` at the start of a trimmed line).

Deliberately does **not** also strip a trailing `// comment` after real code
on the same line — see measurement below for why.

## Real measurement: before/after comment-fabrication rate, 7 corpora

Measured directly (non-invasively mutating the returned index's
`nonImportContentByFile` map to test both a comment-only-line variant and a
more aggressive trailing-comment variant, without touching source) before
implementing, then re-measured against the actual shipped implementation —
identical numbers both times:

| Corpus | edges before | edges after | comment-only removed | % of total | extra from ALSO stripping trailing same-line comments |
|---|---|---|---|---|---|
| kotlinx-coroutines | 1049 | 902 | 147 | 14.0% | +1 |
| klaxon | 238 | 226 | 12 | 5.0% | +0 |
| javapoet | 165 | 161 | 4 | 2.4% | +0 |
| retrofit | 508 | 491 | 17 | 3.3% | +0 |
| okhttp | 1183 | 1105 | 78 | 6.6% | +2 |
| gson | 352 | 283 | 69 | 19.6% | +0 |
| moshi | 188 | 176 | 12 | 6.4% | +0 |

Range 2.4%–19.6%, matching the plan's prior estimate ("roughly 10%, up to
~20% on some"). **Also-stripping trailing same-line comments** (a more
aggressive variant) recovers only 0–2 additional edges per corpus, against
100+ comment-only-line fabrications already caught by the simpler variant —
not worth the added risk (a bare `//` inside a string literal, e.g. a URL,
would wrongly truncate a real code line if stripped blindly). Shipping the
simpler, safer variant only.

## Zero genuine edges lost — by construction, not just by measurement

The fix only ever removes whole comment-only lines and complete block
comments; it never touches a line containing real code (a trailing `//
comment` after real code is explicitly preserved verbatim, including the
real-code portion before it). So a real code reference cannot be
accidentally stripped by this change — confirmed with a dedicated test
(`a REAL code reference still resolves even when a nearby comment ALSO
mentions the same name`) and another for the trailing-comment case
specifically.

## Dogfood — a real comment-only fabrication, found and confirmed gone

Real example from a fresh `javapoet` clone:
`src/main/java/com/squareup/javapoet/NameAllocator.java`'s class-level
Javadoc contains a `<pre>{@code ...}` usage example that writes
`MethodSpec.Builder builder = MethodSpec.methodBuilder("toString")` as
SAMPLE CODE inside the doc comment — this is the ONLY occurrence of
"MethodSpec" anywhere in the file; `NameAllocator.java` never actually
imports or uses `MethodSpec` in its real implementation:

```
$ grep -n MethodSpec NameAllocator.java
46: *   MethodSpec.Builder builder = MethodSpec.methodBuilder("toString")
```

Before this fix: `MethodSpec.java -> NameAllocator.java` was a resolved
edge. After this fix: it's gone (confirmed via the same before/after edge
computation used for the table above).

## Verification

- `jvm-same-package-signals.test.ts`: 34/34 green, including 5 new tests
  (Javadoc-only reference, whole-line `//`-only reference, multi-line block
  comment not bleeding into real code, real reference surviving a nearby
  comment, real reference surviving its own trailing same-line comment).
- Full `npm run test -w @liendev/parser`: 1975/1975 green.
- `npm test` (parser, core, review, cli, action): all green.
- `npm run build`, `npm run typecheck`, `npm run lint` (0 errors), `npm run
  format:check`: all clean.
- `lien delta`: no worsened/new-over-threshold functions.
- `packages/cli/test/integration/index-state-matrix.test.ts`: 49/49 green.
- Query-time only change (`nonImportContentByFile` is rebuilt from
  already-stored chunk content) — no `INDEX_FORMAT_VERSION` bump needed,
  unlike Item D.

## Not in this PR

Item B (Java annotation declarations) is the next and final PR in this
sequence, built after this one merges.

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR tightens the Java/Kotlin same-package dependent resolver by stripping Javadoc/KDoc/block comments and whole-line `//` comments from the text-match corpus, preventing comment-only references from being counted as real dependents. The change is query-time only, internal to the parser, and well-covered by new tests. The accepted regex limitations (e.g., `/*` inside string literals, nested Kotlin block comments) are explicitly documented and operate in the fail-safe over-strip direction rather than fabricating edges.
>
> - Added block-comment and whole-line comment stripping to the same-package text-match corpus
> - Preserved trailing same-line comments after real code by design, with measured justification
> - Updated doc comments and changeset to match the new behavior

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit 3c244ed. Updates automatically on new commits.</sup>
<!-- /lien-stats -->