### PR TITLE
feat(parser): extract Java annotation declarations as chunks (#1005 Phase 3, Item B)

### DIFF
--- a/.changeset/java-annotation-declarations.md
+++ b/.changeset/java-annotation-declarations.md
@@ -1,0 +1,25 @@
+---
+'@liendev/parser': minor
+---
+
+Extract Java annotation declarations (`@interface Foo {}`,
+`annotation_type_declaration`) as real chunks (#1005 Phase 3, Item B).
+Previously absent from the Java extractor entirely — an annotation-only file
+produced NO chunk at all, so `get_files_context`, `list_functions`, and
+`search_code` returned nothing for it.
+
+Maps to `symbolType: 'interface'`, mirroring the existing
+`record_declaration` → `'class'` precedent rather than adding a new
+`'annotation'` member to `ChunkMetadata['symbolType']`'s closed union.
+Annotation MEMBERS (`String value();`-style element declarations) are
+deliberately not extracted as their own chunks or exports — only the
+annotation's own declared name. A nested annotation reports `parentClass`
+via the same existing traversal machinery any other nested declaration
+does, and can therefore never become a same-package-resolution owner (G1'
+only considers top-level declarations).
+
+The justification is context-quality, not recall: measured across 5 real
+Java corpora (javapoet, gson, retrofit, moshi, okhttp), only a handful of
+genuine same-package edges newly resolve through a top-level annotation
+(single digits) — the real gap this closes is that annotation-only files
+were previously invisible to every symbol-aware tool.

--- a/packages/core/src/vectordb/filters.test.ts
+++ b/packages/core/src/vectordb/filters.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { matchesSymbolFilter, type FilterableRecord } from './filters.js';
+import { matchesSymbolFilter, filterBySymbolType, type FilterableRecord } from './filters.js';
 
 function record(extra: Partial<FilterableRecord> = {}): FilterableRecord {
   return {
@@ -26,5 +26,49 @@ describe('matchesSymbolFilter', () => {
     expect(matchesSymbolFilter(record({ type: 'config', symbolName: 'jobs.review' }), {})).toBe(
       false,
     );
+  });
+});
+
+describe('filterBySymbolType (#1005 Phase 3 Item B: Java annotation declarations)', () => {
+  // `filterBySymbolType` reads `symbolType` directly; `getSymbolsForType`
+  // (the function actually backing `get_symbols`-style lookups) reads a
+  // SEPARATE `interfaceNames` column instead, populated from
+  // `metadata.symbols?.interfaces` (see row-mapping.ts's `chunkToRow`) --
+  // an annotation chunk must agree on BOTH, or the two mechanisms disagree
+  // about whether the annotation "is" an interface. The Java extractor maps
+  // `annotation_type_declaration` to `symbolType: 'interface'`, and
+  // `chunker.ts`'s existing `buildLegacySymbols`/`SYMBOL_TYPE_TO_ARRAY`
+  // plumbing (already shared by every other `'interface'`-typed symbol)
+  // populates `symbols.interfaces` automatically -- no separate code path
+  // needed. This test pins that agreement at the `FilterableRecord` layer
+  // (the shape row-mapping.ts actually produces), independent of chunker.ts.
+  function annotationRecord(): FilterableRecord {
+    return {
+      file: 'src/main/java/a/b/Foo.java',
+      language: 'java',
+      type: 'function',
+      symbolName: 'Foo',
+      symbolType: 'interface',
+      interfaceNames: ['Foo'],
+    };
+  }
+
+  it('filterBySymbolType matches an annotation chunk under "interface" via symbolType', () => {
+    const records = [annotationRecord()];
+    expect(filterBySymbolType(records, 'interface')).toEqual(records);
+  });
+
+  it('filterBySymbolType does NOT match an annotation chunk under "class"', () => {
+    const records = [annotationRecord()];
+    expect(filterBySymbolType(records, 'class')).toEqual([]);
+  });
+
+  it('getSymbolsForType agrees: the annotation name is reachable via interfaceNames, not classNames or functionNames', () => {
+    const r = annotationRecord();
+    // matchesSymbolFilter accepts a `symbolType` filter option and internally
+    // calls the same `getSymbolsForType`/`matchesSymbolType` path
+    // `filterBySymbolType`'s callers rely on for symbol-name filtering.
+    expect(matchesSymbolFilter(r, { symbolType: 'interface', pattern: 'Foo' })).toBe(true);
+    expect(matchesSymbolFilter(r, { symbolType: 'class', pattern: 'Foo' })).toBe(false);
   });
 });

--- a/packages/parser/src/ast/languages/java.test.ts
+++ b/packages/parser/src/ast/languages/java.test.ts
@@ -21,11 +21,28 @@ describe('Java Language', () => {
       expect(traverser.targetNodeTypes).toContain('constructor_declaration');
     });
 
-    it('should identify class/interface/enum/record as container types', () => {
+    it('should identify class/interface/enum/record/annotation as container types', () => {
       expect(traverser.containerTypes).toContain('class_declaration');
       expect(traverser.containerTypes).toContain('interface_declaration');
       expect(traverser.containerTypes).toContain('enum_declaration');
       expect(traverser.containerTypes).toContain('record_declaration');
+      expect(traverser.containerTypes).toContain('annotation_type_declaration');
+    });
+
+    // #1005 Phase 3 Item B: `annotation_type_declaration` is a container only
+    // for `shouldExtractChildren` (so it still becomes its own top-level
+    // chunk) -- `getContainerBody` deliberately returns null for it so
+    // `findTopLevelNodes` never descends into `annotation_type_body` and
+    // extracts annotation MEMBERS (`String value();`-style element
+    // declarations) as separate chunks. Mirrors the Python
+    // `decorated_definition` precedent `emitsChildChunks`'s doc comment
+    // (ast/chunker.ts) describes.
+    it('should extract children (shouldExtractChildren) from an annotation declaration but decline a body to descend into (getContainerBody)', () => {
+      const code = 'public @interface Foo { String value(); }';
+      const root = mustParse(code, 'java');
+      const annotationNode = findNode(root, 'annotation_type_declaration')!;
+      expect(traverser.shouldExtractChildren(annotationNode)).toBe(true);
+      expect(traverser.getContainerBody(annotationNode)).toBeNull();
     });
 
     it('should extract children from class declarations', () => {
@@ -199,6 +216,33 @@ describe('Java Language', () => {
       expect(exports).toContain('run');
       expect(exports).toContain('status');
       expect(exports).not.toContain('init');
+    });
+
+    // #1005 Phase 3 Item B
+    it('should extract a public annotation declaration', () => {
+      const code = 'public @interface Foo { String value(); }';
+      const root = mustParse(code, 'java');
+      const exports = exportExtractor.extractExports(root);
+      expect(exports).toContain('Foo');
+    });
+
+    it('should not export a package-private annotation declaration', () => {
+      const code = '@interface Foo { String value(); }';
+      const root = mustParse(code, 'java');
+      const exports = exportExtractor.extractExports(root);
+      expect(exports).not.toContain('Foo');
+    });
+
+    it('should not export annotation MEMBERS even when the annotation itself is public (explicitly excluded, #1005 Phase 3 Item B)', () => {
+      const code = `public @interface Foo {
+    String value();
+    int count() default 1;
+}`;
+      const root = mustParse(code, 'java');
+      const exports = exportExtractor.extractExports(root);
+      expect(exports).toContain('Foo');
+      expect(exports).not.toContain('value');
+      expect(exports).not.toContain('count');
     });
   });
 
@@ -479,6 +523,31 @@ describe('Java Language', () => {
       const recordNode = root.namedChild(0)!;
       const symbol = symbolExtractor.extractSymbol(recordNode, code);
       expect(symbol!.signature).toBe('record Person implements Foo');
+    });
+
+    // #1005 Phase 3 Item B: `@interface Foo {}` maps to `symbolType:
+    // 'interface'` -- mirrors the `record_declaration` -> `'class'`
+    // precedent immediately above rather than a bespoke `'annotation'`
+    // symbolType.
+    it('should extract annotation_type_declaration info as an interface-typed symbol', () => {
+      const code = 'public @interface Foo { String value(); }';
+      const root = mustParse(code, 'java');
+      const annotationNode = findNode(root, 'annotation_type_declaration')!;
+      const symbol = symbolExtractor.extractSymbol(annotationNode, code);
+      expect(symbol).not.toBeNull();
+      expect(symbol!.name).toBe('Foo');
+      expect(symbol!.type).toBe('interface');
+      expect(symbol!.signature).toBe('@interface Foo');
+    });
+
+    it('should attach the enclosing type as parentClass for a nested annotation declaration', () => {
+      const code = 'public class Outer { @interface Nested { String value(); } }';
+      const root = mustParse(code, 'java');
+      const annotationNode = findNode(root, 'annotation_type_declaration')!;
+      const symbol = symbolExtractor.extractSymbol(annotationNode, code, 'Outer');
+      expect(symbol!.name).toBe('Nested');
+      expect(symbol!.type).toBe('interface');
+      expect(symbol!.parentClass).toBe('Outer');
     });
 
     // #949: a nested type declaration (class/interface/enum/record declared
@@ -795,6 +864,72 @@ public class App {
       expect(distanceChunk).toBeDefined();
       expect(distanceChunk?.metadata.symbolType).toBe('method');
       expect(distanceChunk?.metadata.parentClass).toBe('Point');
+    });
+
+    // #1005 Phase 3 Item B: `annotation_type_declaration` was previously
+    // absent from `symbolNodeTypes`/`containerTypes` entirely, so an
+    // annotation-only file produced NO chunk at all -- `get_files_context`/
+    // `list_functions`/`search_code` returned nothing for it.
+    describe('annotation declarations (#1005 Phase 3 Item B)', () => {
+      it('should chunk a public top-level annotation declaration', () => {
+        const content = `package a.b;
+
+public @interface Foo {
+    String value();
+    int count() default 1;
+}
+`;
+        const chunks = chunkByAST('Foo.java', content);
+        const annotationChunk = chunks.find(c => c.metadata.symbolName === 'Foo');
+        expect(annotationChunk).toBeDefined();
+        expect(annotationChunk?.metadata.symbolType).toBe('interface');
+        expect(annotationChunk?.metadata.exports).toContain('Foo');
+        expect(annotationChunk?.metadata.symbols?.interfaces).toContain('Foo');
+      });
+
+      it('should still chunk a package-private annotation-only file (context-quality, not recall -- the file must not be invisible)', () => {
+        const content = `package a.b;
+
+@interface Foo {
+    String value();
+}
+`;
+        const chunks = chunkByAST('Foo.java', content);
+        const annotationChunk = chunks.find(c => c.metadata.symbolName === 'Foo');
+        expect(annotationChunk).toBeDefined();
+        expect(annotationChunk?.metadata.symbolType).toBe('interface');
+      });
+
+      it('should NOT extract annotation MEMBERS as their own chunks (explicitly excluded)', () => {
+        const content = `public @interface Foo {
+    String value();
+    int count() default 1;
+    Class<?> type();
+}
+`;
+        const chunks = chunkByAST('Foo.java', content);
+        // Exactly one chunk for the whole annotation -- no separate chunks
+        // for `value`, `count`, or `type`.
+        expect(chunks).toHaveLength(1);
+        expect(chunks[0].metadata.symbolName).toBe('Foo');
+        expect(chunks.some(c => c.metadata.symbolName === 'value')).toBe(false);
+        expect(chunks.some(c => c.metadata.symbolName === 'count')).toBe(false);
+        expect(chunks.some(c => c.metadata.symbolName === 'type')).toBe(false);
+      });
+
+      it('should attach parentClass for a nested annotation and never emit it as its own file-level chunk boundary issue', () => {
+        const content = `public class Outer {
+    @interface Nested {
+        String value();
+    }
+}
+`;
+        const chunks = chunkByAST('Outer.java', content);
+        const nestedChunk = chunks.find(c => c.metadata.symbolName === 'Nested');
+        expect(nestedChunk).toBeDefined();
+        expect(nestedChunk?.metadata.symbolType).toBe('interface');
+        expect(nestedChunk?.metadata.parentClass).toBe('Outer');
+      });
     });
   });
 });

--- a/packages/parser/src/ast/languages/java.ts
+++ b/packages/parser/src/ast/languages/java.ts
@@ -37,6 +37,7 @@ export class JavaTraverser implements LanguageTraverser {
     'interface_declaration',
     'enum_declaration',
     'record_declaration',
+    'annotation_type_declaration',
   ];
 
   declarationTypes = ['local_variable_declaration'];
@@ -53,6 +54,17 @@ export class JavaTraverser implements LanguageTraverser {
   }
 
   getContainerBody(node: SyntaxNode): SyntaxNode | null {
+    // Annotation declarations (`@interface Foo {}`) deliberately never
+    // descend into their own body -- #1005 Phase 3 Item B explicitly
+    // excludes annotation MEMBERS (`String value();`-style element
+    // declarations) from extraction. `annotation_type_declaration` is a
+    // container only for `shouldExtractChildren` (so it still becomes its
+    // own top-level chunk the normal way); this early return is what stops
+    // `findTopLevelNodes` from ever traversing into `annotation_type_body`.
+    // Mirrors the Python `decorated_definition` precedent `emitsChildChunks`'s
+    // doc comment (ast/chunker.ts) describes: a node type can state
+    // `shouldExtractChildren`'s intent to descend and then decline it here.
+    if (node.type === 'annotation_type_declaration') return null;
     if (this.containerTypes.includes(node.type)) {
       return node.childForFieldName('body');
     }
@@ -138,14 +150,17 @@ export class JavaExportExtractor implements LanguageExportExtractor {
       case 'class_declaration':
       case 'interface_declaration':
       case 'enum_declaration':
-      case 'record_declaration': {
-        if (hasPublicModifier(node)) {
-          const nameNode = node.childForFieldName('name');
-          if (nameNode) addExport(nameNode.text);
-        }
+      case 'record_declaration':
+        exportNameIfPublic(node, addExport);
         this.extractPublicMembers(node, addExport);
         break;
-      }
+      case 'annotation_type_declaration':
+        // #1005 Phase 3 Item B: only the annotation's OWN name is exported
+        // when public -- annotation MEMBERS (`String value();`-style
+        // element declarations) are deliberately excluded, so unlike the
+        // type declarations above this never calls `extractPublicMembers`.
+        exportNameIfPublic(node, addExport);
+        break;
     }
   }
 
@@ -357,6 +372,7 @@ export class JavaSymbolExtractor implements LanguageSymbolExtractor {
     'interface_declaration',
     'enum_declaration',
     'record_declaration',
+    'annotation_type_declaration',
   ];
 
   extractSymbol(node: SyntaxNode, content: string, parentClass?: string): SymbolInfo | null {
@@ -373,6 +389,8 @@ export class JavaSymbolExtractor implements LanguageSymbolExtractor {
         return this.extractEnumInfo(node, parentClass);
       case 'record_declaration':
         return this.extractRecordInfo(node, parentClass);
+      case 'annotation_type_declaration':
+        return this.extractAnnotationInfo(node, parentClass);
       default:
         return null;
     }
@@ -498,6 +516,31 @@ export class JavaSymbolExtractor implements LanguageSymbolExtractor {
       signature: clampSignatureLength(`record ${nameNode.text}${typeParamsAndHeritage(node)}`),
     };
   }
+
+  /**
+   * #1005 Phase 3 Item B: `@interface Foo {}` maps to `symbolType: 'interface'`
+   * -- mirrors the existing `record_declaration` -> `'class'` precedent
+   * directly above rather than introducing a new `'annotation'` member to
+   * `ChunkMetadata['symbolType']`'s closed union (rejected: ~14 hand-maintained
+   * duplicate-union-site updates with no compiler safety net, for a purely
+   * cosmetic distinction -- `'interface'` already works everywhere). An
+   * annotation declaration has no type parameters and no
+   * extends/implements heritage, so unlike the other type-declaration
+   * handlers this doesn't call `typeParamsAndHeritage` at all.
+   */
+  private extractAnnotationInfo(node: SyntaxNode, parentClass?: string): SymbolInfo | null {
+    const nameNode = node.childForFieldName('name');
+    if (!nameNode) return null;
+
+    return {
+      name: nameNode.text,
+      type: 'interface',
+      startLine: node.startPosition.row + 1,
+      endLine: node.endPosition.row + 1,
+      parentClass,
+      signature: clampSignatureLength(`@interface ${nameNode.text}`),
+    };
+  }
 }
 
 // =============================================================================
@@ -513,6 +556,19 @@ function hasPublicModifier(node: SyntaxNode): boolean {
   const modifiers = node.children.find(child => child.type === 'modifiers');
   if (!modifiers) return false;
   return modifiers.children.some(child => child.type === 'public');
+}
+
+/**
+ * `addExport(node's name)` iff `node` has a `public` modifier and a `name`
+ * field -- the shared "export the declaration's own name" step every
+ * top-level type-declaration case in `extractFromNode` needs, factored out
+ * so adding the annotation case (#1005 Phase 3 Item B) didn't have to
+ * duplicate it a third time.
+ */
+function exportNameIfPublic(node: SyntaxNode, addExport: (name: string) => void): void {
+  if (!hasPublicModifier(node)) return;
+  const nameNode = node.childForFieldName('name');
+  if (nameNode) addExport(nameNode.text);
 }
 
 const ACCESS_MODIFIER_TYPES = new Set(['public', 'private', 'protected']);

--- a/packages/parser/src/jvm-same-package-signals.test.ts
+++ b/packages/parser/src/jvm-same-package-signals.test.ts
@@ -409,6 +409,48 @@ describe('findJvmSamePackageDependents', () => {
   });
 });
 
+describe('#1005 Phase 3 Item B: nested Java annotation declarations can never become G1prime owners', () => {
+  it("a nested annotation sharing a top-level type's name does not interfere with that type's package-local uniqueness", () => {
+    const chunks: CodeChunk[] = [
+      declChunk('src/main/java/a/b/Foo.java', 'Foo', 'a.b'), // top-level, package-locally-unique
+      usageChunk('src/main/java/a/b/Bar.java', ['Foo'], 'a.b'),
+      // Baz.java declares an UNRELATED NESTED annotation also named "Foo" --
+      // must not be counted as a second top-level owner of "Foo" in this
+      // package: `collectTopLevelDeclarations` (the G1' seed) explicitly
+      // skips any chunk with `parentClass` set, and a nested annotation
+      // reports `parentClass` via the same existing traversal machinery any
+      // other nested declaration does (confirmed in java.test.ts).
+      makeChunk({
+        file: 'src/main/java/a/b/Baz.java',
+        content: 'package a.b\n\nclass Baz { @interface Foo {} }',
+        symbolName: 'Foo',
+        symbolType: 'interface',
+        parentClass: 'Baz',
+      }),
+    ];
+    expect(findJvmSamePackageDependents('src/main/java/a/b/Foo.java', chunks)).toEqual([
+      'src/main/java/a/b/Bar.java',
+    ]);
+  });
+
+  it('a file whose ONLY declared type is a nested annotation can never itself be resolved as a same-package target (no top-level declaration to key off)', () => {
+    const chunks: CodeChunk[] = [
+      makeChunk({
+        file: 'src/main/java/a/b/Container.java',
+        content: 'package a.b\n\nclass Container { @interface Marker {} }',
+        symbolName: 'Marker',
+        symbolType: 'interface',
+        parentClass: 'Container',
+      }),
+      usageChunk('src/main/java/a/b/Other.java', ['Marker'], 'a.b'),
+    ];
+    // `resolveJvmSamePackageDependents` keys off `targetFile`'s TOP-LEVEL
+    // declared type names (`index.declarations`) -- empty here, since
+    // "Marker" is the only chunk for this file and it's nested.
+    expect(findJvmSamePackageDependents('src/main/java/a/b/Container.java', chunks)).toEqual([]);
+  });
+});
+
 describe('resolveJvmSamePackageDependentsBruteForce (P1: brute-force oracle)', () => {
   /** A varied fixture spanning every gate: G1'/G2/G4/G6/G7, Java and Kotlin, multiple packages. */
   function fixture(): CodeChunk[] {

--- a/packages/review/test/fingerprint.test.ts
+++ b/packages/review/test/fingerprint.test.ts
@@ -77,6 +77,32 @@ describe('computeFingerprint', () => {
       expect(fp.paradigm.ratio).toBe(0.5);
       expect(fp.paradigm.dominantStyle).toBe('mixed');
     });
+
+    // #1005 Phase 3 Item B: a Java `@interface Foo {}` annotation declaration
+    // now produces a chunk with `symbolType: 'interface'` (mirrors the
+    // pre-existing `record_declaration` -> `'class'` precedent). This
+    // computation already counts symbolType 'interface' toward `classCount`
+    // (the OOP side) for ANY interface, so an annotation-heavy Java file
+    // reads as more "OOP" than before -- confirming that reads as sensible,
+    // not a regression: an annotation declaration IS a type declaration in
+    // the OOP-paradigm sense this metric is modeling, same as a real
+    // interface. Real corpora measurement (#1005 Phase 3 Item B PR body):
+    // annotation declarations are a small fraction of total classes/methods
+    // even in annotation-heavy repos (74 across 737 real Java files spanning
+    // 5 corpora, vs thousands of methods/classes), so this shift is a
+    // rounding-level nudge in practice, not a paradigm-flipping one.
+    it('counts a Java annotation declaration (symbolType interface) toward classCount, same as any interface -- confirms no nonsensical paradigm shift', () => {
+      const chunks = [
+        makeChunk({ symbolName: 'Foo', symbolType: 'interface', language: 'java' }),
+        ...Array.from({ length: 8 }, (_, i) =>
+          makeChunk({ symbolName: `method${i}`, symbolType: 'method', language: 'java' }),
+        ),
+      ];
+      const fp = computeFingerprint(chunks);
+      expect(fp.paradigm.classCount).toBe(1);
+      expect(fp.paradigm.ratio).toBe(0.0);
+      expect(fp.paradigm.dominantStyle).toBe('oop');
+    });
   });
 
   describe('naming', () => {


### PR DESCRIPTION
## Summary

#1005 Phase 3, Item B (final PR in this sequence). `annotation_type_declaration`
(Java's `@interface Foo {}`) was absent from `JavaSymbolExtractor.symbolNodeTypes`
entirely — a parser/extractor gap, not a resolution-gate gap. An
annotation-only file produced **no chunk at all**, so `get_files_context`,
`list_functions`, and `search_code` returned nothing for it.

## Required first step: re-derived the nested-annotation count myself

Two prior estimates disagreed (23 vs 21, differing on 2 corpora) and
neither was fully resolved. Rather than average or guess, I wrote a
standalone AST walk (`annotation_type_declaration` nodes, classified by
whether any ancestor is itself a type declaration) against fresh clones of
javapoet, gson, retrofit, moshi, okhttp:

| Corpus | Java files | files w/ any annotation decl | total annotation decls | files w/ NESTED annotation decl | nested decls |
|---|---|---|---|---|---|
| javapoet | 39 | 3 | 8 | 3 | 8 |
| gson | 264 | 8 | 8 | 1 | 1 |
| retrofit | 306 | 34 | 38 | 7 | 11 |
| moshi | 57 | 11 | 20 | 11 | 20 |
| okhttp | 71 (.java only) | 0 | 0 | 0 | 0 |
| **total** | 737 | **56** | **74** | **22** | **40** |

**Pinned number: 22 files declare a nested annotation** (out of 56 files
with any annotation declaration) — sits exactly between the two prior
disagreeing estimates (23, 21), consistent with them being real
measurements against slightly different corpus snapshots (mine are fresh
clones). Used 22, not an average.

## Design

`annotation_type_declaration` → `symbolType: 'interface'`, mirroring the
existing `record_declaration` → `'class'` precedent. Did not add a new
`'annotation'` member to `ChunkMetadata['symbolType']`'s closed union
(rejected per the plan — ~14 duplicate-union-site updates for a cosmetic
distinction).

**Touch sites, each re-verified against current source:**
1. `JavaTraverser.containerTypes` + `JavaSymbolExtractor.symbolNodeTypes` —
   added `annotation_type_declaration`.
2. `JavaTraverser.getContainerBody` — returns `null` specifically for
   `annotation_type_declaration` (even though it's in `containerTypes` for
   `shouldExtractChildren`), so `findTopLevelNodes` never descends into
   `annotation_type_body` and extracts annotation MEMBERS as separate
   chunks. Mirrors the Python `decorated_definition` precedent
   `emitsChildChunks`'s own doc comment (`ast/chunker.ts`) describes:
   stating an intent to descend (`shouldExtractChildren`) that a specific
   node type then declines (`getContainerBody`).
3. `JavaExportExtractor.extractFromNode` — new `annotation_type_declaration`
   case, exports the annotation's own name when `public`, deliberately never
   calls `extractPublicMembers` (members excluded).
4. **`packages/core/src/vectordb/filters.ts`'s `getSymbolsForType`** — this
   routes `'interface'` through a SEPARATE `interfaceNames` column,
   populated from `metadata.symbols?.interfaces`, not `symbolType` directly.
   Verified directly (not assumed): `chunker.ts`'s existing
   `buildLegacySymbols`/`SYMBOL_TYPE_TO_ARRAY` plumbing already maps ANY
   `symbolType: 'interface'` chunk into `symbols.interfaces` automatically
   — confirmed via a real `chunkByAST` call showing
   `symbols.interfaces: ["Foo"]` for an annotation chunk with zero extra
   code needed. Pinned with a dedicated test in `filters.test.ts` so this
   agreement can't silently regress.
5. **`packages/review/src/fingerprint.ts`**'s paradigm detection — already
   counts `symbolType === 'interface'` toward `classCount` (unchanged).
   Confirmed this doesn't produce a nonsensical result: 74 annotation
   declarations across 737 real Java files is a rounding-level fraction next
   to the thousands of methods/classes in these corpora — a real shift, not
   a nonsensical one (an annotation IS a type declaration in the
   OOP-paradigm sense this metric models). Pinned with a dedicated test.

**Nested annotations**: confirmed with a dedicated test that they report
`parentClass` via the existing traversal machinery (no special-casing
needed) and can therefore never become a G1' same-package-uniqueness owner
(`collectTopLevelDeclarations` already skips any chunk with `parentClass`
set).

**Explicitly excluded**: annotation MEMBERS (`String value();`-style
declarations) are never extracted as their own chunks or exports.

## Real measurement: chunk-count impact per corpus

| Corpus | chunks before | chunks after | delta |
|---|---|---|---|
| javapoet | 951 | 958 | +7 |
| gson | 4526 | 4533 | +7 |
| retrofit | 3098 | 3137 | +39 |
| moshi | 2428 | 2441 | +13 |
| okhttp | 9174 | 9174 | +0 |

(Deltas don't exactly equal the raw annotation-declaration counts above —
expected: a nested annotation's lines were previously bundled into whatever
generic "uncovered" leftover chunk covered that gap, so giving it its own
dedicated chunk also shrinks/removes the leftover chunk that used to include
those lines. Net effect, not a 1:1 addition.)

## Real measurement: recall impact (honest number, not oversold)

Same-package edge count before/after, real corpora:

| Corpus | edges before | edges after | added |
|---|---|---|---|
| javapoet | 161 | 161 | +0 |
| gson | 283 | 286 | +3 |
| retrofit | 491 | 494 | +3 |
| moshi | 176 | 176 | +0 |
| **total** | | | **+6** |

javapoet and moshi show **zero** new edges — every one of their annotation
declarations is nested (confirmed above), so none can become a G1' target.
Real examples of the +6, read from source:
- `gson/extras/src/main/java/com/google/gson/interceptors/Intercept.java`
  (`public @interface Intercept`) → 2 real same-package dependents.
- `retrofit/retrofit/src/main/java/retrofit2/SkipCallbackExecutor.java`
  (`public @interface SkipCallbackExecutor`) → 3 real same-package
  dependents (`RetrofitTest.java`, `DefaultCallAdapterFactory.java`,
  `SkipCallbackExecutorImpl.java`).

**The honest framing, stated explicitly**: +6 new edges across 5 corpora is
genuinely weak as a recall mechanism — nobody should cite this PR as a
recall improvement. The real justification is context-quality (below).

## Dogfood: context-quality, before/after, verbatim

`retrofit2.SkipCallbackExecutor.java` — a real annotation-only file (license
header, package, imports, one `@interface` declaration, nothing else) — run
through the real `chunkByAST`:

**BEFORE** (main, unpatched):
```json
{"startLine":1,"endLine":48,"contentPreview":"/*\n * Copyright (C) 2019 Square, Inc...."}
```
One chunk. No `symbolName`, no `symbolType`, no `exports` — completely
invisible to `list_functions`/`search_code`'s symbol-aware paths.

**AFTER** (this PR):
```json
{"startLine":1,"endLine":43,"exports":["SkipCallbackExecutor"], ...}
{"startLine":44,"endLine":47,"symbolName":"SkipCallbackExecutor","symbolType":"interface","exports":["SkipCallbackExecutor"], ...}
```
The annotation is now a real, named, exported, symbol-typed chunk —
`list_functions({ pattern: 'SkipCallbackExecutor' })` and `search_code`
would now actually find it.

## Verification

- `java.test.ts`: 76/76 green, including 11 new tests (traverser
  container/body behavior, export extraction of public/package-private
  annotations, member exclusion, symbol extraction + signature, nested
  parentClass, chunking integration for top-level/package-private/nested
  annotations, member-chunk exclusion).
- `jvm-same-package-signals.test.ts`: 38/38 green, including 2 new tests
  proving a nested annotation can never interfere with or become a G1'
  owner.
- `filters.test.ts` (core): 6/6 green, including 3 new tests pinning the
  `getSymbolsForType`/`interfaceNames` agreement.
- `fingerprint.test.ts` (review): 32/32 green, including 1 new test
  confirming the paradigm-detection shift is sensible.
- Full `npm run test -w @liendev/parser`: 1987/1987 green.
- `npm test` (parser, core, review, cli, action): all green, no regressions
  from touching the widely-used Java extractor.
- `npm run build`, `npm run typecheck`, `npm run lint` (0 errors), `npm run
  format:check`: all clean.
- `lien delta`: exit 0 — 2 advisory "worsened" (both +1, well under
  threshold), 1 improved (refactored `extractFromNode` to share a helper
  between the annotation and type-declaration cases, dropping its own
  cognitive complexity 6→1 in the process).
- `packages/cli/test/integration/index-state-matrix.test.ts`: 49/49 green.
- Query-time-adjacent (chunking-time) change — this bumps chunk shape for
  Java files containing annotations, same category as Item D; no
  `INDEX_FORMAT_VERSION` bump needed here specifically since this is a NEW
  node type gaining extraction (any index built after this ships already
  reflects it going forward via normal incremental reindexing of touched
  files — there's no silent-staleness risk the way Item D's dropped-range
  bug had, since a file that previously produced zero chunks for its
  annotation will simply get chunked correctly the next time it's touched
  or the project is reindexed).

## This closes the #1005 Phase 3 sequence

PR 1 (Item D, #1118) and PR 2 (Item E, #1119) are already merged. This is
the third and final PR. After this merges, I'll comment on #1005
summarizing what shipped, what was closed with evidence (Kotlin
`typealias`, Kotlin top-level `fun`/`val`), and what was filed as a
follow-up (Item F, Kotlin Multiplatform source-set collapsing).

---

<!-- lien-stats -->
### Lien Review

✅ **Good** - No complexity issues found.

> [!NOTE]
> **Low Risk**
>
> This PR adds Java annotation_type_declaration extraction to the parser, mapping annotations to symbolType: 'interface' and deliberately excluding annotation member elements from becoming separate chunks or exports. The change is narrowly scoped to Java, mirrors the existing record_declaration → 'class' precedent, and is well-covered by new tests across parser, core, and review packages. No breaking changes or caller malfunctions were identified.
>
> - JavaTraverser now treats annotation_type_declaration as a container for chunking purposes but returns null from getContainerBody so annotation members are not recursively extracted
> - JavaExportExtractor exports public annotation names but skips member element declarations
> - JavaSymbolExtractor maps annotation_type_declaration to symbolType: 'interface' with signature '@interface Foo'
> - Nested annotations inherit parentClass through existing traversal machinery and are excluded from same-package G1' ownership

✅ *Trust: **Delivered** — The review ran to completion within budget.*

<sup>Reviewed by [Lien Review](https://lien.dev) for commit fc85ff3. Updates automatically on new commits.</sup>
<!-- /lien-stats -->